### PR TITLE
Translate comments and list TODO modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # robust-malware-graph
+
+이 저장소는 악성코드 분석을 위한 그래프 기반 실험 코드를 포함합니다.
+아직 구현되지 않은 모듈은 모두 `TODO` 표시만 존재하며 다음과 같습니다.
+
+## 미구현 모듈 목록
+
+- src/__init__.py
+- src/cli/__init__.py
+- src/cli/certify_res.py
+- src/cli/detect.py
+- src/cli/finetune_supcon.py
+- src/cli/preprocessing.py
+- src/cli/pretrain_selfgcl.py
+- src/cli/rulegen_cli.py
+- src/collect/__init__.py
+- src/common/logger.py
+- src/continual/__init__.py
+- src/explain/__init__.py
+- src/explain/cf_generator.py
+- src/explain/cfg_explainer/__init__.py
+- src/explain/cfg_explainer/aggregator.py
+- src/explain/cfg_explainer/mapper.py
+- src/explain/cfg_explainer/ranker.py
+- src/explain/cfg_explainer/selector.py
+- src/explain/report.py
+- src/extract/__init__.py
+- src/extract/backends/__init__.py
+- src/extract/backends/angr_engine.py
+- src/extract/backends/capstone_disasm.py
+- src/extract/backends/ghidra_bridge.py
+- src/extract/backends/lief_parser.py
+- src/extract/backends/radare2_bridge.py
+- src/extract/extractors/__init__.py
+- src/extract/extractors/fcg_extractor.py
+- src/extract/extractors/syscall_extractor.py
+- src/extract/pipelines/__init__.py
+- src/extract/pipelines/cli.py
+- src/extract/pipelines/extract_pipeline.py
+- src/extract/validators/__init__.py
+- src/extract/validators/fixer.py
+- src/extract/validators/sanity_checks.py
+- src/extract/validators/schema.py
+- src/models/contrast/__init__.py
+- src/models/contrast/self_gcl.py
+- src/models/contrast/sup_con.py
+- src/models/distill/__init__.py
+- src/models/distill/sgcn_kd.py
+- src/models/llm_embed.py
+- src/rulegen/__init__.py
+- src/rulegen/capa_builder.py
+- src/rulegen/feature_miner.py
+- src/rulegen/rl_agent.py
+- src/rulegen/rl_env.py
+- src/rulegen/yara_builder.py

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -1,11 +1,11 @@
-"""TODO"""
+# TODO
 """
 src/common/logger.py
 ~~~~~~~~~~~~~~~~~~~~
-Light-weight project-wide logger helper.
+프로젝트 전반에서 사용할 수 있는 가벼운 로거 헬퍼입니다.
 
-Usage
------
+사용 예
+-------
 >>> from src.common.logger import get_logger
 >>> log = get_logger(__name__, level="INFO", log_file="logs/run.log")
 >>> log.info("ready!")

--- a/src/extract/cache.py
+++ b/src/extract/cache.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 """src.extract.cache
 ====================
-Helpers for inspecting, sizing and purging the on‑disk cache used by
-:pyclass:`src.extract.base.ExtractorBase`.
-
-The cache layout is *content‑addressable*:
+디스크에 저장된 캐시를 점검하고 용량을 계산하며 정리하기 위한 보조 기능을 제공합니다.
+:pyclass:`src.extract.base.ExtractorBase`에서 사용하는 캐시는 내용 기반 주소 체계를 따릅니다.
 
 ```
   data/views/<VIEW>/<sha256>.<fmt>
 ```
 
-This module never touches extractor internals – it only performs simple
-filesystem operations, making it safe to run even while other processes are
-writing to the cache (best‑effort; no locks).  Typical use‑cases:
+이 모듈은 추출기 내부 구조를 다루지 않고 단순한 파일 시스템 작업만 수행합니다.
+따라서 다른 프로세스가 캐시에 쓰기 중이더라도 안전하게 사용할 수 있습니다(최선의 노력 수준이며 잠금은 사용하지 않습니다).
+주요 사용 예시는 다음과 같습니다.
 
 * "How much disk space does the *AST* view consume right now?"
 * "Remove everything older than 90 days across all views."
@@ -44,11 +42,11 @@ if not log.handlers:
     )
 
 # --------------------------------------------------------------------------- #
-# Core helpers
+# 핵심 도우미
 # --------------------------------------------------------------------------- #
 
 def cache_path(view: str, sha256: str, *, fmt: str = "json", root: Path = DEFAULT_VIEWS_DIR) -> Path:  # noqa: D401
-    """Return canonical cache path for *(view, sha256, fmt)*."""
+    """*(view, sha256, fmt)* 조합에 대한 표준 캐시 경로를 반환합니다."""
     if fmt not in SUPPORTED_FMTS:
         raise ValueError(f"Unsupported fmt: {fmt} — choose from {sorted(SUPPORTED_FMTS)}")
     return root / view / f"{sha256}.{fmt}"
@@ -60,15 +58,14 @@ def iter_cache_files(
     older_than: datetime | None = None,
     root: Path = DEFAULT_VIEWS_DIR,
 ) -> Iterator[Path]:  # noqa: D401
-    """Yield cache file *Path*s filtered by *view* and/or *mtime*.
+    """*view*와/또는 *mtime* 기준으로 필터링된 캐시 파일 경로를 차례로 제공합니다.
 
     Parameters
     ----------
     view
-        Restrict to a single extractor view (e.g. ``"cfg"``).  *None* → all.
+        특정 추출기 뷰만 대상으로 제한합니다(예: ``"cfg"``). *None*이면 모든 뷰를 의미합니다.
     older_than
-        If given, only yield entries whose *mtime* is **strictly older** than
-        this timestamp (UTC‑aware).
+        지정하면 *mtime*이 이 시간보다 **엄격히 이전**인 항목만 반환합니다(UTC).
     """
     if not root.exists():
         return
@@ -86,7 +83,7 @@ def iter_cache_files(
 
 
 def cache_size(view: str | None = None) -> Tuple[int, str]:  # noqa: D401
-    """Return *(bytes, human‑readable)* size for *view* or the entire cache."""
+    """지정한 뷰 또는 전체 캐시의 크기를 *(바이트, 사람이 읽기 쉬운 형식)*으로 반환합니다."""
     total = sum(p.stat().st_size for p in iter_cache_files(view=view))
     return total, _sizeof_fmt(total)
 
@@ -97,17 +94,16 @@ def purge_cache(
     older_than: datetime | timedelta | None = None,
     dry_run: bool = False,
 ) -> Dict[str, int]:  # noqa: D401
-    """Delete cache files and return statistics.
+    """캐시 파일을 삭제하고 통계 정보를 반환합니다.
 
     Parameters
     ----------
     view
-        Restrict deletion to this view.  *None* → all views.
+        이 뷰로 범위를 제한합니다. *None*이면 모든 뷰를 대상으로 합니다.
     older_than
-        Keep only entries newer than this absolute (``datetime``) **or**
-        relative (``timedelta``) threshold.
+        절대(`datetime`) 또는 상대(`timedelta`) 시각을 지정하면, 이보다 새로운 항목만 유지합니다.
     dry_run
-        If *True*, just compute what *would* be removed.
+        *True*이면 실제 삭제 대신 영향만 계산합니다.
     """
     if isinstance(older_than, timedelta):
         older_than = datetime.now(timezone.utc) - older_than
@@ -126,11 +122,11 @@ def purge_cache(
 
 
 # --------------------------------------------------------------------------- #
-# CLI entry‑point
+# CLI 진입점
 # --------------------------------------------------------------------------- #
 
 def _parse_args() -> argparse.Namespace:  # noqa: D401
-    ap = argparse.ArgumentParser(description="Cache inspection / GC util")
+    ap = argparse.ArgumentParser(description="캐시 점검 및 정리 도구")
     ap.add_argument("--view", help="Restrict to a single view id")
     ap.add_argument("--older-than", type=int, metavar="DAYS", help="Purge entries older than N days")
     ap.add_argument("--purge", action="store_true", help="Delete matched cache entries")
@@ -153,7 +149,7 @@ def main() -> None:  # noqa: D401
 
 
 # --------------------------------------------------------------------------- #
-# Misc utilities
+# 기타 유틸리티
 # --------------------------------------------------------------------------- #
 
 def _sizeof_fmt(num: int, suffix: str = "B") -> str:  # noqa: D401


### PR DESCRIPTION
## Summary
- translate English comments to Korean in logger and cache modules
- add a TODO module list in README

## Testing
- `python -m py_compile src/common/logger.py src/extract/cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68546527fd34832eb7582fba660ac2cc