### PR TITLE
Add pyproject for editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "robust-malware-graph"
+version = "0.1.0"
+description = "Robust Malware Graph research code"
+readme = "README.md"
+authors = [{name="Unknown"}]
+requires-python = ">=3.10"
+license = {text = "MIT"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+]
+
+[project.urls]
+Homepage = "https://example.com"
+
+[project.scripts]
+rmg-cli = "cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -55,7 +55,7 @@ __all__ = [
 
 # ───────────────────────── version info
 try:
-    __version__: str = metadata.version("robust-malware-graph-rulegen")
+    __version__: str = metadata.version("robust-malware-graph")
 except metadata.PackageNotFoundError:  # dev/CLI 실행 시
     __version__ = "0.0.0.dev"
 


### PR DESCRIPTION
## Summary
- enable editable installs with pyproject.toml
- align rulegen package metadata with new project name

## Testing
- `pip install -e .`
- `rmg-cli --help`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856e1042a68832eaa007220f422ce93