### PR TITLE
Fix config dataclass initialization

### DIFF
--- a/src/common/config.py
+++ b/src/common/config.py
@@ -73,20 +73,24 @@ class _Config:
     PRINT_CONFIG: bool = True     # 시작 시 config 로그 출력 여부
     EXP_NAME: str = "debug"       # 실험 폴더 이름(logs/EXP_NAME)
 
+    # Derived attributes (set in __post_init__)
+    EXP_DIR: Path = field(init=False)
+    DEVICE: torch.device = field(init=False)
+
     # --------------------------------------------------------------------- #
     #              Derived / helper properties (not editable)              #
     # --------------------------------------------------------------------- #
     def __post_init__(self) -> None:
         # 파생 경로
-        self.EXP_DIR: Path = self.LOG_DIR / self.EXP_NAME
+        object.__setattr__(self, "EXP_DIR", self.LOG_DIR / self.EXP_NAME)
         self.EXP_DIR.mkdir(parents=True, exist_ok=True)
 
         # 디바이스
         if not self.FORCE_CPU and torch.cuda.is_available():
-            self.DEVICE = torch.device(f"cuda:{self.GPU_ID}")
+            object.__setattr__(self, "DEVICE", torch.device(f"cuda:{self.GPU_ID}"))
             torch.cuda.set_device(self.DEVICE)
         else:
-            self.DEVICE = torch.device("cpu")
+            object.__setattr__(self, "DEVICE", torch.device("cpu"))
 
         # 시드 고정
         random.seed(self.SEED)


### PR DESCRIPTION
## Summary
- define derived config fields and set using `object.__setattr__`
- avoid `AttributeError` when `settings` is built

## Testing
- `python -m py_compile src/common/config.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e7a0939c832ea6446431fa99e016