### PR TITLE
Fix view registry import and usage

### DIFF
--- a/src/extract/extractors/ast_extractor.py
+++ b/src/extract/extractors/ast_extractor.py
@@ -212,9 +212,9 @@ class ASTExtractor(ExtractorBase):
 
 try:
     # Lazy import to avoid circular deps when registry imports this module
-    from .view_registry import register_extractor
+    from .view_registry import register_view
 
-    register_extractor("ast", ASTExtractor)  # noqa: E402
+    register_view("ast", ASTExtractor)  # noqa: E402
 except ImportError:
     # ASTExtractor can still be used without the global registry
     pass

--- a/src/extract/pipelines/cli.py
+++ b/src/extract/pipelines/cli.py
@@ -42,7 +42,7 @@ except ImportError:  # graceful fallback
 # --------------------------------------------------------------------------- #
 from src.common.utils import ensure_dir, get_logger, set_random_seed
 from src.extract.validators import clean, check, FixReport, SanityError
-from src.extract.extractors.view_registry import VIEW_REGISTRY  # view -> ExtractorCls
+from src.extract.extractors.view_registry import get_extractor, list_views  # view registry helpers
 
 LOG = get_logger(__name__)
 
@@ -86,7 +86,7 @@ def _process_one(
     errors: List[str] = []
     sha = _sha256_of_file(sample_path)
     for v in view_names:
-        extractor_cls = VIEW_REGISTRY[v]
+        extractor_cls = get_extractor(v)
         extractor = extractor_cls()  # each extractor should be stateless/light
         try:
             view_dict = extractor.run(sample_path)  # ← MUST return Python dict
@@ -134,9 +134,9 @@ def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--views",
         nargs="+",
-        default=list(VIEW_REGISTRY.keys()),
-        choices=list(VIEW_REGISTRY.keys()),
-        help=f"which view(s) to extract (default: all {list(VIEW_REGISTRY)})",
+        default=list(list_views()),
+        choices=list(list_views()),
+        help=f"which view(s) to extract (default: all {list(list_views())})",
     )
     parser.add_argument(
         "--out-dir",

--- a/src/extract/pipelines/extract_pipeline.py
+++ b/src/extract/pipelines/extract_pipeline.py
@@ -50,7 +50,7 @@ except ModuleNotFoundError:  # fallback: no-op iterator
 # --------------------------------------------------------------------------- #
 from src.common.utils import ensure_dir, get_logger, set_random_seed
 from src.extract.validators import clean, check, SanityError
-from src.extract.extractors.view_registry import VIEW_REGISTRY  # {"ast": ASTExtractor, …}
+from src.extract.extractors.view_registry import get_extractor, list_views
 
 LOG = get_logger(__name__)
 
@@ -127,7 +127,7 @@ def _process_sample(
     sha = _sha256(sample)
 
     for view in view_names:
-        extractor_cls = VIEW_REGISTRY[view]
+        extractor_cls = get_extractor(view)
         extractor = extractor_cls()            # stateless
         view_tag = f"[{sample.name}/{view}]"
 
@@ -183,7 +183,7 @@ class ExtractPipeline:
         workers: int | None = None,
         seed: int = 42,
     ) -> None:
-        self.views = views or list(VIEW_REGISTRY.keys())
+        self.views = views or list(list_views())
         self.out_dir = out_dir
         self.strict = strict
         self.auto_fix = auto_fix


### PR DESCRIPTION
## Summary
- use `get_extractor`/`list_views` instead of nonexistent `VIEW_REGISTRY`
- update ExtractPipeline, CLI and AST extractor registry integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f7499b2c832e9bbd87d7182dc701