### PR TITLE
Implement graph build & split using library functions

### DIFF
--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -15,6 +15,8 @@ import sys
 from pathlib import Path
 from typing import Callable, Dict, Sequence
 
+import torch
+
 # ────────────────────────────────────────────────────────────────
 # 0. 공통 유틸
 # ────────────────────────────────────────────────────────────────
@@ -91,21 +93,46 @@ def run_extract(args: argparse.Namespace) -> None:  # noqa: D401
 @register_stage("graphs")
 def run_graphs(args: argparse.Namespace) -> None:
     """Stage 3 – View 통합 → Hetero Graph."""
-    # ✅ builders 서브패키지 안의 함수로 경로 수정
-    from src.graphs.builders.hetero_builder import build_hetero_dataset  # <-- fix!
+    from src.graphs.builders.hetero_builder import HeteroGraphBuilder
+    from src.graphs.loaders import get_loader
+    from src.graphs.normalizers import get_normalizer
 
     logger = _get_logger(args.log_level)
     logger.info("[GRAPHS] rebuild=%s  normalise=%s", args.rebuild, args.normalise)
     try:
+        views_root = Path(args.out_dir, "data", "views")
         hetero_dir = Path(args.out_dir, "data", "hetero")
         ensure_dir(hetero_dir)
-        build_hetero_dataset(
-            views_dir=Path(args.out_dir, "data", "views"),
-            hetero_dir=hetero_dir,
-            normalise=args.normalise,
-            rebuild=args.rebuild,
-            workers=args.workers,
-        )
+
+        view_names = [d.name for d in views_root.iterdir() if d.is_dir()]
+        sha_set = {
+            p.stem.split(".")[0]
+            for v in view_names
+            for p in (views_root / v).glob("*.json*")
+        }
+
+        for sha in sorted(sha_set):
+            out_file = hetero_dir / f"{sha}.pt"
+            if out_file.exists() and not args.rebuild:
+                continue
+
+            builder = HeteroGraphBuilder()
+            for view in view_names:
+                src = (views_root / view / f"{sha}.json")
+                if not src.is_file():
+                    gz = src.with_suffix(".json.gz")
+                    if gz.is_file():
+                        src = gz
+                    else:
+                        continue
+
+                g = get_loader(view).load(src)
+                if args.normalise:
+                    g = get_normalizer(view).normalize(g)
+                builder.add_view(g, view)
+
+            hetero = builder.build()
+            torch.save(hetero, out_file)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Graphs stage failed")
         raise StageError from exc
@@ -117,8 +144,7 @@ def run_graphs(args: argparse.Namespace) -> None:
 @register_stage("splits")
 def run_splits(args: argparse.Namespace) -> None:
     """Stage 4 – 시간 기반 Train/Val/Test 분할."""
-    # ✅ dataset.split_generator 모듈로 경로 수정
-    from src.graphs.dataset.split_generator import build_time_splits  # <-- fix!
+    from src.graphs.dataset.split_generator import split_by_time, split_random
 
     logger = _get_logger(args.log_level)
     logger.info("[SPLITS] strategy=%s  val=%.2f  test=%.2f",
@@ -126,14 +152,24 @@ def run_splits(args: argparse.Namespace) -> None:
     try:
         splits_dir = Path(args.out_dir, "data", "splits")
         ensure_dir(splits_dir)
-        build_time_splits(
-            hetero_dir=Path(args.out_dir, "data", "hetero"),
-            splits_dir=splits_dir,
-            strategy=args.strategy,
-            val_ratio=args.val_ratio,
-            test_ratio=args.test_ratio,
-            seed=args.seed,
-        )
+        meta_csv = Path(args.out_dir, "data", "meta.csv")
+        graphs_dir = Path(args.out_dir, "data", "hetero")
+
+        if args.strategy == "time":
+            split_by_time(
+                meta_csv=meta_csv,
+                graph_dir=graphs_dir,
+                out_root=splits_dir,
+                val_ratio=args.val_ratio,
+                test_ratio=args.test_ratio,
+            )
+        else:
+            split_random(
+                meta_csv=meta_csv,
+                graph_dir=graphs_dir,
+                out_root=splits_dir,
+                seed=args.seed,
+            )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Splits stage failed")
         raise StageError from exc


### PR DESCRIPTION
## Summary
- use `HeteroGraphBuilder` with view loaders/normalisers in preprocessing
- invoke `split_by_time` or `split_random` for dataset splitting

## Testing
- `python -m py_compile src/cli/preprocessing.py`

------
https://chatgpt.com/codex/tasks/task_e_685709136bf8832e9e1e06f6f19fa42d