### PR TITLE
Fix AST extractor registration and CLI docstring import

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -22,10 +22,12 @@ No further wiring required – the sub‑command is auto‑registered at import 
 """
 from __future__ import annotations
 
+import ast
 import importlib
+import importlib.util
 import sys
 from types import ModuleType
-from typing import Dict, List, Final
+from typing import Dict, List, Final, Optional
 
 import click
 
@@ -62,6 +64,21 @@ def _lazy_import(module_name: str) -> ModuleType:  # pragma: no cover
     return importlib.import_module(full_name)
 
 
+def _read_docstring(module_name: str) -> Optional[str]:  # pragma: no cover
+    """Return the first line of the target module's docstring without importing."""
+    spec = importlib.util.find_spec(f"{__name__}.{module_name}")
+    if spec and spec.origin:
+        try:
+            with open(spec.origin, "r", encoding="utf-8") as fp:
+                node = ast.parse(fp.read())
+            doc = ast.get_docstring(node)
+            if doc:
+                return doc.splitlines()[0]
+        except Exception:
+            return None
+    return None
+
+
 # --------------------------------------------------------------------------- #
 # 3. Build the **click** group dynamically
 # --------------------------------------------------------------------------- #
@@ -93,11 +110,10 @@ def _add_proxy(cmd_name: str, module_name: str) -> None:  # pragma: no cover
             )
         module.main(argv_slice)
 
-    # Adopt the docstring of the target module (first line only)
-    try:
-        _proxy.__doc__ = _lazy_import(module_name).__doc__  # type: ignore[misc]
-    except Exception:  # pragma: no cover
-        pass  # module import failed – keep generic help
+    # Adopt the docstring of the target module (first line only) without import
+    doc = _read_docstring(module_name)
+    if doc:
+        _proxy.__doc__ = doc
 
     cli.add_command(_proxy)
 

--- a/src/extract/extractors/ast_extractor.py
+++ b/src/extract/extractors/ast_extractor.py
@@ -174,6 +174,14 @@ class ASTExtractor(ExtractorBase):
         return result
 
     # ------------------------------------------------------------------
+    # Adapter for ExtractorBase
+    # ------------------------------------------------------------------
+
+    def extract(self, sample_path: Path) -> Dict[str, Any]:  # type: ignore[override]
+        """Alias for :meth:`run` to satisfy :class:`ExtractorBase`."""
+        return self.run(sample_path)
+
+    # ------------------------------------------------------------------
     # I/O helpers
     # ------------------------------------------------------------------
     def save(self, result: Dict[str, Any], out_path: Path) -> None:
@@ -214,7 +222,7 @@ try:
     # Lazy import to avoid circular deps when registry imports this module
     from .view_registry import register_view
 
-    register_view("ast", ASTExtractor,force=True)  # noqa: E402
+    register_view("ast", ASTExtractor, force=True)  # noqa: E402
 except ImportError:
     # ASTExtractor can still be used without the global registry
     pass

--- a/src/extract/extractors/view_registry.py
+++ b/src/extract/extractors/view_registry.py
@@ -150,8 +150,12 @@ def register_view(
         raise TypeError("extractor must be a class or ('module', 'ClassName') tuple")
 
     with _LOCK:
-        if view_id in _REGISTRY and not force:
-            raise ViewRegistrationError(f"View id '{view_id}' already registered – use force=True to override.")
+        if view_id in _REGISTRY:
+            if not force and _REGISTRY[view_id] != extractor:
+                raise ViewRegistrationError(
+                    f"View id '{view_id}' already registered – use force=True to override."
+                )
+            if _REGISTRY.get(view_id) == extractor:
+                return  # idempotent re-registration
         _REGISTRY[view_id] = extractor
-        # Invalidate cache so that next get_extractor resolves new target.
-        _CACHE.pop(view_id, None)
+        _CACHE.pop(view_id, None)  # force lazy re-import on next get

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,19 @@
+import inspect
+import pytest
+
+from src.extract.extractors.view_registry import (
+    list_views,
+    get_extractor,
+    ViewRegistrationError,
+)
+from src.extract.base import ExtractorBase
+
+
+def test_extractors_concrete():
+    for view_id in list_views():
+        try:
+            cls = get_extractor(view_id)
+        except ViewRegistrationError as exc:
+            pytest.skip(f"dependency missing for {view_id}: {exc}")
+        assert not inspect.isabstract(cls), f"{view_id} still abstract"
+


### PR DESCRIPTION
## Summary
- add `extract` wrapper so `ASTExtractor` is no longer abstract
- make `register_view` idempotent and update AST registration
- avoid eager imports in CLI docstring logic
- add regression test ensuring extractors are concrete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685717fea3a4832e9d2991a4333be648