### PR TITLE
Fix extractor init bug

### DIFF
--- a/src/extract/extractors/ast_extractor.py
+++ b/src/extract/extractors/ast_extractor.py
@@ -95,7 +95,9 @@ class ASTExtractor(ExtractorBase):
         normalize_unicode: bool = True,
         keep_tmp: bool = False,
     ) -> None:
-        super().__init__(timeout=timeout)
+        # ExtractorBase no longer accepts a timeout parameter; store locally
+        super().__init__()
+        self.timeout = timeout
         self.backend_name = backend.lower()
         self.normalize_unicode = normalize_unicode
         self.keep_tmp = keep_tmp

--- a/src/extract/extractors/import_extractor.py
+++ b/src/extract/extractors/import_extractor.py
@@ -100,7 +100,9 @@ class ImportExtractor(BaseExtractor):
     _FORMAT_MAP: Dict[str, str] = {"pe": "PE", "elf": "ELF"}
 
     def __init__(self, *, timeout: int | None = 120, cache_dir: str | Path | None = None, backend: Literal["angr", "lief", "auto"] = "auto") -> None:  # noqa: D401,E501
-        super().__init__(timeout=timeout, cache_dir=cache_dir)
+        # BaseExtractor no longer supports a timeout parameter
+        super().__init__(cache_dir=cache_dir)
+        self.timeout = timeout
         self.backend = self._resolve_backend(backend)
         self.name = "ImportExtractor"
         self.logger = logging.getLogger(self.name)


### PR DESCRIPTION
## Summary
- update `ASTExtractor` and `ImportExtractor` initializers
- remove unexpected `timeout` argument to `ExtractorBase`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571bc5ac78832ea252ebf35564f7ca