### PR TITLE
Use sha256_file in ASTExtractor

### DIFF
--- a/src/extract/extractors/ast_extractor.py
+++ b/src/extract/extractors/ast_extractor.py
@@ -19,7 +19,7 @@ Overview
          ▼                                ▼
       save() JSON  ◀──────────── format_ast() ──────────────┐
                            ┌───────────────┐               │
-                           │ utils.hash_file│  derive SHA  │
+                           │ utils.sha256_file│  derive SHA  │
                            └───────────────┘               │
 ```
 
@@ -116,7 +116,7 @@ class ASTExtractor(ExtractorBase):
     def run(self, sample_path: Path) -> Dict[str, Any]:  # noqa: D401, override
         """Run the backend and return a *Python* dict that follows the schema."""
         logger.info("[AST] Parsing %s using backend=%s", sample_path, self.backend_name)
-        sha256 = u.hash_file(sample_path)
+        sha256 = u.sha256_file(sample_path)
 
         try:
             func_asts = self.backend.extract_ast(
@@ -205,7 +205,7 @@ class ASTExtractor(ExtractorBase):
         """Run + save → return output path."""
         if out_dir is None:
             out_dir = Path("data") / "views" / self.VIEW
-        sha256 = u.hash_file(sample_path)
+        sha256 = u.sha256_file(sample_path)
         out_path = out_dir / f"{sha256}.json"
         if out_path.exists():
             logger.info("[AST] Cache hit –%s", out_path)


### PR DESCRIPTION
## Summary
- use `utils.sha256_file` in `ASTExtractor`
- update docstring to mention `utils.sha256_file`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685720fe6a64832e8edde9bf70cc3419