### PR TITLE
Fix CFG dataclass ClassVar

### DIFF
--- a/src/extract/extractors/cfg_extractor.py
+++ b/src/extract/extractors/cfg_extractor.py
@@ -14,7 +14,7 @@ import multiprocessing as mp
 import shutil
 import signal
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, ClassVar
 
 import networkx as nx
 
@@ -37,7 +37,7 @@ class CFGExtractor:  # pylint: disable=too-many-instance-attributes
     """Recover control‑flow graph (CFG) and serialise it to JSON."""
 
     # The registry inspects this attribute to match the extractor to the view
-    VIEW: str = VIEW_CFG  # <- **key change**
+    VIEW: ClassVar[str] = VIEW_CFG  # <- **key change**
 
     out_dir: Path
     backend: str = "angr"


### PR DESCRIPTION
## Summary
- treat CFG extractor `VIEW` constant as a `ClassVar`
- update typing imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685721054a24832e9fe17b9e2acb4a69