### PR TITLE
Fix logging formatter hyphen

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -70,7 +70,7 @@ def _build_colour_formatter() -> logging.Formatter:
             msg = super().format(record).replace("-", "-").replace("–", "-")  # CP949 우회
             return f"{prefix} {msg}"
 
-    return _AnsiFormatter("%(asctime)s | %(name)s | %(message)s", "%Y‑%m‑%d %H:%M:%S")
+    return _AnsiFormatter("%(asctime)s | %(name)s | %(message)s", "%Y-%m-%d %H:%M:%S")
 
 
 def get_logger(name: str = "robust‑mg", level: int = logging.INFO) -> logging.Logger:  # noqa: D401


### PR DESCRIPTION
## Summary
- swap nonstandard hyphens in `_build_colour_formatter` for standard ones

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685723cc59b8832e8f186e8bd6faba78