### PR TITLE
Fix CFGExtractor default out_dir

### DIFF
--- a/src/extract/extractors/cfg_extractor.py
+++ b/src/extract/extractors/cfg_extractor.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Iterable, List, ClassVar
 import networkx as nx
 
 # NEW: canonical view identifier (supersedes DEFAULT_CFG_VIEW)
-from ..constants import VIEW_CFG  # noqa: E402  pylint: disable=wrong-import-position
+from ..constants import DEFAULT_VIEWS_DIR, VIEW_CFG  # noqa: E402  pylint: disable=wrong-import-position
 
 try:
     import angr  # type: ignore
@@ -39,7 +39,7 @@ class CFGExtractor:  # pylint: disable=too-many-instance-attributes
     # The registry inspects this attribute to match the extractor to the view
     VIEW: ClassVar[str] = VIEW_CFG  # <- **key change**
 
-    out_dir: Path
+    out_dir: Path = DEFAULT_VIEWS_DIR / VIEW_CFG
     backend: str = "angr"
     jobs: int = 1
     timeout: int = 300  # seconds per binary
@@ -48,6 +48,10 @@ class CFGExtractor:  # pylint: disable=too-many-instance-attributes
 
     # internal fields (not part of __init__ signature)
     _pool: mp.pool.Pool | None = field(init=False, default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        """Ensure ``out_dir`` defaults to the standard view cache."""
+        object.__setattr__(self, "out_dir", self.out_dir or DEFAULT_VIEWS_DIR / self.VIEW)
 
     # ------------------------------------------------------------------ #
     # Public API

--- a/src/extract/pipelines/extract_pipeline.py
+++ b/src/extract/pipelines/extract_pipeline.py
@@ -36,6 +36,7 @@ import json
 import multiprocessing as mp
 import os
 from dataclasses import dataclass, field
+import inspect
 from functools import partial
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
@@ -129,7 +130,11 @@ def _process_sample(
 
     for view in view_names:
         extractor_cls = get_extractor(view)
-        extractor = extractor_cls()            # stateless
+        sig = inspect.signature(extractor_cls)
+        if "out_dir" in sig.parameters:
+            extractor = extractor_cls(out_dir=out_dir / view)
+        else:
+            extractor = extractor_cls()            # stateless
         view_tag = f"[{sample.name}/{view}]"
 
         # --------------------- run extractor ------------------------------ #

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -7,6 +7,8 @@ from src.extract.extractors.view_registry import (
     ViewRegistrationError,
 )
 from src.extract.base import ExtractorBase
+from src.extract.constants import DEFAULT_VIEWS_DIR, VIEW_CFG
+from src.extract.extractors.cfg_extractor import CFGExtractor
 
 
 def test_extractors_concrete():
@@ -16,4 +18,9 @@ def test_extractors_concrete():
         except ViewRegistrationError as exc:
             pytest.skip(f"dependency missing for {view_id}: {exc}")
         assert not inspect.isabstract(cls), f"{view_id} still abstract"
+
+
+def test_cfg_extractor_default_out_dir():
+    ext = CFGExtractor()
+    assert ext.out_dir == DEFAULT_VIEWS_DIR / VIEW_CFG
 


### PR DESCRIPTION
## Summary
- make `CFGExtractor.out_dir` default to standard cache location
- pass `out_dir` from `ExtractPipeline` when extractor accepts it
- test default value for `CFGExtractor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685723cef810832e8c6b38503759f5aa