### PR TITLE
Fix SysCallExtractor to inherit ExtractorBase

### DIFF
--- a/src/extract/extractors/syscall_extractor.py
+++ b/src/extract/extractors/syscall_extractor.py
@@ -17,13 +17,13 @@ from typing import Any, Dict, List, Set
 import angr  # heavy import; only used when extract() is called
 
 from ..constants import VIEW_SYSCALL  # <‑‑ NEW constant import
-from .base import BaseExtractor  # shared interface
+from ..base import ExtractorBase  # shared interface
 from ..utils import ensure_dir
 
 __all__ = ["SysCallExtractor"]
 
 
-class SysCallExtractor(BaseExtractor):
+class SysCallExtractor(ExtractorBase):
     """Recover system‑call usage and dump to ``*.syscalls.json``."""
 
     VIEW: str = VIEW_SYSCALL  # <‑‑ registry‑friendly identifier


### PR DESCRIPTION
## Summary
- update the import and base class for `SysCallExtractor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857294217f0832e9299b29ae0016844