### PR TITLE
Implement run methods for CFG & FCG extractors

### DIFF
--- a/src/extract/extractors/cfg_extractor.py
+++ b/src/extract/extractors/cfg_extractor.py
@@ -57,6 +57,11 @@ class CFGExtractor:  # pylint: disable=too-many-instance-attributes
     # Public API
     # ------------------------------------------------------------------ #
 
+    def run(self, sample_path: Path) -> Dict[str, Any]:
+        """Extract CFG data for *sample_path* and return a Python dict."""
+        json_path = self._extract_single(Path(sample_path))
+        return json.loads(Path(json_path).read_text())
+
     def __call__(self, *binaries: Path | str) -> List[Path]:  # noqa: D401
         """Extract CFG(s) for one or more binaries.
 

--- a/src/extract/extractors/fcg_extractor.py
+++ b/src/extract/extractors/fcg_extractor.py
@@ -188,6 +188,15 @@ class FCGExtractor:  # pylint: disable=too-few-public-methods
         self.log = logging.getLogger(self.__class__.__name__)
 
     # ------------------------------------------------------------------
+    #  In-memory API used by the pipeline
+    # ------------------------------------------------------------------
+
+    def run(self, sample_path: Path) -> Dict[str, Any]:  # noqa: D401
+        """Return JSON-compatible dict for the given binary."""
+        json_path = self.extract(sample_path)
+        return json.loads(Path(json_path).read_text())
+
+    # ------------------------------------------------------------------
     #  Single‑binary API
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add pipeline-facing `run` method to `CFGExtractor`
- add pipeline-facing `run` method to `FCGExtractor`
- ensure tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572941976c832eb9a435c19ebc8446