### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/explain/report.py
+++ b/src/explain/report.py
@@ -113,7 +113,7 @@ _BASE_MD = textwrap.dedent(
 
     # {{ title }}
 
-    **SHA‑256:** `{{ sha256 }}`  
+    **SHA‑256:** `{{ sha256 }}`
     **Generated:** {{ ts }}
 
     ## Highlighted Code
@@ -134,7 +134,7 @@ _BASE_MD = textwrap.dedent(
 
     {% if cf %}
     ## Counter‑factual
-    ΔV (nodes): {{ cf.delta_nodes }}  
+    ΔV (nodes): {{ cf.delta_nodes }}
     ΔE (edges): {{ cf.delta_edges }}
 
     {% if cf.img_src %}![CF Graph]({{ cf.img_src }}){% endif %}

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -11,33 +11,33 @@ PPORuleAgent
 
 • 특징
     ─────────────────────────────────────────────────────────────
-    1. ***의존성 최소화***  
+    1. ***의존성 최소화***
        Stable‑Baselines3 대신 **pure‑PyTorch** 구현
        (torch≥2.1, gymnasium≥0.29, numpy).
 
-    2. ***시퀀스 관측 처리***  
-       관측값(obs)은 길이 `max_len`의 토큰 ID 배열.  
+    2. ***시퀀스 관측 처리***
+       관측값(obs)은 길이 `max_len`의 토큰 ID 배열.
        ‑ PAD 토큰을 제외한 임베딩의 **mean pooling**을 상태 표현으로 사용
        (간단·경량, GPU 메모리 절약).
 
-    3. ***정책 네트워크***  
+    3. ***정책 네트워크***
        `Embedding` → `LayerNorm` → `GRU`(1 layer, hidden=256) →
        (a) **Policy head** (logits), (b) **Value head** (V(s)).
 
-    4. ***학습 루프***  
+    4. ***학습 루프***
        ‑ Rollout n_steps 수집 → GAE(λ) ADV 계산 →
-         미니배치 다중 epoch으로 **clip objective** 업데이트.  
+         미니배치 다중 epoch으로 **clip objective** 업데이트.
        ‑ `entropy_coef`, `vf_coef` 등 하이퍼파라미터 configurable.
 
-    5. ***저장·재시작***  
+    5. ***저장·재시작***
        `save(path)` / `load(path)` 제공. policy state_dict만 저장하므로
        가볍고 호환성 ↑.
 
-    6. ***로깅***  
+    6. ***로깅***
        프로젝트 전역 `common.logger` 존재 시 활용,
        없으면 Python 기본 `logging`.
 
-    7. ***스모크 테스트***  
+    7. ***스모크 테스트***
        `python -m rulegen.rl_agent --smoke_test` 한 줄로
        3 000 스텝 학습을 돌려 reward가 + 증가하는지 확인 가능.
 """


### PR DESCRIPTION
## Summary
- remove stray whitespace from `report.py` markdown template
- trim trailing spaces in `rl_agent.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685778983604832eae852f8574edf461