### PR TITLE
Fix ensure_dir import for SysCallExtractor

### DIFF
--- a/src/extract/extractors/syscall_extractor.py
+++ b/src/extract/extractors/syscall_extractor.py
@@ -18,7 +18,7 @@ import angr  # heavy import; only used when extract() is called
 
 from ..constants import VIEW_SYSCALL  # <‑‑ NEW constant import
 from ..base import ExtractorBase  # shared interface
-from ..utils import ensure_dir
+from src.common.utils import ensure_dir
 
 __all__ = ["SysCallExtractor"]
 


### PR DESCRIPTION
## Summary
- import ensure_dir from `src.common.utils` instead of nonexistent `extract.utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68579fe65174832e878ed7b427026984