### PR TITLE
Fix ImportExtractor base class

### DIFF
--- a/src/extract/extractors/import_extractor.py
+++ b/src/extract/extractors/import_extractor.py
@@ -25,7 +25,7 @@ The extractor follows the same *pluggable backend* design used by
 on **angr** (which internally uses *cle* + *lief*) for binary loading, but
 switches to plain *lief* if angr is not available.  Caching, timeout handling,
 and multiprocessing hooks are also supported via the shared
-:class:`~src.extract.base.BaseExtractor` mixin.
+:class:`~src.extract.base.ExtractorBase` mixin.
 """
 
 from dataclasses import dataclass
@@ -37,6 +37,8 @@ import os
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Literal
+# Import the shared extractor interface
+from ..base import ExtractorBase
 
 try:
     import angr  # type: ignore
@@ -47,31 +49,6 @@ try:
     import lief  # type: ignore
 except ImportError:  # pragma: no cover
     lief = None  # noqa: N816 – keep sentinel lowercase
-
-# ---------------------------------------------------------------------------
-# BaseExtractor interface stub (import locally to avoid cyclic deps during type
-# checking).  The real implementation lives in src.extract.base.
-# ---------------------------------------------------------------------------
-
-class BaseExtractor:  # pragma: no cover – runtime stub
-    """Minimal stub; full version resides in *src.extract.base*"""
-
-    name: str
-    logger: logging.Logger
-
-    def __init__(self, timeout: int | None = None, cache_dir: str | Path | None = None):
-        raise NotImplementedError
-
-    # All concrete extractors implement this
-    def _extract(self, binary: Path, **kwargs: Any) -> dict[str, Any]:  # noqa: D401
-        """Return in‑memory JSON‑serialisable dict"""
-        raise NotImplementedError
-
-    # This helper is provided by the real base class – here only for mypy.
-    def run(self, binary: str | os.PathLike[str], out_dir: str | Path | None = None, *, overwrite: bool = False, **kwargs: Any) -> Path:  # noqa: D401,E501
-        """Extract + write JSON; returns output path"""
-        raise NotImplementedError
-
 
 # ---------------------------------------------------------------------------
 # ImportExtractor implementation
@@ -93,14 +70,14 @@ class ImportRecord:
         }
 
 
-class ImportExtractor(BaseExtractor):
+class ImportExtractor(ExtractorBase):
     """Concrete extractor for import table."""
 
     #: File extension → format name mapping (angr uses *cle* loader names)
     _FORMAT_MAP: Dict[str, str] = {"pe": "PE", "elf": "ELF"}
 
     def __init__(self, *, timeout: int | None = 120, cache_dir: str | Path | None = None, backend: Literal["angr", "lief", "auto"] = "auto") -> None:  # noqa: D401,E501
-        # BaseExtractor no longer supports a timeout parameter
+        # ExtractorBase no longer supports a timeout parameter
         super().__init__(cache_dir=cache_dir)
         self.timeout = timeout
         self.backend = self._resolve_backend(backend)
@@ -230,7 +207,7 @@ class ImportExtractor(BaseExtractor):
 
 
 # ---------------------------------------------------------------------------
-# Convenience function for single‑shot extraction (bypasses BaseExtractor.run)
+# Convenience function for single‑shot extraction (bypasses ExtractorBase.run)
 # ---------------------------------------------------------------------------
 
 def extract_imports(


### PR DESCRIPTION
## Summary
- import `ExtractorBase` for shared interface
- remove old `BaseExtractor` stub
- subclass `ExtractorBase` in `ImportExtractor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a1e0b058832ea86873be18c0a17e