### PR TITLE
Implement SysCallExtractor run API

### DIFF
--- a/src/extract/extractors/syscall_extractor.py
+++ b/src/extract/extractors/syscall_extractor.py
@@ -31,6 +31,10 @@ class SysCallExtractor(ExtractorBase):
     output_suffix: str = ".syscalls.json"
     default_timeout: int = 60  # seconds
 
+    def _output_path(self, binary_path: Path) -> Path:
+        sha256 = hashlib.sha256(binary_path.read_bytes()).hexdigest()
+        return self.cache_dir / f"{sha256}{self.output_suffix}"
+
     # ---------------------------------------------------------------------
     # Core worker (runs inside the thread‑pool so we can enforce a timeout)
     # ---------------------------------------------------------------------
@@ -51,7 +55,7 @@ class SysCallExtractor(ExtractorBase):
                 for insn in block.capstone.insns:
                     if insn.mnemonic.startswith("sys"):  # e.g., "syscall"
                         sc_name = "syscall"  # x86‑64 generic
-                    elif insn.insn.id in proj.arch.syscall_instructions:
+                    elif getattr(proj.arch, "syscall_instructions", None) and insn.insn.id in proj.arch.syscall_instructions:
                         sc_name = "syscall"
                     else:
                         continue
@@ -102,3 +106,7 @@ class SysCallExtractor(ExtractorBase):
 
         out_path.write_text(json.dumps(data, indent=2))
         return out_path
+
+    def run(self, sample_path: Path) -> Dict[str, Any]:
+        json_path = self.extract(sample_path)
+        return json.loads(Path(json_path).read_text())

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -9,6 +9,8 @@ from src.extract.extractors.view_registry import (
 from src.extract.base import ExtractorBase
 from src.extract.constants import DEFAULT_VIEWS_DIR, VIEW_CFG
 from src.extract.extractors.cfg_extractor import CFGExtractor
+from src.extract.extractors.syscall_extractor import SysCallExtractor
+from src.extract.constants import VIEW_SYSCALL
 
 
 def test_extractors_concrete():
@@ -23,4 +25,29 @@ def test_extractors_concrete():
 def test_cfg_extractor_default_out_dir():
     ext = CFGExtractor()
     assert ext.out_dir == DEFAULT_VIEWS_DIR / VIEW_CFG
+
+
+def test_syscall_extractor_run(tmp_path):
+    pytest.importorskip("angr")
+
+    asm = tmp_path / "exit.s"
+    asm.write_text(
+        """
+        .global _start
+    _start:
+        mov $60, %rax
+        xor %rdi, %rdi
+        syscall
+        """
+    )
+    bin_path = tmp_path / "exit"
+    import subprocess
+
+    subprocess.check_call(["gcc", "-nostdlib", "-static", "-o", str(bin_path), str(asm)])
+
+    ext = SysCallExtractor(cache_dir=tmp_path)
+    result = ext.run(bin_path)
+
+    assert result["view"] == VIEW_SYSCALL
+    assert result.get("binary_sha256")
 


### PR DESCRIPTION
## Summary
- add `_output_path` helper in `SysCallExtractor`
- implement in-memory `run()` method
- add regression test covering `SysCallExtractor.run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a1e74030832e9bb2a17491b8bec4