### PR TITLE
Add JSON preprocessing stage

### DIFF
--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -86,6 +86,63 @@ def run_extract(args: argparse.Namespace) -> None:  # noqa: D401
         raise StageError from exc
 
 # ────────────────────────────────────────────────────────────────
+# 2. JSON → VIEWS
+# ────────────────────────────────────────────────────────────────
+@register_stage("json")
+def run_json(args: argparse.Namespace) -> None:
+    """Stage 2 – PE metadata JSON → view JSONs."""
+    import json
+    from src.graphs.loaders.ast_loader import ASTLoader
+    from src.graphs.loaders.cfg_loader import CFGLoader
+    from src.graphs.loaders.fcg_loader import FCGLoader
+    from src.graphs.loaders.syscall_loader import SysCallLoader
+
+    logger = _get_logger(args.log_level)
+    converters = {
+        "ast": ASTLoader._convert_pejson_to_ast,
+        "cfg": CFGLoader._convert_pejson_to_cfg,
+        "fcg": FCGLoader._convert_pejson_to_fcg,
+        "syscall": SysCallLoader._convert_pejson_to_syscalls,
+    }
+
+    input_dir = Path(args.input_dir)
+    views_dir = Path(args.out_dir, "data", "views")
+    ensure_dir(views_dir)
+    files = list(input_dir.glob("*.json"))
+    logger.info("[JSON] %d file(s) → views=%s", len(files), ",".join(args.views))
+
+    for fp in files:
+        try:
+            js = json.loads(fp.read_text())
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to read %s: %s", fp, exc)
+            continue
+
+        sha = js.get("get_metadata", {}).get("sha256", fp.stem)
+
+        for view in args.views:
+            conv = converters.get(view)
+            if conv is None:
+                continue
+            try:
+                data_dict = conv(js)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("[%s/%s] convert error: %s", fp.name, view, exc)
+                continue
+
+            dst = views_dir / view / f"{sha}.json"
+            if dst.exists() and not args.overwrite:
+                logger.debug("%s exists; skip", dst)
+                continue
+            ensure_dir(dst.parent)
+            try:
+                with dst.open("w", encoding="utf-8") as f:
+                    json.dump(data_dict, f, indent=2)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("[%s/%s] save error: %s", fp.name, view, exc)
+
+
+# ────────────────────────────────────────────────────────────────
 # 3. GRAPHS
 # ────────────────────────────────────────────────────────────────
 @register_stage("graphs")
@@ -204,6 +261,12 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--views", nargs="+", default=["ast", "cfg", "fcg", "syscall"],
                    choices=["ast", "cfg", "fcg", "syscall"])
     p.set_defaults(func=run_extract)
+
+    # ---------------- json ---------------- #
+    p = sub.add_parser("json", help="Convert PE JSON → view JSONs")
+    p.add_argument("--views", nargs="+", default=["ast", "cfg", "fcg", "syscall"],
+                   choices=["ast", "cfg", "fcg", "syscall"])
+    p.set_defaults(func=run_json)
 
     # ---------------- graphs ---------------- #
     p = sub.add_parser("graphs", help="Merge views into hetero graphs")


### PR DESCRIPTION
## Summary
- support converting PE metadata JSON files into view-specific JSONs
- register new `json` stage and CLI subcommand

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b10594dc832ebe54fa2e96fb69c0