### PR TITLE
Fix docstring order and future import in graphs

### DIFF
--- a/src/graphs/__init__.py
+++ b/src/graphs/__init__.py
@@ -1,5 +1,5 @@
-"""Unified registry and single entry point for graph utilities."""
-"""
+"""Unified registry and single entry point for graph utilities.
+
 src.graphs
 ==========
 
@@ -18,7 +18,6 @@ src.graphs
 >>> builder  = HeteroGraphBuilder(); builder.add_view(ast_norm, 'ast')
 >>> g_hetero = builder.build()
 """
-
 from __future__ import annotations
 
 from typing import List


### PR DESCRIPTION
## Summary
- merge the introduction docstrings in `src/graphs/__init__.py`
- place `from __future__ import annotations` directly under the docstring

## Testing
- `pytest -q` *(fails: capstone has no attribute `CS_ARCH_ARM64`)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6075a0c832e8608db95572c7b90