### PR TITLE
Fix import order in relabeler

### DIFF
--- a/src/graphs/builders/relabeler.py
+++ b/src/graphs/builders/relabeler.py
@@ -1,5 +1,7 @@
 """Remap node IDs and remove isolates."""
 
+from __future__ import annotations
+
 class Relabeler:
     """Ensure node IDs are contiguous and prune isolated nodes."""
     pass
@@ -25,8 +27,6 @@ new_g : Data | HeteroData
 maps  : dict[str, torch.Tensor]
     node_type 별 (old_id → new_id or -1) 텐서.
 """
-
-from __future__ import annotations
 
 from typing import Dict, Tuple
 


### PR DESCRIPTION
## Summary
- move `from __future__ import annotations` to immediately follow the module docstring in `relabeler.py`

## Testing
- `pip install networkx`
- `pip install angr`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b96b481c832ea1143782e45bca9b