### PR TITLE
Fix augment registry import and optional angr

### DIFF
--- a/src/augment/__init__.py
+++ b/src/augment/__init__.py
@@ -158,6 +158,10 @@ def build_from_yaml(path: str | Path) -> ViewGenerator:
     return build_view(view_name, ops_a=ops_a, ops_b=ops_b, **other_kwargs)
 
 
+# 하위 모듈에서 사용할 통합 빌더(registry) 노출
+from . import registry  # noqa: E402
+
+
 # ──────────────────────────────────────────────────────────────
 # 5. 공개 API
 # ──────────────────────────────────────────────────────────────
@@ -174,4 +178,5 @@ __all__ = [
     "build_op",
     "build_view",
     "build_from_yaml",
+    "registry",
 ]

--- a/src/augment/registry.py
+++ b/src/augment/registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from . import build_op, build_view
+
+
+def _build_op_from_cfg(cfg: Dict[str, Any]):
+    cfg = dict(cfg)
+    name = cfg.pop("name")
+    return build_op(name, **cfg)
+
+
+def build(cfg: Dict[str, Any]):
+    """Instantiate augmentation object from a configuration dictionary."""
+    if "type" in cfg:
+        op_cfg = dict(cfg)
+        name = op_cfg.pop("type")
+        return build_op(name, **op_cfg)
+
+    if "view" in cfg:
+        view_cfg = dict(cfg)
+        ops_a_cfg = view_cfg.pop("ops_a", [])
+        ops_b_cfg = view_cfg.pop("ops_b", [])
+        ops_a = [_build_op_from_cfg(c) for c in ops_a_cfg]
+        ops_b = [_build_op_from_cfg(c) for c in ops_b_cfg]
+        view_name = view_cfg.pop("view")
+        return build_view(view_name, ops_a=ops_a, ops_b=ops_b, **view_cfg)
+
+    raise ValueError("Config must contain 'type' or 'view' key")
+
+
+__all__ = ["build"]

--- a/src/extract/extractors/syscall_extractor.py
+++ b/src/extract/extractors/syscall_extractor.py
@@ -14,7 +14,10 @@ import logging
 import multiprocessing.pool as mpool
 from typing import Any, Dict, List, Set
 
-import angr  # heavy import; only used when extract() is called
+try:
+    import angr  # heavy import; only used when extract() is called
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    angr = None  # type: ignore
 
 from ..constants import VIEW_SYSCALL  # <‑‑ NEW constant import
 from ..base import ExtractorBase  # shared interface
@@ -40,6 +43,8 @@ class SysCallExtractor(ExtractorBase):
     # ---------------------------------------------------------------------
     @staticmethod
     def _recover_worker(binary_path: str) -> Dict[str, Any]:
+        if angr is None:  # pragma: no cover - import guard
+            raise ImportError("angr is required for SysCallExtractor")
         proj = angr.Project(binary_path, auto_load_libs=False)
         arch = proj.arch.name
         os_hint = proj.loader.main_object.os


### PR DESCRIPTION
## Summary
- expose a registry helper in `augment` and implement `augment.registry.build`
- handle missing optional dependency `angr` in `SysCallExtractor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857bcc8b870832e96bb500b1c7092d8