### PR TITLE
Handle legacy AST data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ flowchart TD
 
 ```
 
+## Pre-processing quickstart
+
+Run the following command to convert raw JSON metadata into graph view files.
+Use `--overwrite` if legacy AST files may still be present:
+
+```bash
+python -m cli.preprocessing --input-dir data/raw --out . json --overwrite
+```
+
+Alternatively, remove stale files from `data/views/ast` before rerunning the stage.
+
 | #  | 논문 (첫 저자 · 연도)                                                                              | 학회 / 저널   | 링크                            | 파이프라인 적용 포인트                             |
 | -- | ------------------------------------------------------------------------------------------- | --------- | ----------------------------- | ---------------------------------------- |
 | 1  | **Yamaguchi 2014**<br/>“Modeling and Discovering Vulnerabilities with Code Property Graphs” | IEEE S\&P | ([sec.cs.tu-bs.de][1])        | 멀티뷰 → 이기종 그래프 통합 원형                      |

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -108,6 +108,21 @@ def run_json(args: argparse.Namespace) -> None:
     input_dir = Path(args.input_dir)
     views_dir = Path(args.out_dir, "data", "views")
     ensure_dir(views_dir)
+
+    # --- remove legacy AST caches -------------------------------------------
+    if "ast" in args.views:
+        ast_dir = views_dir / "ast"
+        if ast_dir.exists():
+            for fp in ast_dir.glob("*.json"):
+                try:
+                    with fp.open("r", encoding="utf-8") as f:
+                        js = json.load(f)
+                    if "nodes" not in js:
+                        logger.debug("Removing legacy AST file %s", fp)
+                        fp.unlink()
+                except Exception:  # noqa: BLE001
+                    logger.debug("Removing unparsable AST file %s", fp)
+                    fp.unlink()
     files = list(input_dir.glob("*.json"))
     logger.info("[JSON] %d file(s) → views=%s", len(files), ",".join(args.views))
 


### PR DESCRIPTION
## Summary
- clean up legacy AST view files before running JSON conversion
- document preprocessing overwrite step in README

## Testing
- `pip install -q -r requirements.txt` *(fails: torch build error)*
- `pytest -q` *(fails: ModuleNotFoundError: networkx)*

------
https://chatgpt.com/codex/tasks/task_e_6857fbc79a50832ebe5659e813da20c2