### PR TITLE
Add label CSV generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ flowchart TD
 
 ## Pre-processing quickstart
 
+Generate ``labels.csv`` from raw metadata JSON files. All samples in the input
+folder will receive the same label (``--label``).
+
+```bash
+python -m cli.preprocessing --input-dir data/raw/benign --out . labels --label 0
+```
+
 Run the following command to convert raw JSON metadata into graph view files.
 Use `--overwrite` if legacy AST files may still be present:
 

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -61,6 +61,59 @@ def load_yaml_cfg(path: Path) -> dict:
             return yaml.safe_load(f)
 
 # ────────────────────────────────────────────────────────────────
+# labels.csv 생성
+# ────────────────────────────────────────────────────────────────
+@register_stage("labels")
+def run_labels(args: argparse.Namespace) -> None:
+    """Generate or update ``labels.csv`` from raw JSON files."""
+    import csv
+    import json
+
+    logger = _get_logger(args.log_level)
+
+    src_dir = Path(args.input_dir)
+    csv_path = Path(args.csv or (Path(args.out_dir) / "labels.csv"))
+    ensure_dir(csv_path.parent)
+
+    existing: dict[str, str] = {}
+    if csv_path.is_file():
+        with csv_path.open("r", encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                existing[row["sha256"]] = row["label"]
+
+    new_rows: list[dict[str, str]] = []
+    for fp in src_dir.glob("*.json"):
+        try:
+            js = json.loads(fp.read_text())
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to read %s: %s", fp, exc)
+            continue
+
+        sha = js.get("virustotal", {}).get("sha256")
+        if not sha:
+            logger.warning("sha256 not found in %s", fp.name)
+            continue
+        if sha in existing:
+            logger.debug("%s already in CSV", sha)
+            continue
+        new_rows.append({"sha256": sha, "label": str(args.label)})
+
+    if not new_rows:
+        logger.info("[LABELS] no new entries for %s", csv_path)
+        return
+
+    mode = "a" if csv_path.exists() else "w"
+    with csv_path.open(mode, encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["sha256", "label"])
+        if mode == "w":
+            writer.writeheader()
+        for row in new_rows:
+            writer.writerow(row)
+
+    logger.info("[LABELS] %d new entries written to %s", len(new_rows), csv_path)
+
+# ────────────────────────────────────────────────────────────────
 # 1. EXTRACT
 # ────────────────────────────────────────────────────────────────
 @register_stage("extract")
@@ -270,6 +323,14 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     parser.add_argument("--config", type=str, help="YAML config merging into CLI args (OmegaConf/PyYAML)")
 
     sub = parser.add_subparsers(dest="command", required=True)
+
+    # ---------------- labels ---------------- #
+    p = sub.add_parser("labels", help="Generate labels.csv from raw JSONs")
+    p.add_argument("--label", type=int, choices=[0, 1], required=True,
+                   help="Label for all samples (0=benign, 1=malicious)")
+    p.add_argument("--csv", type=str,
+                   help="Output CSV path (default: OUT/labels.csv)")
+    p.set_defaults(func=run_labels)
 
     # ---------------- extract ---------------- #
     p = sub.add_parser("extract", help="Generate AST/CFG/FCG/SysCall views")

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,28 @@
+import argparse
+import json
+from src.cli.preprocessing import run_labels
+
+
+def test_run_labels(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    data = {"virustotal": {"sha256": "deadbeef"}}
+    (raw_dir / "sample.json").write_text(json.dumps(data))
+
+    args = argparse.Namespace(
+        input_dir=str(raw_dir),
+        out_dir=str(tmp_path),
+        workers=1,
+        log_level="INFO",
+        overwrite=False,
+        command="labels",
+        label=1,
+        csv=str(tmp_path / "labels.csv"),
+    )
+
+    run_labels(args)
+
+    csv_path = tmp_path / "labels.csv"
+    text = csv_path.read_text().strip().splitlines()
+    assert text[0] == "sha256,label"
+    assert "deadbeef,1" in text[1]


### PR DESCRIPTION
## Summary
- generate labels.csv from raw JSON files
- add `labels` stage to CLI
- document label generation in README
- test labels generation

## Testing
- `pip install networkx`
- `pip install numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685803c8414c832e836fb494c2c1df1f