### PR TITLE
Move process_one for hetero build to module scope

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -185,6 +185,44 @@ from ..loaders.factory    import get_loader          # view JSON → (Hetero)Dat
 from ..normalizers.base   import get_normalizer      # optional schema normaliser
 from ..utils              import tqdm_wrap, ensure_dir, set_random_seed
 
+
+def _process_one(
+    sha: str,
+    *,
+    views_dir: Path,
+    hetero_dir: Path,
+    views: Tuple[str, ...],
+    normalise: bool,
+    rebuild: bool,
+    log_level: int,
+) -> None:
+    """Single sample processing for :func:`build_hetero_dataset`."""
+    log = get_logger("builder.dataset", log_level)
+
+    out_path = hetero_dir / f"{sha}.pt"
+    if out_path.exists() and not rebuild:
+        return  # skip existing
+
+    builder = HeteroGraphBuilder(log_level=log_level)
+    for v in views:
+        fp_json = views_dir / v / f"{sha}.json"
+        if not fp_json.exists():
+            fp_json = fp_json.with_suffix(".json.gz")
+        if not fp_json.exists():
+            continue
+
+        g = get_loader(v).load(fp_json)
+        if normalise:
+            g = get_normalizer(v)().transform(g)
+        builder.add_view(g, v)
+
+    if not builder._views:
+        log.warning("(%s) skipped – no view graphs found", sha)
+        return
+
+    hetero = builder.build()
+    torch.save(hetero, out_path)
+
 def build_hetero_dataset(
     *,
     views_dir : Path,
@@ -222,39 +260,23 @@ def build_hetero_dataset(
     all_ids = sorted(set.union(*id_sets))
     log.info("▶ %d sample(s) aggregated across views=%s", len(all_ids), ",".join(views))
 
-    # ── 2. 단일 샘플 처리 함수 ───────────────────────────────────────────
-    def _process_one(sha: str) -> None:
-        out_path = hetero_dir / f"{sha}.pt"
-        if out_path.exists() and not rebuild:
-            return  # skip
-
-        builder = HeteroGraphBuilder(log_level=log_level)
-        for v in views:
-            fp_json = (views_dir / v / f"{sha}.json")
-            if not fp_json.exists():
-                fp_json = fp_json.with_suffix(".json.gz")
-            if not fp_json.exists():
-                continue  # 해당 뷰 미존재
-
-            g = get_loader(v).load(fp_json)                  # raw → Data/HeteroData
-            if normalise:
-                g = get_normalizer(v)().transform(g)         # schema 통일
-            builder.add_view(g, v)
-
-        if not builder._views:                               # 모든 뷰가 없음
-            log.warning("(%s) skipped – no view graphs found", sha)
-            return
-
-        hetero = builder.build()
-        torch.save(hetero, out_path)
+    process_one = partial(
+        _process_one,
+        views_dir=views_dir,
+        hetero_dir=hetero_dir,
+        views=views,
+        normalise=normalise,
+        rebuild=rebuild,
+        log_level=log_level,
+    )
 
     # ── 3. 실행 (병렬 or 직렬) ───────────────────────────────────────────
     iterable = tqdm_wrap(all_ids, desc="[hetero]")           # tqdm 없으면 no-op
     if workers and workers > 1:
         with mp.Pool(workers) as pool:
-            list(pool.imap_unordered(_process_one, iterable))
+            list(pool.imap_unordered(process_one, iterable))
     else:
-        for _ in map(_process_one, iterable):
+        for _ in map(process_one, iterable):
             pass
 
     log.info("✔ hetero graphs saved → %s", hetero_dir)


### PR DESCRIPTION
## Summary
- refactor hetero_builder to expose `_process_one` at module level
- wire build_hetero_dataset through `functools.partial`

## Testing
- `pip install networkx numpy torch --extra-index-url https://download.pytorch.org/whl/cpu`
- `pip install torch_geometric gensim sentencepiece pandas pyarrow pefile pyyaml`
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python -m cli.preprocessing --input-dir data/raw --out . graphs --normalise --rebuild` *(fails: ValueError: Unknown normalizer 'ast')*

------
https://chatgpt.com/codex/tasks/task_e_68581daae08c832e927c24669410e6d9