### PR TITLE
Add auto-registration imports for normalizers

### DIFF
--- a/src/graphs/normalizers/__init__.py
+++ b/src/graphs/normalizers/__init__.py
@@ -36,6 +36,8 @@ try:
 except Exception:                           # pragma: no cover
     __version__: str = "0.0.0"
 
+from . import ast_norm, cfg_norm, fcg_norm, syscall_norm  # register built-ins
+
 # IDE / 타입체커용 스타틱 임포트 힌트
 if TYPE_CHECKING:                           # pragma: no cover
     from . import ast_norm                  # noqa: F401


### PR DESCRIPTION
## Summary
- ensure builtin normalizers import on module init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582191849c832eb67d56e08699cb88