### PR TITLE
Fix normalizer call in hetero builder

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -213,7 +213,7 @@ def _process_one(
 
         g = get_loader(v).load(fp_json)
         if normalise:
-            g = get_normalizer(v)().transform(g)
+            g = get_normalizer(v).normalize(g)
         builder.add_view(g, v)
 
     if not builder._views:


### PR DESCRIPTION
## Summary
- fix invocation of graph normalizer to use `.normalize`

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m cli.preprocessing --input-dir data/raw --out . labels --label 0`


------
https://chatgpt.com/codex/tasks/task_e_685827807a78832ea6a4867f5bb279b5