### PR TITLE
Fix address normalization

### DIFF
--- a/src/graphs/loaders/cfg_loader.py
+++ b/src/graphs/loaders/cfg_loader.py
@@ -43,7 +43,13 @@ class CFGLoader(GraphLoaderBase):
         # -------- B) 기존 CFG 로직 ---------------------------- #
         nodes: Sequence[dict] = js["nodes"]
         id2idx: Dict[int, int] = {n["id"]: i for i, n in enumerate(nodes)}
-        addrs: List[str] = [n.get("addr", f"BB_{n['id']}") for n in nodes]
+        addrs: List[int] = []
+        for n in nodes:
+            raw = n.get("addr", f"BB_{n['id']}")
+            try:
+                addrs.append(_hex_to_int(raw))
+            except Exception:  # noqa: BLE001 -- fallback for non numeric addr
+                addrs.append(0)
 
         # ---- (1) 노드 feature 행렬 --------------------------- #
         if any("feat" in n and n["feat"] for n in nodes):
@@ -105,7 +111,8 @@ class CFGLoader(GraphLoaderBase):
 
         next_id = 0
         root_id = next_id
-        nodes.append({"id": root_id, "addr": js.get("get_metadata", {}).get("path", "file"), "kind": "file", "feat": []})
+        root_base = js.get("get_metadata", {}).get("base", 0)
+        nodes.append({"id": root_id, "addr": _hex_to_int(root_base), "kind": "file", "feat": []})
         next_id += 1
 
         # 1) 섹션 순서 보존
@@ -116,7 +123,7 @@ class CFGLoader(GraphLoaderBase):
             next_id += 1
             vsize = _hex_to_int(sec.get("virtual_size", 0))
             rsize = _hex_to_int(sec.get("raw_size",    0))
-            addr  = sec.get("virtual_address", "0x0")
+            addr  = _hex_to_int(sec.get("virtual_address", "0x0"))
             nodes.append({"id": sid,
                           "addr": addr,
                           "kind": "section",
@@ -130,7 +137,7 @@ class CFGLoader(GraphLoaderBase):
             bid = next_id
             next_id += 1
             # 이 BB 주소는 section VA + 0 (섹션 시작)
-            bb_addr = sec.get("virtual_address", "0x0")
+            bb_addr = _hex_to_int(sec.get("virtual_address", "0x0"))
             nodes.append({"id": bid,
                           "addr": bb_addr,
                           "kind": "bb",

--- a/src/graphs/loaders/fcg_loader.py
+++ b/src/graphs/loaders/fcg_loader.py
@@ -38,7 +38,12 @@ class FCGLoader(GraphLoaderBase):
 
         # -------- 1) 노드 메타 & feat ------------------------- #
         names: List[str] = [f.get("name", f"fn_{f['id']}") for f in funcs]
-        addrs: List[str] = [f.get("addr", "") for f in funcs]
+        addrs: List[int] = []
+        for f in funcs:
+            try:
+                addrs.append(_hex_to_int(f.get("addr", 0)))
+            except Exception:  # noqa: BLE001 -- non-numeric addr
+                addrs.append(0)
         is_ext = torch.tensor([bool(f.get("external", False)) for f in funcs])
 
         # --- feat 행렬 (있을 때만) ---------------------------- #
@@ -105,7 +110,7 @@ class FCGLoader(GraphLoaderBase):
         calls: List[Dict[str, Union[int, str]]] = []
 
         # 1) entry_start
-        ep = js.get("pe_headers", {}).get("entry_point", "0x0")
+        ep = _hex_to_int(js.get("pe_headers", {}).get("entry_point", "0x0"))
         ep_size = _hex_to_int(js.get("get_current_function", {}).get("size", 0))
         functions.append(
             {"id": 0, "name": "entry_start", "addr": ep, "feat": [ep_size]}
@@ -115,7 +120,7 @@ class FCGLoader(GraphLoaderBase):
         sections = js.get("pe_headers", {}).get("sections", [])
         for idx, sec in enumerate(sections, start=1):
             name = sec.get("name", "").strip() or f"sec_{idx}"
-            addr = sec.get("virtual_address", "0x0")
+            addr = _hex_to_int(sec.get("virtual_address", "0x0"))
             vsize = _hex_to_int(sec.get("virtual_size", 0))
             functions.append(
                 {


### PR DESCRIPTION
## Summary
- convert addresses to integers in CFG and FCG loaders to avoid tensor casting errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858291b90f0832eb497d139fe30e851