### PR TITLE
Handle string attributes in normalizers

### DIFF
--- a/src/graphs/normalizers/base.py
+++ b/src/graphs/normalizers/base.py
@@ -135,6 +135,12 @@ class NormalizerBase(abc.ABC):
                     to_drop.append(k)
                 elif isinstance(v, torch.Tensor):
                     continue
+                elif isinstance(v, str):
+                    # string attributes (e.g. function name) remain as-is
+                    continue
+                elif isinstance(v, Sequence) and all(isinstance(x, str) for x in v):
+                    # ensure list type for sequences of strings
+                    attrs[k] = list(v)
                 else:  # list/np.ndarray etc. → torch
                     try:
                         attrs[k] = torch.as_tensor(v)

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from src.graphs.normalizers.fcg_norm import FCGNormalizer
+from src.graphs.normalizers.schema import NodeType
+
+
+def test_fcg_normalizer_name_list():
+    g = Data(
+        x=torch.randn(3, 2),
+        addr=[0x1000, 0x2000, 0x3000],
+        name=["main", "foo", "bar"],
+        is_external=torch.tensor([False, True, False]),
+        edge_index=torch.tensor([[0, 1], [1, 2]], dtype=torch.long),
+    )
+
+    norm = FCGNormalizer()
+    out = norm.normalize(g)
+
+    fn_store = out[NodeType.FUNCTION.value]
+    assert fn_store.name == ["main", "foo", "bar"]


### PR DESCRIPTION
## Summary
- avoid tensor conversion for string node attributes in `NormalizerBase`
- add unit test for `FCGNormalizer` handling list of names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582cae8f74832e8d70621b8d2b4cc9