### PR TITLE
Check num_nodes in hetero builder

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -83,12 +83,20 @@ class HeteroGraphBuilder:
     # internals
     # ===========================================================
     def _assign_global_ids(self) -> None:
-        """
-        각 뷰의 로컬 노드 → global 연속 ID 할당.
+        """Assign contiguous global IDs for nodes across views.
+
+        Raises
+        ------
+        ValueError
+            If a node store does not define ``num_nodes``.
         """
         for view_name, g in self._views.items():
             for ntype in g.node_types:
                 num = g[ntype].num_nodes
+                if num is None:
+                    raise ValueError(
+                        f"view '{view_name}' node type '{ntype}' lacks num_nodes"
+                    )
                 start = self._global_counters[ntype]
                 self._global_counters[ntype] += num
                 for lid in range(num):

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.graphs.builders.hetero_builder import HeteroGraphBuilder
+
+
+def test_missing_num_nodes_error():
+    g = HeteroData()
+    # create an empty node store without specifying num_nodes
+    _ = g["function"]
+    builder = HeteroGraphBuilder()
+    builder.add_view(g, "fcg")
+    with pytest.raises(ValueError, match="function"):
+        builder.build()


### PR DESCRIPTION
## Summary
- validate that each node store has `num_nodes` when building the heterograph
- unit test for the missing-node-count case

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68583044f17c832eaebdbe7801fecc03