### PR TITLE
Add num_nodes to CFG normalizer

### DIFF
--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -56,6 +56,7 @@ class CFGNormalizer(NormalizerBase):
 
         # (1-c) inst_cnt : 없는 경우 0 으로 패딩
         n_nodes = g.num_nodes
+        bb_store.num_nodes = n_nodes
         if hasattr(g, "inst_cnt"):
             bb_store.inst_cnt = torch.as_tensor(g.inst_cnt)
         else:


### PR DESCRIPTION
## Summary
- expose basic block count in CFG normalizer

## Testing
- `pytest -k hetero_builder -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685835b90c1c832ea3ae83f2226f2c61