### PR TITLE
Add num_nodes metadata in normalizers

### DIFF
--- a/src/graphs/normalizers/ast_norm.py
+++ b/src/graphs/normalizers/ast_norm.py
@@ -52,6 +52,9 @@ class ASTNormalizer(NormalizerBase):
         if hasattr(g, "x") and g.x is not None:
             new_g[NodeType.TOKEN.value].emb = g.x.clone()
 
+        # num_nodes 명시적으로 기록
+        new_g[NodeType.TOKEN.value].num_nodes = n
+
         # ── 2) edge 영역 ────────────────────────────────────────────
         rel_key = (NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)
         new_g[rel_key].edge_index = g.edge_index.clone()

--- a/src/graphs/normalizers/fcg_norm.py
+++ b/src/graphs/normalizers/fcg_norm.py
@@ -46,6 +46,9 @@ class FCGNormalizer(NormalizerBase):
         # ──────────────────────────────────────────────────────────
         fn_store = new_g[NodeType.FUNCTION.value]
 
+        # 노드 개수 기록
+        fn_store.num_nodes = g.num_nodes
+
         # (1-a) Dense feature
         if hasattr(g, "x") and g.x is not None:
             fn_store.feat = g.x.clone()

--- a/src/graphs/normalizers/syscall_norm.py
+++ b/src/graphs/normalizers/syscall_norm.py
@@ -49,6 +49,9 @@ class SysCallNormalizer(NormalizerBase):
         # ──────────────────────────────────────────────────────────
         sc_store = new_g[NodeType.SYSCALL.value]
 
+        # 노드 개수 기록
+        sc_store.num_nodes = g.num_nodes
+
         # (1-a) feat
         if hasattr(g, "x") and g.x is not None:
             # 로더가 Dense 특성을 제공한 경우 그대로 사용

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -2,7 +2,9 @@ import pytest
 import torch
 from torch_geometric.data import Data
 
+from src.graphs.normalizers.ast_norm import ASTNormalizer
 from src.graphs.normalizers.fcg_norm import FCGNormalizer
+from src.graphs.normalizers.syscall_norm import SysCallNormalizer
 from src.graphs.normalizers.schema import NodeType
 
 
@@ -13,6 +15,7 @@ def test_fcg_normalizer_name_list():
         name=["main", "foo", "bar"],
         is_external=torch.tensor([False, True, False]),
         edge_index=torch.tensor([[0, 1], [1, 2]], dtype=torch.long),
+        num_nodes=3,
     )
 
     norm = FCGNormalizer()
@@ -20,3 +23,29 @@ def test_fcg_normalizer_name_list():
 
     fn_store = out[NodeType.FUNCTION.value]
     assert fn_store.name == ["main", "foo", "bar"]
+    assert fn_store.num_nodes == 3
+
+
+def test_ast_normalizer_num_nodes():
+    g = Data(
+        kind_id=torch.tensor([1, 2], dtype=torch.long),
+        edge_index=torch.tensor([[0], [1]], dtype=torch.long),
+        num_nodes=2,
+    )
+
+    out = ASTNormalizer().normalize(g)
+    tok_store = out[NodeType.TOKEN.value]
+    assert tok_store.num_nodes == 2
+
+
+def test_syscall_normalizer_num_nodes():
+    g = Data(
+        sc_id=torch.tensor([1, 2, 3], dtype=torch.long),
+        sc_name=["open", "read", "close"],
+        edge_index=torch.tensor([[0, 1], [1, 2]], dtype=torch.long),
+        num_nodes=3,
+    )
+
+    out = SysCallNormalizer().normalize(g)
+    sc_store = out[NodeType.SYSCALL.value]
+    assert sc_store.num_nodes == 3


### PR DESCRIPTION
## Summary
- track node counts in AST, FCG and Syscall normalizers
- extend normalizer tests for new num_nodes attribute

## Testing
- `pytest -q` *(fails: ImportError: No module named 'augment')*

------
https://chatgpt.com/codex/tasks/task_e_685835b94264832eb1e861c5040538a8