### PR TITLE
Fix num_nodes warnings for heterograph builder

### DIFF
--- a/src/graphs/normalizers/ast_norm.py
+++ b/src/graphs/normalizers/ast_norm.py
@@ -43,14 +43,18 @@ class ASTNormalizer(NormalizerBase):
 
         # ── 1) 노드 영역 ────────────────────────────────────────────
         n = g.num_nodes
-        new_g[NodeType.TOKEN.value].tok_id = g.kind_id.clone()
+        tok_store = new_g[NodeType.TOKEN.value]
+        tok_store.tok_id = g.kind_id.clone()
 
         # 위치(pos) : 0 … N-1
-        new_g[NodeType.TOKEN.value].pos = torch.arange(n, dtype=torch.long)
+        tok_store.pos = torch.arange(n, dtype=torch.long)
 
         # 임베딩(x) → 'emb'
         if hasattr(g, "x") and g.x is not None:
-            new_g[NodeType.TOKEN.value].emb = g.x.clone()
+            tok_store.emb = g.x.clone()
+
+        # num_nodes 명시적으로 지정해 경고 제거
+        tok_store.num_nodes = n
 
         # ── 2) edge 영역 ────────────────────────────────────────────
         rel_key = (NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)

--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -60,6 +60,8 @@ class CFGNormalizer(NormalizerBase):
             bb_store.inst_cnt = torch.as_tensor(g.inst_cnt)
         else:
             bb_store.inst_cnt = torch.zeros(n_nodes, dtype=torch.long)
+        # 명시적으로 설정해 PyG 경고 방지
+        bb_store.num_nodes = n_nodes
 
         # ────────────────────────────────────────────────────────────
         # 2) 엣지 – ('bb', 'cfg', 'bb')

--- a/src/graphs/normalizers/fcg_norm.py
+++ b/src/graphs/normalizers/fcg_norm.py
@@ -61,6 +61,7 @@ class FCGNormalizer(NormalizerBase):
             fn_store.is_external = g.is_external.clone()
         else:
             fn_store.is_external = torch.zeros(g.num_nodes, dtype=torch.bool)
+        fn_store.num_nodes = g.num_nodes
 
         # ──────────────────────────────────────────────────────────
         # 2) 엣지 – ('function','calls','function')

--- a/src/graphs/normalizers/syscall_norm.py
+++ b/src/graphs/normalizers/syscall_norm.py
@@ -48,6 +48,7 @@ class SysCallNormalizer(NormalizerBase):
         # 1) 노드 – 'syscall'
         # ──────────────────────────────────────────────────────────
         sc_store = new_g[NodeType.SYSCALL.value]
+        n_nodes = g.num_nodes
 
         # (1-a) feat
         if hasattr(g, "x") and g.x is not None:
@@ -60,6 +61,7 @@ class SysCallNormalizer(NormalizerBase):
         # (1-b) name 리스트
         if hasattr(g, "sc_name"):
             sc_store.name = list(g.sc_name)
+        sc_store.num_nodes = n_nodes
 
         # ──────────────────────────────────────────────────────────
         # 2) 엣지 – ('syscall','seq','syscall')

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -4,9 +4,10 @@ pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
 import torch
-from torch_geometric.data import HeteroData
+from torch_geometric.data import Data, HeteroData
 
 from src.graphs.builders.hetero_builder import HeteroGraphBuilder
+from src.graphs.normalizers.ast_norm import ASTNormalizer
 
 
 def test_missing_num_nodes_error():
@@ -17,3 +18,18 @@ def test_missing_num_nodes_error():
     builder.add_view(g, "fcg")
     with pytest.raises(ValueError, match="function"):
         builder.build()
+
+
+def test_builder_num_nodes_inferred(caplog):
+    import logging
+
+    g = Data(edge_index=torch.tensor([[0, 1], [1, 2]]), kind_id=torch.tensor([0, 1, 2]))
+    norm = ASTNormalizer()
+    g_norm = norm.normalize(g)
+
+    caplog.set_level(logging.WARNING)
+    builder = HeteroGraphBuilder()
+    builder.add_view(g_norm, "ast")
+    _ = builder.build()
+
+    assert "Unable to accurately infer" not in caplog.text


### PR DESCRIPTION
## Summary
- ensure each normalizer sets `num_nodes`
- test builder with normalized AST view to verify no warning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_685835bc0384832ea0690ceb52593ac4