### PR TITLE
Allow num_nodes attribute in schema

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -120,6 +120,7 @@ class HeteroGraphBuilder:
 
             # 모든 속성 키 집계
             keys = set(itertools.chain.from_iterable(s.keys() for s in stores))
+            keys.discard("num_nodes")
             merged_store = out[ntype]
 
             for k in keys:

--- a/src/graphs/normalizers/schema.py
+++ b/src/graphs/normalizers/schema.py
@@ -81,14 +81,16 @@ EDGE_TYPES: Final[Tuple[Tuple[str, str, str], ...]] = (
 #    - 정규화 시 해당 키만 남기거나, 누락 시 zero-vector 채움
 # --------------------------------------------------------------------------- #
 NODE_ATTRS: Final[Dict[NodeType, Sequence[str]]] = {
-    NodeType.TOKEN:    ("tok_id", "pos", "emb"),
-    NodeType.BB:       ("feat", "addr", "inst_cnt"),
-    NodeType.FUNCTION: ("feat", "addr", "name", "is_external"),
-    NodeType.SYSCALL:  ("feat", "name"),
-    NodeType.IMPORT:   ("dll", "ordinal"),
-    NodeType.SECTION:  ("name", "size"),
-    NodeType.STRING:   ("slen",),
-    NodeType.PEHEADER: ("numeric",),
+    NodeType.TOKEN:    ("tok_id", "pos", "emb", "num_nodes"),
+    NodeType.BB:       ("feat", "addr", "inst_cnt", "num_nodes"),
+    NodeType.FUNCTION: ("feat", "addr", "name", "is_external", "num_nodes"),
+    NodeType.SYSCALL:  ("feat", "name", "num_nodes"),
+    NodeType.IMPORT:   ("dll", "ordinal", "num_nodes"),
+    NodeType.SECTION:  ("name", "size", "num_nodes"),
+    NodeType.STRING:   ("slen", "num_nodes"),
+    NodeType.PEHEADER: ("numeric", "num_nodes"),
+    NodeType.EXPORT:   ("num_nodes",),
+    NodeType.API:      ("num_nodes",),
 }
 
 


### PR DESCRIPTION
## Summary
- update schema to allow `num_nodes` for each node type
- skip `num_nodes` when merging node stores

## Testing
- `pytest tests/test_normalizer.py tests/test_hetero_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685882af7b10832eb4e1a5401d0d7a9c