### PR TITLE
Add metric tracking and plotting to SelfGraphCL pretrain CLI

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -42,6 +42,8 @@ from graphs.utils import tqdm_wrap
 from augment import auto_aug  # noqa: F401 (registers policies)
 from augment.basic import get_default_graphcl_transforms
 from models.contrast.self_gcl import SelfGraphCL
+from evaluation.metrics import Alignment, Uniformity
+import matplotlib.pyplot as plt
 
 LOGGER = get_logger(__name__)
 
@@ -78,15 +80,29 @@ class HeteroGraphDiskDataset(InMemoryDataset):
 # Training utilities
 # --------------------------------------------------------------------------- #
 
-def train_epoch(model: SelfGraphCL, loader: DataLoader, device: torch.device, *,
-                optimizer: torch.optim.Optimizer, epoch: int, log_interval: int = 50):
+def train_epoch(
+    model: SelfGraphCL,
+    loader: DataLoader,
+    device: torch.device,
+    *,
+    optimizer: torch.optim.Optimizer,
+    epoch: int,
+    log_interval: int = 50,
+):
     model.train()
     total_loss = 0.0
+    align = Alignment()
+    uni = Uniformity()
     for step, batch in enumerate(loader):
         batch = batch.to(device)
         # GraphCL requires *two* augmented views of the same graph
         view1, view2 = get_default_graphcl_transforms()(batch), get_default_graphcl_transforms()(batch)
-        z1, z2, loss = model(view1, view2)  # forward returns contrastive loss
+        out = model(view1, view2, return_emb=True)
+        loss = out["loss"]
+        emb = out["emb"]
+        B = emb.size(0) // 2
+        align.update(emb[:B], emb[B:])
+        uni.update(emb)
         loss.backward()
         optimizer.step()
         optimizer.zero_grad(set_to_none=True)
@@ -95,7 +111,8 @@ def train_epoch(model: SelfGraphCL, loader: DataLoader, device: torch.device, *,
         if (step + 1) % log_interval == 0:
             LOGGER.info("Epoch %d | Step %d/%d | Loss %.4f", epoch, step + 1, len(loader),
                         total_loss / (step + 1))
-    return total_loss / len(loader)
+    avg = total_loss / len(loader)
+    return avg, {"alignment": align.compute(), "uniformity": uni.compute()}
 
 
 # --------------------------------------------------------------------------- #
@@ -114,6 +131,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--gpu", type=int, default=0, help="CUDA device id (‑1 ⇒ CPU)")
     p.add_argument("--num-workers", type=int, default=4)
     p.add_argument("--output", type=Path, required=True, help="Path to save encoder weights (\.pt)")
+    p.add_argument("--plot-path", type=Path, help="Path to save training plot (.png)")
     p.add_argument("--save-every", type=int, default=10, help="Checkpoint interval (epochs)")
     return p.parse_args()
 
@@ -154,9 +172,25 @@ def main():
     # --------------------------------------------------------------------- #
     best_loss = float("inf")
     ensure_dir(args.output.parent)
+    plot_path = args.plot_path if args.plot_path else args.output.with_suffix(".png")
+    ensure_dir(plot_path.parent)
+    loss_hist: list[float] = []
+    align_hist: list[float] = []
+    uni_hist: list[float] = []
     for epoch in range(1, args.epochs + 1):
-        epoch_loss = train_epoch(model, train_loader, device, optimizer=optimizer, epoch=epoch)
-        LOGGER.info("Epoch %d finished | AvgLoss %.4f", epoch, epoch_loss)
+        epoch_loss, metrics = train_epoch(
+            model, train_loader, device, optimizer=optimizer, epoch=epoch
+        )
+        LOGGER.info(
+            "Epoch %d finished | AvgLoss %.4f Alignment %.4f Uniformity %.4f",
+            epoch,
+            epoch_loss,
+            metrics["alignment"],
+            metrics["uniformity"],
+        )
+        loss_hist.append(epoch_loss)
+        align_hist.append(metrics["alignment"])
+        uni_hist.append(metrics["uniformity"])
 
         # Checkpointing
         if epoch % args.save_every == 0 or epoch == args.epochs:
@@ -164,6 +198,16 @@ def main():
             torch.save(model.state_dict(), ckpt_path)
             LOGGER.info("Saved checkpoint → %s", ckpt_path)
         best_loss = min(best_loss, epoch_loss)
+
+    # Plot metrics history
+    plt.figure()
+    epochs = range(1, len(loss_hist) + 1)
+    plt.plot(epochs, loss_hist, label="Loss")
+    plt.plot(epochs, align_hist, label="Alignment")
+    plt.plot(epochs, uni_hist, label="Uniformity")
+    plt.xlabel("Epoch")
+    plt.legend()
+    plt.savefig(plot_path)
 
     # Save final encoder weights (without projection head)
     if hasattr(model, "module"):


### PR DESCRIPTION
## Summary
- log Alignment and Uniformity during SelfGraphCL training
- collect per-epoch histories and plot them after training
- allow custom plot path via new `--plot-path` argument

## Testing
- `ruff check .` *(fails: many existing lint errors)*
- `pytest -q` *(fails: ImportError: Cannot import 'augment.registry' during tests)*

------
https://chatgpt.com/codex/tasks/task_e_685889aa5d78832e8afd3f436448aa2b