### PR TITLE
Add date-key support for labels command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ folder will receive the same label (``--label``).
 python -m cli.preprocessing --input-dir data/raw/benign --out . labels --label 0
 ```
 
+To add a ``collected_at`` column, pass the JSON path to ``--date-key``:
+
+```bash
+python -m cli.preprocessing --input-dir data/raw/benign --out . \
+    labels --label 0 --date-key meta.date
+```
+
 Run the following command to convert raw JSON metadata into graph view files.
 Use `--overwrite` if legacy AST files may still be present:
 

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -60,6 +60,19 @@ def load_yaml_cfg(path: Path) -> dict:
         with path.open("r", encoding="utf-8") as f:
             return yaml.safe_load(f)
 
+
+def _get_nested(js: dict, path: str) -> str | None:
+    """Retrieve nested value via dotted ``path``."""
+    cur = js
+    for key in path.split("."):
+        if isinstance(cur, dict) and key in cur:
+            cur = cur[key]
+        else:
+            return None
+    if isinstance(cur, (str, int, float)):
+        return str(cur)
+    return None
+
 # ────────────────────────────────────────────────────────────────
 # labels.csv 생성
 # ────────────────────────────────────────────────────────────────
@@ -97,15 +110,26 @@ def run_labels(args: argparse.Namespace) -> None:
         if sha in existing:
             logger.debug("%s already in CSV", sha)
             continue
-        new_rows.append({"sha256": sha, "label": str(args.label)})
+
+        row = {"sha256": sha, "label": str(args.label)}
+        if args.date_key:
+            date_val = _get_nested(js, args.date_key)
+            if date_val is None:
+                logger.warning("%s missing date key '%s'", fp.name, args.date_key)
+            else:
+                row["collected_at"] = date_val
+        new_rows.append(row)
 
     if not new_rows:
         logger.info("[LABELS] no new entries for %s", csv_path)
         return
 
     mode = "a" if csv_path.exists() else "w"
+    fieldnames = ["sha256", "label"]
+    if args.date_key:
+        fieldnames.append("collected_at")
     with csv_path.open(mode, encoding="utf-8", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["sha256", "label"])
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
         if mode == "w":
             writer.writeheader()
         for row in new_rows:
@@ -330,6 +354,8 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
                    help="Label for all samples (0=benign, 1=malicious)")
     p.add_argument("--csv", type=str,
                    help="Output CSV path (default: OUT/labels.csv)")
+    p.add_argument("--date-key", type=str, default=None,
+                   help="Dotted JSON path for sample collection date")
     p.set_defaults(func=run_labels)
 
     # ---------------- extract ---------------- #

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -18,6 +18,7 @@ def test_run_labels(tmp_path):
         command="labels",
         label=1,
         csv=str(tmp_path / "labels.csv"),
+        date_key=None,
     )
 
     run_labels(args)
@@ -26,3 +27,32 @@ def test_run_labels(tmp_path):
     text = csv_path.read_text().strip().splitlines()
     assert text[0] == "sha256,label"
     assert "deadbeef,1" in text[1]
+
+
+def test_run_labels_with_date_key(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    data = {
+        "virustotal": {"sha256": "deadbeef"},
+        "meta": {"date": "2024-01-02"},
+    }
+    (raw_dir / "sample.json").write_text(json.dumps(data))
+
+    args = argparse.Namespace(
+        input_dir=str(raw_dir),
+        out_dir=str(tmp_path),
+        workers=1,
+        log_level="INFO",
+        overwrite=False,
+        command="labels",
+        label=1,
+        csv=str(tmp_path / "labels.csv"),
+        date_key="meta.date",
+    )
+
+    run_labels(args)
+
+    csv_path = tmp_path / "labels.csv"
+    text = csv_path.read_text().strip().splitlines()
+    assert text[0] == "sha256,label,collected_at"
+    assert "deadbeef,1,2024-01-02" in text[1]


### PR DESCRIPTION
## Summary
- allow specifying collection date when generating labels CSV
- support nested JSON keys for date extraction
- test date-key behaviour in label generation
- document date-key usage in README

## Testing
- `pytest tests/test_labels.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*

------
https://chatgpt.com/codex/tasks/task_e_68588fa701e0832eb5e2cdbb06d2b042