### PR TITLE
Handle missing dates in time splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ Alternatively, remove stale files from `data/views/ast` before rerunning the sta
 [10]: https://arxiv.org/abs/1503.02406?utm_source=chatgpt.com "Deep Learning and the Information Bottleneck Principle"
 [11]: https://arxiv.org/abs/1707.06347?utm_source=chatgpt.com "Proximal Policy Optimization Algorithms"
 [12]: https://arxiv.org/pdf/2402.11565?utm_source=chatgpt.com "[PDF] Continual Learning on Graphs: Challenges, Solutions, and ... - arXiv"
+
+### Handling missing dates
+
+`split_by_time` skips rows with an invalid or missing collection date by default.
+Pass `--fallback random` to randomly assign those samples to the train/val/test
+splits using the same ratios as the dated entries.

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -268,8 +268,13 @@ def run_splits(args: argparse.Namespace) -> None:
     from src.graphs.dataset.split_generator import build_time_splits
 
     logger = _get_logger(args.log_level)
-    logger.info("[SPLITS] strategy=%s  val=%.2f  test=%.2f",
-                args.strategy, args.val_ratio, args.test_ratio)
+    logger.info(
+        "[SPLITS] strategy=%s  val=%.2f  test=%.2f  fallback=%s",
+        args.strategy,
+        args.val_ratio,
+        args.test_ratio,
+        args.fallback,
+    )
     try:
         splits_dir = Path(args.out_dir, "data", "splits")
         ensure_dir(splits_dir)
@@ -279,6 +284,7 @@ def run_splits(args: argparse.Namespace) -> None:
             strategy=args.strategy,
             val_ratio=args.val_ratio,
             test_ratio=args.test_ratio,
+            fallback=args.fallback,
             seed=args.seed,
         )
     except Exception as exc:  # noqa: BLE001
@@ -381,6 +387,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--strategy", default="time", choices=["time", "stratified", "random"])
     p.add_argument("--val-ratio", type=float, default=0.1)
     p.add_argument("--test-ratio", type=float, default=0.1)
+    p.add_argument("--fallback", choices=["random", "skip"], default="skip")
     p.add_argument("--seed", type=int, default=42)
     p.set_defaults(func=run_splits)
 

--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -92,6 +92,7 @@ def split_by_time(
     cut_date: str | datetime = "2024-01-01",
     val_ratio: float = 0.1,
     test_ratio: float = 0.1,
+    fallback: str = "skip",
     op: str = "symlink",
 ) -> None:
     """
@@ -99,16 +100,21 @@ def split_by_time(
     """
     cut_dt = datetime.fromisoformat(cut_date) if isinstance(cut_date, str) else cut_date
 
-    train, post_cut = [], []
+    train, post_cut, missing_date = [], [], []
     labels: Dict[str, int] = {}
 
     with meta_csv.open() as f:
         reader = csv.DictReader(f)
         for row in reader:
             sha = row[id_col]
-            dt = datetime.fromisoformat(row[date_col])
             if label_col:
                 labels[sha] = int(row[label_col])
+            try:
+                dt = datetime.fromisoformat(row[date_col])
+            except (KeyError, ValueError):
+                _LOG.warning("missing %s for %s", date_col, sha)
+                missing_date.append(sha)
+                continue
             (train if dt < cut_dt else post_cut).append(sha)
 
     # post_cut → val / test
@@ -116,6 +122,27 @@ def split_by_time(
     val_cnt = int(len(rng) * val_ratio / (val_ratio + test_ratio))
     val = rng[:val_cnt]
     test = rng[val_cnt:]
+
+    if missing_date:
+        _LOG.warning("%d samples missing dates", len(missing_date))
+        if fallback == "random":
+            total = len(train) + len(val) + len(test)
+            if total == 0:
+                ratios = (1.0, 0.0, 0.0)
+            else:
+                ratios = (
+                    len(train) / total,
+                    len(val) / total,
+                    len(test) / total,
+                )
+            rng_md = sorted(missing_date)
+            n_train = int(len(rng_md) * ratios[0])
+            n_val = int(len(rng_md) * ratios[1])
+            train.extend(rng_md[:n_train])
+            val.extend(rng_md[n_train : n_train + n_val])
+            test.extend(rng_md[n_train + n_val :])
+        elif fallback != "skip":
+            raise ValueError(f"Unknown fallback '{fallback}'")
 
     _LOG.info("split_by_time  train=%d  val=%d  test=%d", len(train), len(val), len(test))
     _apply_split(graph_dir, out_root, train, val, test, op)
@@ -203,6 +230,7 @@ def _build_argparser() -> argparse.ArgumentParser:
     p.add_argument("--val-ratio", type=float, default=0.1)
     p.add_argument("--test-ratio", type=float, default=0.1)
     p.add_argument("--date-col", type=str, default="collected_at")
+    p.add_argument("--fallback", choices=["random", "skip"], default="skip")
 
     # random-split params
     p.add_argument("--k-fold", type=int, default=5)
@@ -223,6 +251,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             val_ratio=args.val_ratio,
             test_ratio=args.test_ratio,
             date_col=args.date_col,
+            fallback=args.fallback,
             op=args.op,
         )
     else:
@@ -251,6 +280,7 @@ def build_time_splits(
     val_ratio  : float       = 0.1,
     test_ratio : float       = 0.1,
     date_col   : str         = "collected_at",
+    fallback   : str         = "skip",
     # random-split 옵션
     k_fold     : int         = 5,
     # 공통
@@ -293,6 +323,7 @@ def build_time_splits(
             cut_date   = cut_date,
             val_ratio  = val_ratio,
             test_ratio = test_ratio,
+            fallback   = fallback,
             op         = op,
         )
     elif strategy in {"random", "stratified"}:

--- a/tests/test_split_generator.py
+++ b/tests/test_split_generator.py
@@ -1,0 +1,59 @@
+import csv
+from pathlib import Path
+
+from src.graphs.dataset.split_generator import split_by_time
+
+
+def _make_graph_files(tmp_path: Path, shas: list[str]):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    for sha in shas:
+        (graph_dir / f"{sha}.pt").write_text("")
+    return graph_dir
+
+
+def _write_meta(tmp_path: Path, rows: list[dict[str, str]]):
+    meta = tmp_path / "meta.csv"
+    with meta.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    return meta
+
+
+def test_split_by_time_missing_date_skip(tmp_path):
+    rows = [
+        {"sha256": "a", "collected_at": "2023-01-01"},
+        {"sha256": "b", "collected_at": "BAD"},
+        {"sha256": "c", "collected_at": "2024-01-02"},
+    ]
+    meta = _write_meta(tmp_path, rows)
+    graph_dir = _make_graph_files(tmp_path, ["a", "b", "c"])
+    out = tmp_path / "splits"
+
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01", fallback="skip")
+
+    lists = []
+    for s in ["train", "val", "test"]:
+        lst = (out / s / f"{s}_list.txt").read_text().splitlines()
+        lists.extend(lst)
+    assert "b" not in lists
+
+
+def test_split_by_time_missing_date_random(tmp_path):
+    rows = [
+        {"sha256": "a", "collected_at": "2023-01-01"},
+        {"sha256": "b", "collected_at": "BAD"},
+        {"sha256": "c", "collected_at": "2024-01-02"},
+    ]
+    meta = _write_meta(tmp_path, rows)
+    graph_dir = _make_graph_files(tmp_path, ["a", "b", "c"])
+    out = tmp_path / "splits"
+
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01", fallback="random")
+
+    lists = []
+    for s in ["train", "val", "test"]:
+        lst = (out / s / f"{s}_list.txt").read_text().splitlines()
+        lists.extend(lst)
+    assert "b" in lists


### PR DESCRIPTION
## Summary
- allow providing fallback strategy to split_by_time and build_time_splits
- warn and collect samples with invalid dates
- randomly assign or skip missing-date samples
- expose `--fallback` CLI option and document behaviour
- add regression tests for missing date handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589952cb7c832e999b277adbdb38b0