### PR TITLE
Handle missing split file for SelfGraphCL pre-training

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -150,6 +150,12 @@ def main():
     # --------------------------------------------------------------------- #
     # Dataset & Loader
     # --------------------------------------------------------------------- #
+    if not args.splits.is_file():
+        LOGGER.error(
+            "Splits file %s not found. Generate it using split_generator.py (e.g. `python -m graphs.dataset.split_generator`).",
+            args.splits,
+        )
+        raise SystemExit(1)
     split_json = json.loads(Path(args.splits).read_text())
     train_shas = split_json["train"]
 


### PR DESCRIPTION
## Summary
- validate that the `--splits` JSON exists before reading in `pretrain_selfgcl.py`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a25a77dc832e911b998f2dcd29ba