### PR TITLE
Improve timer logging with tqdm support

### DIFF
--- a/src/graphs/loaders/base.py
+++ b/src/graphs/loaders/base.py
@@ -110,7 +110,11 @@ class GraphLoaderBase(abc.ABC):
                 return pickle.load(f)
 
         # (2) 새로 파싱
-        with timer(f"{self.LOADER_NAME} parse"):
+        with timer(
+            f"{self.LOADER_NAME} parse",
+            logger=self.log,
+            use_tqdm=True,
+        ):
             g = self._parse(src, **kwargs)
 
         # (3) post-process

--- a/src/graphs/utils.py
+++ b/src/graphs/utils.py
@@ -92,10 +92,28 @@ def tqdm_wrap(iterable, desc: str = "", total: Optional[int] = None, **kwargs):
 # 4. 타이머 컨텍스트
 # --------------------------------------------------------------------------- #
 @contextmanager
-def timer(msg: str = "elapsed") -> Iterator[None]:
+def timer(
+    msg: str = "elapsed",
+    *,
+    logger: Optional[logging.Logger] = None,
+    use_tqdm: bool = False,
+) -> Iterator[None]:
+    """Measure wall time of a ``with`` block."""
     start = perf_counter()
     yield
-    print(f"{msg}: {perf_counter() - start:.2f}s")
+    elapsed = perf_counter() - start
+    if use_tqdm:
+        try:
+            from tqdm.auto import tqdm
+        except ModuleNotFoundError:  # pragma: no cover - optional dep
+            print(f"{msg}: {elapsed:.2f}s")
+        else:
+            tqdm.write(f"{msg}: {elapsed:.2f}s")
+    else:
+        if logger:
+            logger.info(f"{msg}: {elapsed:.2f}s")
+        else:
+            print(f"{msg}: {elapsed:.2f}s")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- enhance `timer` with optional logger and tqdm output
- log parse time via tqdm in graph loader

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'augment')*
- `python - <<'EOF'
import types, sys
sys.modules['augment'] = types.ModuleType('augment'); sys.modules['augment'].registry = {}
from src.graphs.loaders.cfg_loader import CFGLoader
from src.graphs.utils import tqdm_wrap
loader = CFGLoader()
for fp in tqdm_wrap(['data/views/cfg/f76cc117d2451bbf95ba064f7fb7d5698f153905ceef448c8d00d2a089406569.json']*2, desc='load'):
    loader.load(fp)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6858b25da4bc832e85b3bbc7adfbcd45