### PR TITLE
Fix split generator to overwrite existing output files

### DIFF
--- a/src/graphs/__init__.py
+++ b/src/graphs/__init__.py
@@ -43,25 +43,31 @@ from .builders import (
     cluster_loader,
 )
 
-# features
-from .features import (
-    TokenEmbedder,
-    OpcodeEmbedder,
-    PEHeaderFeatureExtractor,
-    CallGraphStatExtractor,
-    available as feats_available,
-)
+# features (optional dependencies)
+try:  # pragma: no cover - optional heavy deps
+    from .features import (
+        TokenEmbedder,
+        OpcodeEmbedder,
+        PEHeaderFeatureExtractor,
+        CallGraphStatExtractor,
+        available as feats_available,
+    )
+except Exception:  # noqa: BLE001 - broad for optional import
+    feats_available = lambda: []  # type: ignore
 
 # dataset
 from .dataset import GraphDataset, split_by_time, split_random
 
-# transforms
-from .transforms import (
-    GraphAugmentTransform,
-    GraphPruner,
-    AttributeScaler,
-    available as transforms_available,
-)
+# transforms (optional augment dependency)
+try:  # pragma: no cover - optional heavy deps
+    from .transforms import (
+        GraphAugmentTransform,
+        GraphPruner,
+        AttributeScaler,
+        available as transforms_available,
+    )
+except Exception:  # noqa: BLE001 - broad for optional import
+    transforms_available = lambda: []  # type: ignore
 
 # ────────────────────────────────────────────────────────────────
 # 편의 함수: 전체 가용 심벌 카탈로그
@@ -91,22 +97,28 @@ __all__: List[str] = [
     "sample_edge_drop",
     "sainth_loader",
     "cluster_loader",
-    # features
-    "TokenEmbedder",
-    "OpcodeEmbedder",
-    "PEHeaderFeatureExtractor",
-    "CallGraphStatExtractor",
     # dataset
     "GraphDataset",
     "split_by_time",
     "split_random",
-    # transforms
-    "GraphAugmentTransform",
-    "GraphPruner",
-    "AttributeScaler",
     # util
     "catalog",
 ]
+
+if "TokenEmbedder" in globals():
+    __all__.extend([
+        "TokenEmbedder",
+        "OpcodeEmbedder",
+        "PEHeaderFeatureExtractor",
+        "CallGraphStatExtractor",
+    ])
+
+if "GraphAugmentTransform" in globals():
+    __all__.extend([
+        "GraphAugmentTransform",
+        "GraphPruner",
+        "AttributeScaler",
+    ])
 
 # 선택: 패키지 버전 문자열 (pyproject.toml에 정의돼 있을 때 자동)
 try:

--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -50,7 +50,13 @@ _LOG = get_logger("dataset.split_gen")
 # 내부 헬퍼
 ########################################################################
 def _link_copy_move(src: Path, dst: Path, op: str = "symlink") -> None:
-    """그래프 파일을 dst에 symlink / copy / move."""
+    """그래프 파일을 dst에 symlink / copy / move.
+
+    기존 파일이 있으면 덮어써 FileExistsError 를 방지한다.
+    """
+    if dst.exists():
+        dst.unlink()  # overwrite existing file/link
+
     if op == "symlink":
         dst.symlink_to(src.resolve())
     elif op == "copy":

--- a/tests/test_split_generator.py
+++ b/tests/test_split_generator.py
@@ -57,3 +57,16 @@ def test_split_by_time_missing_date_random(tmp_path):
         lst = (out / s / f"{s}_list.txt").read_text().splitlines()
         lists.extend(lst)
     assert "b" in lists
+
+
+def test_split_by_time_overwrite(tmp_path):
+    """Running split_by_time twice should not raise FileExistsError."""
+    rows = [{"sha256": "a", "collected_at": "2023-01-01"}]
+    meta = _write_meta(tmp_path, rows)
+    graph_dir = _make_graph_files(tmp_path, ["a"])
+    out = tmp_path / "splits"
+
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
+    # rerun with existing output files
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
+


### PR DESCRIPTION
## Summary
- ensure `_link_copy_move` overwrites existing files to avoid `FileExistsError`
- import optional graph features/transforms lazily so tests run without heavy deps
- add regression test for rerunning `split_by_time`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b90093c0832e8f145381f1a45449