### PR TITLE
Add JSON split export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,6 @@ Alternatively, remove stale files from `data/views/ast` before rerunning the sta
 `split_by_time` skips rows with an invalid or missing collection date by default.
 Pass `--fallback random` to randomly assign those samples to the train/val/test
 splits using the same ratios as the dated entries.
+
+The split lists are also saved in `data/splits/time_split.json`. Use
+`--json-out` to choose a different path.

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -278,6 +278,7 @@ def run_splits(args: argparse.Namespace) -> None:
     try:
         splits_dir = Path(args.out_dir, "data", "splits")
         ensure_dir(splits_dir)
+        json_path = Path(args.json_out) if args.json_out else splits_dir / "time_split.json"
         build_time_splits(
             hetero_dir=Path(args.out_dir, "data", "hetero"),
             splits_dir=splits_dir,
@@ -286,6 +287,7 @@ def run_splits(args: argparse.Namespace) -> None:
             test_ratio=args.test_ratio,
             fallback=args.fallback,
             seed=args.seed,
+            json_path=json_path,
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Splits stage failed")
@@ -389,6 +391,8 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--test-ratio", type=float, default=0.1)
     p.add_argument("--fallback", choices=["random", "skip"], default="skip")
     p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--json-out", type=str, default=None,
+                   help="Path to split JSON (default: SPLITS_DIR/time_split.json)")
     p.set_defaults(func=run_splits)
 
     # ---------------- embeds ---------------- #

--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -84,6 +84,19 @@ def _write_split_list(root: Path, split: str, shas: Sequence[str]) -> None:
     lst.write_text("\n".join(shas))
 
 
+def _write_split_json(
+    json_path: Path,
+    train: Sequence[str],
+    val: Sequence[str],
+    test: Sequence[str],
+) -> None:
+    """Save a JSON summary of split lists to ``json_path``."""
+    import json
+
+    data = {"train": list(train), "val": list(val), "test": list(test)}
+    json_path.write_text(json.dumps(data, indent=2))
+
+
 ########################################################################
 # 분할 로직
 ########################################################################
@@ -100,6 +113,7 @@ def split_by_time(
     test_ratio: float = 0.1,
     fallback: str = "skip",
     op: str = "symlink",
+    json_path: Path | None = None,
 ) -> None:
     """
     cut_date 이전은 train, 이후는 (val:test) 비율로 랜덤 분할.
@@ -151,7 +165,7 @@ def split_by_time(
             raise ValueError(f"Unknown fallback '{fallback}'")
 
     _LOG.info("split_by_time  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    _apply_split(graph_dir, out_root, train, val, test, op)
+    _apply_split(graph_dir, out_root, train, val, test, op, json_path)
 
 
 def split_random(
@@ -164,6 +178,7 @@ def split_random(
     k_fold: int = 5,
     seed: int = 42,
     op: str = "symlink",
+    json_path: Path | None = None,
 ) -> None:
     """
     label 균형을 유지한 stratified k-fold → train/val/test.
@@ -188,7 +203,7 @@ def split_random(
     test, val, *tr_folds = folds
     train = list(itertools.chain.from_iterable(tr_folds))
     _LOG.info("split_random  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    _apply_split(graph_dir, out_root, train, val, test, op)
+    _apply_split(graph_dir, out_root, train, val, test, op, json_path)
 
 
 ########################################################################
@@ -201,6 +216,7 @@ def _apply_split(
     val: Sequence[str],
     test: Sequence[str],
     op: str,
+    json_path: Path | None = None,
 ) -> None:
     paths = _make_split_dirs(out_root)
     mapping = [("train", train), ("val", val), ("test", test)]
@@ -215,6 +231,9 @@ def _apply_split(
             for src in src_files:
                 _link_copy_move(src, dst_dir / src.name, op)
         _write_split_list(out_root, split_name, lst)
+
+    json_fp = json_path or (out_root / "time_split.json")
+    _write_split_json(json_fp, train, val, test)
 
 
 ########################################################################
@@ -295,6 +314,7 @@ def build_time_splits(
     label_col  : str         = "label",
     seed       : int         = 42,
     op         : str         = "symlink",
+    json_path  : Path | None = None,
 ) -> None:
     """
     이미 생성된 *.pt 헤테로그래프를 train/val/test 로 배분한다.
@@ -331,6 +351,7 @@ def build_time_splits(
             test_ratio = test_ratio,
             fallback   = fallback,
             op         = op,
+            json_path  = json_path,
         )
     elif strategy in {"random", "stratified"}:
         split_random(
@@ -342,6 +363,7 @@ def build_time_splits(
             k_fold    = k_fold,
             seed      = seed,
             op        = op,
+            json_path = json_path,
         )
     else:
         raise ValueError(f"Unknown strategy '{strategy}' (expect 'time' or 'random')")

--- a/tests/test_split_generator.py
+++ b/tests/test_split_generator.py
@@ -1,6 +1,7 @@
 import csv
 from pathlib import Path
 
+import json
 from src.graphs.dataset.split_generator import split_by_time
 
 
@@ -69,4 +70,23 @@ def test_split_by_time_overwrite(tmp_path):
     split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
     # rerun with existing output files
     split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
+
+
+def test_write_split_json(tmp_path):
+    rows = [
+        {"sha256": "a", "collected_at": "2023-01-01"},
+        {"sha256": "b", "collected_at": "2024-01-02"},
+    ]
+    meta = _write_meta(tmp_path, rows)
+    graph_dir = _make_graph_files(tmp_path, ["a", "b"])
+    out = tmp_path / "splits"
+    json_fp = out / "custom.json"
+
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01", json_path=json_fp)
+
+    data = json.loads(json_fp.read_text())
+    all_shas = sorted(["a", "b"])
+    gathered = sorted(data["train"] + data["val"] + data["test"])
+    assert gathered == all_shas
+
 


### PR DESCRIPTION
## Summary
- add `_write_split_json` and update split helpers to emit a JSON file
- expose `json_path` parameter and CLI option `--json-out`
- document JSON output in README
- test JSON output from `split_by_time`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bf06fb5c832e804e69a81e8b073e