### PR TITLE
Add JSON output parameter to split generator tests

### DIFF
--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import shutil
 import sys
 from collections import defaultdict
@@ -100,6 +101,7 @@ def split_by_time(
     test_ratio: float = 0.1,
     fallback: str = "skip",
     op: str = "symlink",
+    json_path: Path | None = None,
 ) -> None:
     """
     cut_date 이전은 train, 이후는 (val:test) 비율로 랜덤 분할.
@@ -152,6 +154,9 @@ def split_by_time(
 
     _LOG.info("split_by_time  train=%d  val=%d  test=%d", len(train), len(val), len(test))
     _apply_split(graph_dir, out_root, train, val, test, op)
+    if json_path:
+        json_data = {"train": train, "val": val, "test": test}
+        json_path.write_text(json.dumps(json_data, separators=(",", ":")))
 
 
 def split_random(
@@ -295,6 +300,7 @@ def build_time_splits(
     label_col  : str         = "label",
     seed       : int         = 42,
     op         : str         = "symlink",
+    json_path  : Path | None  = None,
 ) -> None:
     """
     이미 생성된 *.pt 헤테로그래프를 train/val/test 로 배분한다.
@@ -331,6 +337,7 @@ def build_time_splits(
             test_ratio = test_ratio,
             fallback   = fallback,
             op         = op,
+            json_path  = json_path,
         )
     elif strategy in {"random", "stratified"}:
         split_random(

--- a/tests/test_split_generator.py
+++ b/tests/test_split_generator.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from pathlib import Path
 
 from src.graphs.dataset.split_generator import split_by_time
@@ -30,14 +31,25 @@ def test_split_by_time_missing_date_skip(tmp_path):
     meta = _write_meta(tmp_path, rows)
     graph_dir = _make_graph_files(tmp_path, ["a", "b", "c"])
     out = tmp_path / "splits"
+    json_file = tmp_path / "split.json"
 
-    split_by_time(meta, graph_dir, out, cut_date="2024-01-01", fallback="skip")
+    split_by_time(
+        meta,
+        graph_dir,
+        out,
+        cut_date="2024-01-01",
+        fallback="skip",
+        json_path=json_file,
+    )
 
     lists = []
     for s in ["train", "val", "test"]:
         lst = (out / s / f"{s}_list.txt").read_text().splitlines()
         lists.extend(lst)
     assert "b" not in lists
+
+    data = json.loads(json_file.read_text())
+    assert data == {"train": ["a"], "val": [], "test": ["c"]}
 
 
 def test_split_by_time_missing_date_random(tmp_path):
@@ -49,14 +61,25 @@ def test_split_by_time_missing_date_random(tmp_path):
     meta = _write_meta(tmp_path, rows)
     graph_dir = _make_graph_files(tmp_path, ["a", "b", "c"])
     out = tmp_path / "splits"
+    json_file = tmp_path / "split.json"
 
-    split_by_time(meta, graph_dir, out, cut_date="2024-01-01", fallback="random")
+    split_by_time(
+        meta,
+        graph_dir,
+        out,
+        cut_date="2024-01-01",
+        fallback="random",
+        json_path=json_file,
+    )
 
     lists = []
     for s in ["train", "val", "test"]:
         lst = (out / s / f"{s}_list.txt").read_text().splitlines()
         lists.extend(lst)
     assert "b" in lists
+
+    data = json.loads(json_file.read_text())
+    assert data == {"train": ["a"], "val": [], "test": ["c", "b"]}
 
 
 def test_split_by_time_overwrite(tmp_path):
@@ -65,8 +88,12 @@ def test_split_by_time_overwrite(tmp_path):
     meta = _write_meta(tmp_path, rows)
     graph_dir = _make_graph_files(tmp_path, ["a"])
     out = tmp_path / "splits"
+    json_file = tmp_path / "split.json"
 
-    split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01", json_path=json_file)
     # rerun with existing output files
-    split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01", json_path=json_file)
+
+    data = json.loads(json_file.read_text())
+    assert data == {"train": ["a"], "val": [], "test": []}
 


### PR DESCRIPTION
## Summary
- support JSON output for splits in `split_by_time` and `build_time_splits`
- update split generator tests to check JSON files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bf054b20832ea749fdf42122092e