### PR TITLE
Add JSON output for split generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,9 @@ Alternatively, remove stale files from `data/views/ast` before rerunning the sta
 `split_by_time` skips rows with an invalid or missing collection date by default.
 Pass `--fallback random` to randomly assign those samples to the train/val/test
 splits using the same ratios as the dated entries.
+
+To save the resulting SHA lists as JSON:
+
+```bash
+python -m cli.preprocessing splits --json-out data/splits/time_split.json ...
+```

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -278,7 +278,7 @@ def run_splits(args: argparse.Namespace) -> None:
     try:
         splits_dir = Path(args.out_dir, "data", "splits")
         ensure_dir(splits_dir)
-        build_time_splits(
+        train, val, test = build_time_splits(
             hetero_dir=Path(args.out_dir, "data", "hetero"),
             splits_dir=splits_dir,
             strategy=args.strategy,
@@ -286,7 +286,10 @@ def run_splits(args: argparse.Namespace) -> None:
             test_ratio=args.test_ratio,
             fallback=args.fallback,
             seed=args.seed,
+            json_out=args.json_out,
         )
+        if args.json_out:
+            logger.info("[SPLITS] JSON saved to %s", args.json_out)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Splits stage failed")
         raise StageError from exc
@@ -389,6 +392,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--test-ratio", type=float, default=0.1)
     p.add_argument("--fallback", choices=["random", "skip"], default="skip")
     p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--json-out", type=Path)
     p.set_defaults(func=run_splits)
 
     # ---------------- embeds ---------------- #

--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import shutil
 import sys
 from collections import defaultdict
@@ -100,7 +101,7 @@ def split_by_time(
     test_ratio: float = 0.1,
     fallback: str = "skip",
     op: str = "symlink",
-) -> None:
+) -> Tuple[List[str], List[str], List[str]]:
     """
     cut_date 이전은 train, 이후는 (val:test) 비율로 랜덤 분할.
     """
@@ -151,7 +152,7 @@ def split_by_time(
             raise ValueError(f"Unknown fallback '{fallback}'")
 
     _LOG.info("split_by_time  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    _apply_split(graph_dir, out_root, train, val, test, op)
+    return _apply_split(graph_dir, out_root, train, val, test, op)
 
 
 def split_random(
@@ -164,7 +165,7 @@ def split_random(
     k_fold: int = 5,
     seed: int = 42,
     op: str = "symlink",
-) -> None:
+) -> Tuple[List[str], List[str], List[str]]:
     """
     label 균형을 유지한 stratified k-fold → train/val/test.
     """
@@ -188,7 +189,7 @@ def split_random(
     test, val, *tr_folds = folds
     train = list(itertools.chain.from_iterable(tr_folds))
     _LOG.info("split_random  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    _apply_split(graph_dir, out_root, train, val, test, op)
+    return _apply_split(graph_dir, out_root, train, val, test, op)
 
 
 ########################################################################
@@ -201,20 +202,26 @@ def _apply_split(
     val: Sequence[str],
     test: Sequence[str],
     op: str,
-) -> None:
+) -> Tuple[List[str], List[str], List[str]]:
     paths = _make_split_dirs(out_root)
-    mapping = [("train", train), ("val", val), ("test", test)]
+    mapping = [("train", list(train)), ("val", list(val)), ("test", list(test))]
+    result = {}
 
     for split_name, lst in mapping:
         dst_dir = paths[split_name]
+        kept: List[str] = []
         for sha in lst:
             src_files = list(graph_dir.glob(f"{sha}.*"))
             if not src_files:
                 _LOG.warning("graph %s.* not found, skip", sha)
                 continue
+            kept.append(sha)
             for src in src_files:
                 _link_copy_move(src, dst_dir / src.name, op)
-        _write_split_list(out_root, split_name, lst)
+        _write_split_list(out_root, split_name, kept)
+        result[split_name] = kept
+
+    return result["train"], result["val"], result["test"]
 
 
 ########################################################################
@@ -295,7 +302,8 @@ def build_time_splits(
     label_col  : str         = "label",
     seed       : int         = 42,
     op         : str         = "symlink",
-) -> None:
+    json_out   : Path | None  = None,
+) -> Tuple[List[str], List[str], List[str]]:
     """
     이미 생성된 *.pt 헤테로그래프를 train/val/test 로 배분한다.
 
@@ -320,7 +328,7 @@ def build_time_splits(
     ensure_dir(splits_dir)
 
     if strategy == "time":
-        split_by_time(
+        train, val, test = split_by_time(
             meta_csv   = meta_csv,
             graph_dir  = hetero_dir,
             out_root   = splits_dir,
@@ -333,7 +341,7 @@ def build_time_splits(
             op         = op,
         )
     elif strategy in {"random", "stratified"}:
-        split_random(
+        train, val, test = split_random(
             meta_csv  = meta_csv,
             graph_dir = hetero_dir,
             out_root  = splits_dir,
@@ -346,7 +354,13 @@ def build_time_splits(
     else:
         raise ValueError(f"Unknown strategy '{strategy}' (expect 'time' or 'random')")
 
+    if json_out is not None:
+        with json_out.open("w", encoding="utf-8") as f:
+            json.dump({"train": train, "val": val, "test": test}, f)
+
     _LOG.info("✔ build_time_splits complete → %s", splits_dir)
+    return train, val, test
+
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_split_generator.py
+++ b/tests/test_split_generator.py
@@ -1,7 +1,8 @@
 import csv
 from pathlib import Path
 
-from src.graphs.dataset.split_generator import split_by_time
+import json
+from src.graphs.dataset.split_generator import split_by_time, build_time_splits
 
 
 def _make_graph_files(tmp_path: Path, shas: list[str]):
@@ -69,4 +70,28 @@ def test_split_by_time_overwrite(tmp_path):
     split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
     # rerun with existing output files
     split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
+
+
+def test_build_time_splits_json(tmp_path):
+    rows = [
+        {"sha256": "x", "collected_at": "2023-01-01"},
+        {"sha256": "y", "collected_at": "2024-01-02"},
+    ]
+    meta = _write_meta(tmp_path, rows)
+    graph_dir = _make_graph_files(tmp_path, ["x", "y"])
+    out = tmp_path / "splits"
+
+    json_path = tmp_path / "split.json"
+    train, val, test = build_time_splits(
+        hetero_dir=graph_dir,
+        splits_dir=out,
+        meta_csv=meta,
+        json_out=json_path,
+    )
+
+    assert json_path.is_file()
+    js = json.loads(json_path.read_text())
+    assert js["train"] == train
+    assert js["val"] == val
+    assert js["test"] == test
 


### PR DESCRIPTION
## Summary
- return final SHA lists from split_by_time and split_random
- support optional JSON export in build_time_splits
- expose --json-out on `preprocessing splits` subcommand
- test JSON export of build_time_splits
- document the option in the quickstart guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bf162a44832ebe48fe782dc54a22