### PR TITLE
Pad heterogeneous graph features in dataset

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -30,8 +30,10 @@ import logging
 import os
 from pathlib import Path
 from typing import Sequence
+from collections import defaultdict
 
 import torch
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torch_geometric.data import Data, InMemoryDataset
 from torch_geometric.loader import DataLoader as PyGLoader
@@ -65,13 +67,32 @@ class HeteroGraphDiskDataset(InMemoryDataset):
     def process(self):
         paths = sorted(Path(self.root).glob("*.pt"))
         data_list = []
+        max_dims: dict[tuple[str, str], int] = defaultdict(int)
         for p in paths:
             sha = p.stem
             if self.sha_list and sha not in self.sha_list:
                 continue
             data: Data = torch.load(p)
             data_list.append(data)
+            for ntype in data.node_types:
+                store = data[ntype]
+                for attr, val in store.items():
+                    if isinstance(val, torch.Tensor) and val.dim() == 2:
+                        key = (ntype, attr)
+                        max_dims[key] = max(max_dims[key], val.size(1))
+
         LOGGER.info("Loaded %d graphs from %s", len(data_list), self.root)
+
+        for data in data_list:
+            for ntype in data.node_types:
+                store = data[ntype]
+                for attr, val in list(store.items()):
+                    if isinstance(val, torch.Tensor) and val.dim() == 2:
+                        key = (ntype, attr)
+                        max_dim = max_dims.get(key, val.size(1))
+                        if val.size(1) < max_dim:
+                            store[attr] = F.pad(val, (0, max_dim - val.size(1)))
+
         data, slices = self.collate(data_list)
         torch.save((data, slices), self.processed_paths[0])
 


### PR DESCRIPTION
## Summary
- pad heterograph 2-D tensor node attributes to a dataset-wide maximum size during processing
- import `defaultdict` and `torch.nn.functional` for padding support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595048ffb8832e898a13e2ebbd0c47