### PR TITLE
Improve collate error visibility

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -67,6 +67,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
     def process(self):
         paths = sorted(Path(self.root).glob("*.pt"))
         data_list = []
+        source_paths: list[Path] = []
         max_dim: dict[tuple[str, str], int] = defaultdict(int)
 
         # --- load graphs & collect maximum feature dimensions ---
@@ -76,6 +77,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 continue
             data: Data | HeteroData = torch.load(p)
             data_list.append(data)
+            source_paths.append(p)
 
             # record the maximum "feature" dimension per (node_type, attr)
             if isinstance(data, HeteroData):
@@ -111,7 +113,28 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                             pad = target - val.size(1)
                             g[attr] = F.pad(val, (0, pad))
 
-        data, slices = self.collate(data_list)
+        try:
+            data, slices = self.collate(data_list)
+        except KeyError as exc:
+            missing_attr = exc.args[0]
+            LOGGER.error("Collation failed: missing attribute '%s'", missing_attr)
+            for path, g in zip(source_paths, data_list):
+                if isinstance(g, HeteroData):
+                    for ntype in g.node_types:
+                        if missing_attr not in g[ntype]:
+                            LOGGER.error(
+                                "Graph %s missing attribute '%s' for node type '%s'",
+                                path,
+                                missing_attr,
+                                ntype,
+                            )
+                else:
+                    if missing_attr not in g:
+                        LOGGER.error("Graph %s missing attribute '%s'", path, missing_attr)
+            raise KeyError(
+                f"Collation failed due to missing attribute '{missing_attr}'. "
+                "Some node features may be missing."
+            ) from exc
         torch.save((data, slices), self.processed_paths[0])
 
 


### PR DESCRIPTION
## Summary
- capture graph paths while loading
- log which graph and attribute caused collate failure
- re-raise KeyError with a more informative message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68595f7294f8832ea6f30e30a802ad55