### PR TITLE
Improve split fallback using filename in meta

### DIFF
--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -111,7 +111,7 @@ def run_labels(args: argparse.Namespace) -> None:
             logger.debug("%s already in CSV", sha)
             continue
 
-        row = {"sha256": sha, "label": str(args.label)}
+        row = {"sha256": sha, "label": str(args.label), "filename": fp.name}
         if args.date_key:
             date_val = _get_nested(js, args.date_key)
             if date_val is None:
@@ -125,7 +125,7 @@ def run_labels(args: argparse.Namespace) -> None:
         return
 
     mode = "a" if csv_path.exists() else "w"
-    fieldnames = ["sha256", "label"]
+    fieldnames = ["sha256", "label", "filename"]
     if args.date_key:
         fieldnames.append("collected_at")
     with csv_path.open(mode, encoding="utf-8", newline="") as f:

--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -109,11 +109,14 @@ def split_by_time(
 
     train, post_cut, missing_date = [], [], []
     labels: Dict[str, int] = {}
+    alt_names: Dict[str, str] = {}
 
     with meta_csv.open() as f:
         reader = csv.DictReader(f)
         for row in reader:
             sha = row[id_col]
+            if "filename" in row:
+                alt_names[sha] = row["filename"]
             if label_col:
                 labels[sha] = int(row[label_col])
             try:
@@ -152,7 +155,7 @@ def split_by_time(
             raise ValueError(f"Unknown fallback '{fallback}'")
 
     _LOG.info("split_by_time  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    return _apply_split(graph_dir, out_root, train, val, test, op)
+    return _apply_split(graph_dir, out_root, train, val, test, op, alt_names)
 
 
 def split_random(
@@ -173,11 +176,15 @@ def split_random(
 
     random.seed(seed)
     buckets: Dict[int, List[str]] = defaultdict(list)
+    alt_names: Dict[str, str] = {}
 
     with meta_csv.open() as f:
         reader = csv.DictReader(f)
         for row in reader:
-            buckets[int(row[label_col])].append(row[id_col])
+            sha = row[id_col]
+            if "filename" in row:
+                alt_names[sha] = row["filename"]
+            buckets[int(row[label_col])].append(sha)
 
     folds: List[List[str]] = [[] for _ in range(k_fold)]
     for lab, shas in buckets.items():
@@ -189,7 +196,7 @@ def split_random(
     test, val, *tr_folds = folds
     train = list(itertools.chain.from_iterable(tr_folds))
     _LOG.info("split_random  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    return _apply_split(graph_dir, out_root, train, val, test, op)
+    return _apply_split(graph_dir, out_root, train, val, test, op, alt_names)
 
 
 ########################################################################
@@ -202,6 +209,7 @@ def _apply_split(
     val: Sequence[str],
     test: Sequence[str],
     op: str,
+    alt_names: Dict[str, str] | None = None,
 ) -> Tuple[List[str], List[str], List[str]]:
     paths = _make_split_dirs(out_root)
     mapping = [("train", list(train)), ("val", list(val)), ("test", list(test))]
@@ -212,6 +220,13 @@ def _apply_split(
         kept: List[str] = []
         for sha in lst:
             src_files = list(graph_dir.glob(f"{sha}.*"))
+            if not src_files and alt_names:
+                alt = alt_names.get(sha)
+                if alt:
+                    src_files = list(graph_dir.glob(alt))
+                    if not src_files:
+                        stem = Path(alt).stem
+                        src_files = list(graph_dir.glob(f"{stem}.*"))
             if not src_files:
                 _LOG.warning("graph %s.* not found, skip", sha)
                 continue

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -25,8 +25,8 @@ def test_run_labels(tmp_path):
 
     csv_path = tmp_path / "labels.csv"
     text = csv_path.read_text().strip().splitlines()
-    assert text[0] == "sha256,label"
-    assert "deadbeef,1" in text[1]
+    assert text[0] == "sha256,label,filename"
+    assert "deadbeef,1,sample.json" in text[1]
 
 
 def test_run_labels_with_date_key(tmp_path):
@@ -54,5 +54,5 @@ def test_run_labels_with_date_key(tmp_path):
 
     csv_path = tmp_path / "labels.csv"
     text = csv_path.read_text().strip().splitlines()
-    assert text[0] == "sha256,label,collected_at"
-    assert "deadbeef,1,2024-01-02" in text[1]
+    assert text[0] == "sha256,label,filename,collected_at"
+    assert "deadbeef,1,sample.json,2024-01-02" in text[1]


### PR DESCRIPTION
## Summary
- include `filename` column in label generation
- fallback to filenames when splitting datasets
- adjust tests for new columns

## Testing
- `pytest tests/test_labels.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859624b6dd8832ea8b446f28ac1f3d4