### PR TITLE
Fix token feature attr

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -41,6 +41,7 @@ from torch_geometric.loader import DataLoader as PyGLoader
 # Project internal imports ----------------------------------------------------
 from common.utils import set_random_seed, get_logger, ensure_dir
 from graphs.utils import tqdm_wrap
+from graphs.normalizers.schema import NodeType
 from augment import auto_aug  # noqa: F401 (registers policies)
 from augment.basic import get_default_graphcl_transforms
 from models.contrast.self_gcl import SelfGraphCL
@@ -76,6 +77,11 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             if self.sha_list and sha not in self.sha_list:
                 continue
             data: Data | HeteroData = torch.load(p)
+            # --- migrate legacy token embedding attribute ---
+            if isinstance(data, HeteroData) and NodeType.TOKEN.value in data.node_types:
+                store = data[NodeType.TOKEN.value]
+                if "emb" in store and "feat" not in store:
+                    store.feat = store.pop("emb")
             data_list.append(data)
             source_paths.append(p)
 

--- a/src/graphs/normalizers/ast_norm.py
+++ b/src/graphs/normalizers/ast_norm.py
@@ -11,7 +11,7 @@ src.graphs.normalizers.ast_norm
 • 출력 : HeteroData
           node type  : 'token'
           edge rel   : ('token', 'child', 'token')
-          node attrs : {'tok_id', 'pos', 'emb'}  (schema.NODE_ATTRS 기준)
+          node attrs : {'tok_id', 'pos', 'feat'}  (schema.NODE_ATTRS 기준)
 
 이후 NormalizerBase 가 _validate_node_attrs / _validate_edge_types 를 호출해
 속성 화이트리스트·edge_type 등 최종 검증·보강을 수행.
@@ -49,9 +49,9 @@ class ASTNormalizer(NormalizerBase):
         # 위치(pos) : 0 … N-1
         tok_store.pos = torch.arange(n, dtype=torch.long)
 
-        # 임베딩(x) → 'emb'
+        # 노드 임베딩(x) → 'feat'
         if hasattr(g, "x") and g.x is not None:
-            tok_store.emb = g.x.clone()
+            tok_store.feat = g.x.clone()
 
         # num_nodes 명시적으로 지정해 경고 제거
         tok_store.num_nodes = n

--- a/src/graphs/normalizers/schema.py
+++ b/src/graphs/normalizers/schema.py
@@ -81,7 +81,7 @@ EDGE_TYPES: Final[Tuple[Tuple[str, str, str], ...]] = (
 #    - 정규화 시 해당 키만 남기거나, 누락 시 zero-vector 채움
 # --------------------------------------------------------------------------- #
 NODE_ATTRS: Final[Dict[NodeType, Sequence[str]]] = {
-    NodeType.TOKEN:    ("tok_id", "pos", "emb", "num_nodes"),
+    NodeType.TOKEN:    ("tok_id", "pos", "feat", "num_nodes"),
     NodeType.BB:       ("feat", "addr", "inst_cnt", "num_nodes"),
     NodeType.FUNCTION: ("feat", "addr", "name", "is_external", "num_nodes"),
     NodeType.SYSCALL:  ("feat", "name", "num_nodes"),


### PR DESCRIPTION
## Summary
- rename token attribute `emb`->`feat` in schema
- update AST normalizer to write `feat`
- migrate existing graphs in `HeteroGraphDiskDataset`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68596e940a24832eabac7e70237974cd