### PR TITLE
Update torch requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # robust-malware-graph
 
+> Python 3.10 이상과 **PyTorch 2.6** 이상의 환경에서 동작합니다.
+
 ```mermaid
 flowchart TD
     %% ─────────────── 노드 정의 ───────────────

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ───────── Deep Learning ─────────
-torch==2.3.*          # 최신 미지원 버전 대신 고정
-torchvision==0.18.*
-torchaudio==2.3.*
+torch>=2.6
+torchvision==0.21.*
+torchaudio==2.6.*
 torch_geometric==2.6.*
 torch_scatter==2.1.2  # PyG 2.6 호환
 torch_sparse==0.6.18


### PR DESCRIPTION
## Summary
- require PyTorch 2.6 or later in docs and dependencies
- update torchvision and torchaudio compatibility versions

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0`
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_68597381ab04832ebde4632e74f9c3dd