### PR TITLE
Add fallback for `name` column in split generator

### DIFF
--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -117,6 +117,8 @@ def split_by_time(
             sha = row[id_col]
             if "filename" in row:
                 alt_names[sha] = row["filename"]
+            elif "name" in row:
+                alt_names[sha] = row["name"]
             if label_col:
                 labels[sha] = int(row[label_col])
             try:
@@ -184,6 +186,8 @@ def split_random(
             sha = row[id_col]
             if "filename" in row:
                 alt_names[sha] = row["filename"]
+            elif "name" in row:
+                alt_names[sha] = row["name"]
             buckets[int(row[label_col])].append(sha)
 
     folds: List[List[str]] = [[] for _ in range(k_fold)]


### PR DESCRIPTION
## Summary
- support `name` column as an alternative to `filename` when generating dataset splits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859758f8898832e98a469074570f21f