### PR TITLE
Add filename column to meta.csv and improve split fallback

### DIFF
--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -111,7 +111,7 @@ def run_labels(args: argparse.Namespace) -> None:
             logger.debug("%s already in CSV", sha)
             continue
 
-        row = {"sha256": sha, "label": str(args.label)}
+        row = {"sha256": sha, "label": str(args.label), "file": fp.name}
         if args.date_key:
             date_val = _get_nested(js, args.date_key)
             if date_val is None:
@@ -125,7 +125,7 @@ def run_labels(args: argparse.Namespace) -> None:
         return
 
     mode = "a" if csv_path.exists() else "w"
-    fieldnames = ["sha256", "label"]
+    fieldnames = ["sha256", "label", "file"]
     if args.date_key:
         fieldnames.append("collected_at")
     with csv_path.open(mode, encoding="utf-8", newline="") as f:

--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -109,11 +109,14 @@ def split_by_time(
 
     train, post_cut, missing_date = [], [], []
     labels: Dict[str, int] = {}
+    name_map: Dict[str, str] = {}
 
     with meta_csv.open() as f:
         reader = csv.DictReader(f)
         for row in reader:
             sha = row[id_col]
+            if "file" in row:
+                name_map[sha] = row["file"]
             if label_col:
                 labels[sha] = int(row[label_col])
             try:
@@ -152,7 +155,7 @@ def split_by_time(
             raise ValueError(f"Unknown fallback '{fallback}'")
 
     _LOG.info("split_by_time  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    return _apply_split(graph_dir, out_root, train, val, test, op)
+    return _apply_split(graph_dir, out_root, train, val, test, op, name_map)
 
 
 def split_random(
@@ -173,11 +176,15 @@ def split_random(
 
     random.seed(seed)
     buckets: Dict[int, List[str]] = defaultdict(list)
+    name_map: Dict[str, str] = {}
 
     with meta_csv.open() as f:
         reader = csv.DictReader(f)
         for row in reader:
-            buckets[int(row[label_col])].append(row[id_col])
+            sha = row[id_col]
+            buckets[int(row[label_col])].append(sha)
+            if "file" in row:
+                name_map[sha] = row["file"]
 
     folds: List[List[str]] = [[] for _ in range(k_fold)]
     for lab, shas in buckets.items():
@@ -189,7 +196,7 @@ def split_random(
     test, val, *tr_folds = folds
     train = list(itertools.chain.from_iterable(tr_folds))
     _LOG.info("split_random  train=%d  val=%d  test=%d", len(train), len(val), len(test))
-    return _apply_split(graph_dir, out_root, train, val, test, op)
+    return _apply_split(graph_dir, out_root, train, val, test, op, name_map)
 
 
 ########################################################################
@@ -202,6 +209,7 @@ def _apply_split(
     val: Sequence[str],
     test: Sequence[str],
     op: str,
+    name_map: Dict[str, str] | None = None,
 ) -> Tuple[List[str], List[str], List[str]]:
     paths = _make_split_dirs(out_root)
     mapping = [("train", list(train)), ("val", list(val)), ("test", list(test))]
@@ -212,6 +220,11 @@ def _apply_split(
         kept: List[str] = []
         for sha in lst:
             src_files = list(graph_dir.glob(f"{sha}.*"))
+            if not src_files and name_map is not None:
+                alt = name_map.get(sha)
+                if alt:
+                    alt_stem = Path(alt).stem
+                    src_files = list(graph_dir.glob(f"{alt_stem}.*"))
             if not src_files:
                 _LOG.warning("graph %s.* not found, skip", sha)
                 continue

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -25,8 +25,8 @@ def test_run_labels(tmp_path):
 
     csv_path = tmp_path / "labels.csv"
     text = csv_path.read_text().strip().splitlines()
-    assert text[0] == "sha256,label"
-    assert "deadbeef,1" in text[1]
+    assert text[0] == "sha256,label,file"
+    assert "deadbeef,1,sample.json" in text[1]
 
 
 def test_run_labels_with_date_key(tmp_path):
@@ -54,5 +54,5 @@ def test_run_labels_with_date_key(tmp_path):
 
     csv_path = tmp_path / "labels.csv"
     text = csv_path.read_text().strip().splitlines()
-    assert text[0] == "sha256,label,collected_at"
-    assert "deadbeef,1,2024-01-02" in text[1]
+    assert text[0] == "sha256,label,file,collected_at"
+    assert "deadbeef,1,sample.json,2024-01-02" in text[1]

--- a/tests/test_split_generator.py
+++ b/tests/test_split_generator.py
@@ -95,3 +95,20 @@ def test_build_time_splits_json(tmp_path):
     assert js["val"] == val
     assert js["test"] == test
 
+
+def test_split_fallback_filename(tmp_path):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    # graph file named 'foo.pt' but meta uses sha 'bar'
+    (graph_dir / "foo.pt").write_text("")
+
+    rows = [{"sha256": "bar", "file": "foo", "collected_at": "2023-01-01"}]
+    meta = _write_meta(tmp_path, rows)
+    out = tmp_path / "splits"
+
+    split_by_time(meta, graph_dir, out, cut_date="2024-01-01")
+
+    assert (out / "train" / "graphs" / "foo.pt").exists()
+    lst = (out / "train" / "train_list.txt").read_text().splitlines()
+    assert "bar" in lst
+


### PR DESCRIPTION
## Summary
- include source filename when creating `meta.csv`
- allow split generator to match graphs by filename if SHA lookup fails
- adjust tests for new `file` column and add coverage for filename fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6859624b6dd8832ea8b446f28ac1f3d4