### PR TITLE
Fix missing attributes in hetero graph builder

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -125,14 +125,15 @@ class HeteroGraphBuilder:
 
             for k in keys:
                 cols = []
+                ref_store = next((s for s in stores if k in s), None)
                 for s in stores:
                     if k in s:
                         cols.append(s[k])
                     else:  # 없는 view → padding 값
-                        if isinstance(s[k] if k in s else torch.tensor([]), torch.Tensor):
-                            shape = list(stores[0][k].shape)
+                        if isinstance(ref_store[k], torch.Tensor):
+                            shape = list(ref_store[k].shape)
                             shape[0] = s.num_nodes
-                            cols.append(torch.zeros(shape, dtype=stores[0][k].dtype))
+                            cols.append(torch.zeros(shape, dtype=ref_store[k].dtype))
                         else:  # list[str] 같은 python obj
                             cols.extend([None] * s.num_nodes)
                 merged_store[k] = torch.cat(cols) if isinstance(cols[0], torch.Tensor) else list(cols)


### PR DESCRIPTION
## Summary
- avoid KeyError when merging node attributes across views
- zero-pad tensor fields based on the reference store that defines the attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859948520a4832e815a7fe4e0d5c196