### PR TITLE
Simplify SelfGraphCL CLI model build

### DIFF
--- a/configs/self_gcl.yaml
+++ b/configs/self_gcl.yaml
@@ -24,11 +24,14 @@ model:
   out_dim: 256
   num_layers: 3
   dropout: 0.1
-  norm: "batch"
+  norm: "batch"                ## batch norm between RGCN layers
+  proj_dim: 256                ## projection head output dimension
+  temperature: 0.5             ## InfoNCE temperature (overrides loss.temperature)
+  gather_distributed: false    ## gather embeddings across GPUs
 
 loss:
   type: "info_nce"
-  temperature: 0.5
+  temperature: 0.5             ## default temperature if not set under model
 
 optimizer:
   name: "adamw"

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -45,6 +45,7 @@ from graphs.normalizers.schema import NodeType
 from augment import auto_aug  # noqa: F401 (registers policies)
 from augment.basic import get_default_graphcl_transforms
 from models.contrast.self_gcl import SelfGraphCL
+from models.gnn.encoder import RGCNEncoder
 from evaluation.metrics import Alignment, Uniformity
 import matplotlib.pyplot as plt
 
@@ -234,7 +235,9 @@ def main():
     # --------------------------------------------------------------------- #
     # Model & Optimizer
     # --------------------------------------------------------------------- #
-    model = SelfGraphCL(**_load_model_hparams(args.config))
+    cfg = _load_model_hparams(args.config)
+    sample_graph = train_ds[0]
+    model = build_model(cfg, sample_graph)
     if device.type == "cuda" and torch.cuda.device_count() > 1:
         model = torch.nn.DataParallel(model)
     model.to(device)
@@ -296,15 +299,59 @@ def main():
 # Helper
 # --------------------------------------------------------------------------- #
 
+def build_model(cfg: dict, sample_graph: HeteroData) -> SelfGraphCL:
+    """Instantiate ``SelfGraphCL`` from YAML config and a sample graph."""
+
+    model_cfg = cfg.get("model", {})
+    loss_cfg = cfg.get("loss", {})
+
+    hidden_dim = model_cfg.get("hidden_dim", 128)
+    out_dim = model_cfg.get("out_dim", 256)
+    num_layers = model_cfg.get("num_layers", 2)
+    dropout = model_cfg.get("dropout", 0.1)
+
+    metadata = sample_graph.metadata()
+    in_dims: dict[str, int] = {}
+    for ntype in sample_graph.node_types:
+        store = sample_graph[ntype]
+        if "x" in store:
+            in_dims[ntype] = store["x"].size(1)
+        elif "feat" in store:
+            in_dims[ntype] = store["feat"].size(1)
+        else:
+            raise KeyError(f"Node type '{ntype}' missing feature tensor")
+
+    encoder = RGCNEncoder(
+        metadata=metadata,
+        in_dims=in_dims,
+        hidden_dim=hidden_dim,
+        out_dim=out_dim,
+        num_layers=num_layers,
+        dropout=dropout,
+    )
+
+    proj_dim = model_cfg.get("proj_dim", 256)
+    temperature = model_cfg.get(
+        "temperature", loss_cfg.get("temperature", 0.2)
+    )
+    gather_distributed = model_cfg.get("gather_distributed", False)
+
+    return SelfGraphCL(
+        encoder,
+        proj_dim=proj_dim,
+        temperature=temperature,
+        gather_distributed=gather_distributed,
+    )
+
 def _load_model_hparams(cfg_path: Path) -> dict:
-    """Load YAML hyper‑parameters & flatten into **kwargs."""
+    """Load full YAML config as a dictionary."""
     try:
         import yaml  # Lazy import (PyYAML optional)
-        with open(cfg_path, "r", encoding="utf‑8") as f:
+        with open(cfg_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f)
-        return cfg.get("model", {})
+        return cfg
     except ModuleNotFoundError:
-        LOGGER.warning("PyYAML not installed ‑ using default hyper‑params")
+        LOGGER.warning("PyYAML not installed - using default hyper-params")
         return {}
 
 


### PR DESCRIPTION
## Summary
- build a RGCNEncoder-based SelfGraphCL using a new `build_model` helper
- create model from dataset sample in `pretrain_selfgcl` CLI
- load entire YAML config and ignore unused keys
- document model fields in `self_gcl.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599442228c832e8efa7a08a7a79df6