### PR TITLE
Fix preprocessing CLI 'all' options

### DIFF
--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -327,6 +327,26 @@ def run_embeds(args: argparse.Namespace) -> None:
 @register_stage("all")
 def run_all(args: argparse.Namespace) -> None:
     """extract → graphs → splits → embeds 순차 실행."""
+    # Populate stage-specific defaults when called via the "all" subcommand.
+    defaults = {
+        "views": ["ast", "cfg", "fcg", "syscall"],
+        "normalise": False,
+        "rebuild": False,
+        "with_feats": False,
+        "strategy": "time",
+        "val_ratio": 0.1,
+        "test_ratio": 0.1,
+        "fallback": "skip",
+        "seed": 42,
+        "json_out": None,
+        "model_name": "microsoft/codebert-base",
+        "batch_size": 64,
+        "device": "cuda",
+    }
+    for key, val in defaults.items():
+        if not hasattr(args, key):
+            setattr(args, key, val)
+
     for name in ("extract", "graphs", "splits", "embeds"):
         _get_logger(args.log_level).info("=== [%s] stage ===", name.upper())
         try:
@@ -408,6 +428,23 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
 
     # ---------------- all ---------------- #
     p = sub.add_parser("all", help="Run *all* pre‑processing stages sequentially")
+    p.add_argument("--views", nargs="+", default=["ast", "cfg", "fcg", "syscall"],
+                   choices=["ast", "cfg", "fcg", "syscall"],
+                   help="Views to extract and convert")
+    p.add_argument("--normalise", action="store_true", help="Normalise features")
+    p.add_argument("--rebuild", action="store_true", help="Rebuild existing graphs")
+    p.add_argument("--with-feats", action="store_true", help="Pad missing node features")
+    p.add_argument("--strategy", default="time", choices=["time", "stratified", "random"],
+                   help="Splitting strategy")
+    p.add_argument("--val-ratio", type=float, default=0.1, help="Validation split ratio")
+    p.add_argument("--test-ratio", type=float, default=0.1, help="Test split ratio")
+    p.add_argument("--fallback", choices=["random", "skip"], default="skip",
+                   help="Fallback policy if no timestamp")
+    p.add_argument("--seed", type=int, default=42, help="Random seed")
+    p.add_argument("--json-out", type=Path, help="Save split info as JSON")
+    p.add_argument("--model-name", default="microsoft/codebert-base", help="LLM model name")
+    p.add_argument("--batch-size", type=int, default=64, help="Encoding batch size")
+    p.add_argument("--device", default="cuda", help="Torch device for inference")
     p.set_defaults(func=run_all)
 
     return parser


### PR DESCRIPTION
## Summary
- ensure `run_all` populates stage defaults
- expose stage options on the `all` subcommand

## Testing
- `pytest -q`
- `python -m src.cli.preprocessing all --help`

------
https://chatgpt.com/codex/tasks/task_e_68599927cffc832eb7c2a18f546904cb