### PR TITLE
Add feature fallback in SelfGraphCL model loader

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -51,6 +51,7 @@ import matplotlib.pyplot as plt
 
 LOGGER = get_logger(__name__)
 
+
 # --------------------------------------------------------------------------- #
 # Dataset stub (thin wrapper around saved PyG Data objects)
 # --------------------------------------------------------------------------- #
@@ -137,7 +138,9 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                             )
                 else:
                     if missing_attr not in g:
-                        LOGGER.error("Graph %s missing attribute '%s'", path, missing_attr)
+                        LOGGER.error(
+                            "Graph %s missing attribute '%s'", path, missing_attr
+                        )
             raise KeyError(
                 f"Collation failed due to missing attribute '{missing_attr}'. "
                 "Some node features may be missing."
@@ -148,6 +151,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
 # --------------------------------------------------------------------------- #
 # Training utilities
 # --------------------------------------------------------------------------- #
+
 
 def train_epoch(
     model: SelfGraphCL,
@@ -165,7 +169,9 @@ def train_epoch(
     for step, batch in enumerate(loader):
         batch = batch.to(device)
         # GraphCL requires *two* augmented views of the same graph
-        view1, view2 = get_default_graphcl_transforms()(batch), get_default_graphcl_transforms()(batch)
+        view1, view2 = get_default_graphcl_transforms()(
+            batch
+        ), get_default_graphcl_transforms()(batch)
         out = model(view1, view2, return_emb=True)
         loss = out["loss"]
         emb = out["emb"]
@@ -178,8 +184,13 @@ def train_epoch(
 
         total_loss += loss.item()
         if (step + 1) % log_interval == 0:
-            LOGGER.info("Epoch %d | Step %d/%d | Loss %.4f", epoch, step + 1, len(loader),
-                        total_loss / (step + 1))
+            LOGGER.info(
+                "Epoch %d | Step %d/%d | Loss %.4f",
+                epoch,
+                step + 1,
+                len(loader),
+                total_loss / (step + 1),
+            )
     avg = total_loss / len(loader)
     return avg, {"alignment": align.compute(), "uniformity": uni.compute()}
 
@@ -188,10 +199,16 @@ def train_epoch(
 # Main
 # --------------------------------------------------------------------------- #
 
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser("SelfGraphCL pre‑training")
     p.add_argument("graph_dir", type=Path, help="Directory with *.pt Graph pickles")
-    p.add_argument("--splits", type=Path, required=True, help="JSON dict with keys train/val/test → [sha]")
+    p.add_argument(
+        "--splits",
+        type=Path,
+        required=True,
+        help="JSON dict with keys train/val/test → [sha]",
+    )
     p.add_argument("--config", type=Path, default=Path("configs/self_gcl.yaml"))
     p.add_argument("--epochs", type=int, default=100)
     p.add_argument("--batch-size", type=int, default=256)
@@ -199,9 +216,13 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--gpu", type=int, default=0, help="CUDA device id (‑1 ⇒ CPU)")
     p.add_argument("--num-workers", type=int, default=4)
-    p.add_argument("--output", type=Path, required=True, help="Path to save encoder weights (\.pt)")
+    p.add_argument(
+        "--output", type=Path, required=True, help="Path to save encoder weights (\.pt)"
+    )
     p.add_argument("--plot-path", type=Path, help="Path to save training plot (.png)")
-    p.add_argument("--save-every", type=int, default=10, help="Checkpoint interval (epochs)")
+    p.add_argument(
+        "--save-every", type=int, default=10, help="Checkpoint interval (epochs)"
+    )
     return p.parse_args()
 
 
@@ -213,7 +234,9 @@ def main():
     # --------------------------------------------------------------------- #
     # Device & Logging
     # --------------------------------------------------------------------- #
-    device = torch.device(f"cuda:{args.gpu}" if args.gpu >= 0 and torch.cuda.is_available() else "cpu")
+    device = torch.device(
+        f"cuda:{args.gpu}" if args.gpu >= 0 and torch.cuda.is_available() else "cpu"
+    )
     LOGGER.info("Using device: %s", device)
 
     # --------------------------------------------------------------------- #
@@ -229,8 +252,13 @@ def main():
     train_shas = split_json["train"]
 
     train_ds = HeteroGraphDiskDataset(args.graph_dir, sha_list=train_shas)
-    train_loader = PyGLoader(train_ds, batch_size=args.batch_size, shuffle=True,
-                             num_workers=args.num_workers, pin_memory=(device.type == "cuda"))
+    train_loader = PyGLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=(device.type == "cuda"),
+    )
 
     # --------------------------------------------------------------------- #
     # Model & Optimizer
@@ -290,12 +318,15 @@ def main():
     else:
         encoder_state = model.encoder.state_dict()
     torch.save(encoder_state, args.output)
-    LOGGER.info("Pre‑training completed ✔  BestLoss %.4f  Saved → %s", best_loss, args.output)
+    LOGGER.info(
+        "Pre‑training completed ✔  BestLoss %.4f  Saved → %s", best_loss, args.output
+    )
 
 
 # --------------------------------------------------------------------------- #
 # Helper
 # --------------------------------------------------------------------------- #
+
 
 def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
     """Return ``SelfGraphCL`` kwargs loaded from ``cfg_path``.
@@ -304,9 +335,14 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
     ``hidden_dim``, ``num_layers``, ``out_dim``, ``dropout``, ``proj_dim``,
     ``temperature``, ``gather_distributed`` and ``target_node``.  Unknown keys
     (e.g. ``name`` or ``backbone``) are ignored.
+
+    Node feature dimensions are inferred from ``graph``.  When a node type
+    lacks a ``.x`` attribute, ``.feat`` is used as a fallback and assigned to
+    ``.x`` so that downstream modules can rely on it.
     """
     try:
         import yaml  # Lazy import (PyYAML optional)
+
         with open(cfg_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
     except ModuleNotFoundError:
@@ -318,15 +354,39 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
         model_cfg.pop(key, None)
 
     encoder_args = {}
-    for k in ("hidden_dim", "num_layers", "out_dim", "dropout", "residual", "target_node"):
+    for k in (
+        "hidden_dim",
+        "num_layers",
+        "out_dim",
+        "dropout",
+        "residual",
+        "target_node",
+    ):
         if k in model_cfg:
             encoder_args[k] = model_cfg.pop(k)
 
     metadata = graph.metadata() if isinstance(graph, HeteroData) else ([], [])
     if isinstance(graph, HeteroData):
-        in_dims = {nt: graph[nt].x.size(-1) for nt in graph.node_types}
+        in_dims: dict[str, int] = {}
+        for nt in graph.node_types:
+            store = graph[nt]
+            if hasattr(store, "x"):
+                feat = store.x
+            elif hasattr(store, "feat"):
+                feat = store.feat
+                store.x = feat  # ensure downstream access
+            else:
+                raise AttributeError(f"Node type '{nt}' lacks '.x' or '.feat'")
+            in_dims[nt] = feat.size(-1)
     else:
-        in_dims = {"": graph.x.size(-1)}  # type: ignore[attr-defined]
+        if hasattr(graph, "x"):
+            feat = graph.x
+        elif hasattr(graph, "feat"):
+            feat = graph.feat
+            graph.x = feat  # type: ignore[attr-defined]
+        else:
+            raise AttributeError("Graph lacks '.x' or '.feat'")
+        in_dims = {"": feat.size(-1)}  # type: ignore[attr-defined]
 
     encoder = RGCNEncoder(metadata=metadata, in_dims=in_dims, **encoder_args)
 


### PR DESCRIPTION
## Summary
- load node feature dimensions from `.feat` when `.x` is absent
- assign `graph[nt].x` from `graph[nt].feat` for downstream use
- document fallback behavior in `_load_model_hparams`

## Testing
- `pytest -q`
- `black --check src/cli/pretrain_selfgcl.py`

------
https://chatgpt.com/codex/tasks/task_e_6859a2dddf60832eb1fb5f1473260c2c