### PR TITLE
Fix injection op when API nodes missing

### DIFF
--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -144,7 +144,10 @@ class InjectAPICall(SimpleAug, AugmentBase):
 
         # (2) API 노드 추가 ------------------------------------------------------------
         api_store = data["api"]
-        old_api_n = api_store.num_nodes if "api" in data.node_types else 0
+        if "api" in data.node_types and api_store.num_nodes is not None:
+            old_api_n = api_store.num_nodes
+        else:
+            old_api_n = 0
         new_api_idx = torch.arange(old_api_n, old_api_n + self.k, device=device)
 
         # 새 노드 수 등록 (특성이 없더라도 반드시 num_nodes 지정)


### PR DESCRIPTION
## Summary
- prevent TypeError in `InjectAPICall` when the graph lacks `api` nodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a5334888832e92a877f3d77f7406