### PR TITLE
Fix SelfGraphCL pretraining dataset

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -63,6 +63,32 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         super().__init__(root)
         self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
+        # Ensure every stored graph has an ``.x`` attribute for each node type.
+        # Some legacy datasets only provide ``.feat`` which breaks newer
+        # modules that expect ``.x``.  We patch the collated ``self.data`` in
+        # place so that ``self.get()`` will yield graphs with the expected
+        # attribute available.
+        if isinstance(self.data, HeteroData):
+            for ntype in self.data.node_types:
+                store = self.data[ntype]
+                if not hasattr(store, "x") and hasattr(store, "feat"):
+                    store.x = store.feat
+        else:
+            if not hasattr(self.data, "x") and hasattr(self.data, "feat"):
+                self.data.x = self.data.feat
+
+    def get(self, idx):  # type: ignore[override]
+        data = super().get(idx)
+        if isinstance(data, HeteroData):
+            for nt in data.node_types:
+                store = data[nt]
+                if not hasattr(store, "x") and hasattr(store, "feat"):
+                    store.x = store.feat
+        else:
+            if not hasattr(data, "x") and hasattr(data, "feat"):
+                data.x = data.feat
+        return data
+
     @property
     def processed_file_names(self) -> list[str]:
         return ["graph_dataset.pt"]


### PR DESCRIPTION
## Summary
- ensure HeteroGraphDiskDataset always yields `.x` node features by mirroring `.feat`
- update dataset initialization and retrieval logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a8dea178832ea37078f1aad4e1f9