### PR TITLE
Fix RGCN encoder for heterogeneous graphs

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -36,6 +36,7 @@ import torch
 from torch import nn, Tensor
 import torch.nn.functional as F
 from torch_geometric.nn import RGCNConv, global_mean_pool
+from torch_geometric.utils import to_homogeneous
 
 try:
     # custom residual + norm wrapper defined elsewhere in the project
@@ -111,21 +112,29 @@ class RGCNEncoder(nn.Module):
         Tensor
             Shape ``(batch_size, out_dim)``.
         """
-        # 1) Project raw features to hidden_dim per node type
-        x_dict = {
-            nt: self.input_proj[nt](data[nt].x)  # type: ignore[attr-defined]
-            for nt in data.node_types
-        }
+        # 1) Project raw features and store back on ``data``
+        for nt in data.node_types:
+            data[nt].x = self.input_proj[nt](data[nt].x)  # type: ignore[attr-defined]
 
-        # 2) RGCN layers
+        # Convert to a homogeneous graph with relation indices
+        homo = to_homogeneous(
+            data,
+            node_attrs=["x", "batch"],
+            add_node_type=True,
+            add_edge_type=True,
+        )
+        x, edge_index, edge_type = homo.x, homo.edge_index, homo.edge_type
+        node_type, batch_vec = homo.node_type, homo.batch
+
+        # 2) RGCN layers on the homogeneous graph
         for conv in self.convs:
-            x_dict = conv(x_dict, data.edge_index_dict)  # type: ignore[arg-type]
-            x_dict = {k: self.drop(self.act(v)) for k, v in x_dict.items()}
+            x = conv(x, edge_index, edge_type)
+            x = self.drop(self.act(x))
 
         # 3) Global mean‑pool over the target node type
-        node_feats = x_dict[self.target_node]
-        batch_vec = data[self.target_node].batch  # type: ignore[attr-defined]
-        g_emb = global_mean_pool(node_feats, batch_vec)
+        target_idx = data.node_types.index(self.target_node)
+        mask = node_type == target_idx
+        g_emb = global_mean_pool(x[mask], batch_vec[mask])
 
         # 4) Final projection
         return self.out_proj(g_emb)


### PR DESCRIPTION
## Summary
- fix `RGCNEncoder` when given `HeteroData`
- convert graph to homogeneous form for `RGCNConv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a9cc8674832ea607ad8a9797d99e