### PR TITLE
Fix ResidualNorm with hetero dict inputs

### DIFF
--- a/src/models/gnn/layers/residual_norm.py
+++ b/src/models/gnn/layers/residual_norm.py
@@ -25,7 +25,7 @@ Example
 
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any, Mapping, Tuple
 
 import torch
 from torch import nn, Tensor
@@ -69,7 +69,7 @@ class ResidualNorm(nn.Module):
         self.norm: nn.Module = self._NORMS[norm_type](in_dim)
 
     # ------------------------------------------------------------------ #
-    def forward(self, x: Tensor, *args: Any, **kwargs: Any):
+    def forward(self, x: Tensor | Mapping[str, Tensor], *args: Any, **kwargs: Any):
         """
         Pass-through that keeps the sublayer’s original signature.
 
@@ -86,8 +86,12 @@ class ResidualNorm(nn.Module):
         else:
             h, rest = out, []
 
-        h = self.drop(h)
-        y = self.norm(x + h)             # Add & Norm
+        if isinstance(h, Mapping) and isinstance(x, Mapping):
+            h = {k: self.drop(v) for k, v in h.items()}
+            y = {k: self.norm(x[k] + h[k]) for k in h}
+        else:
+            h = self.drop(h)
+            y = self.norm(x + h)
 
         return (y, *rest) if rest else y
 


### PR DESCRIPTION
## Summary
- support dict features in ResidualNorm

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6859a9cc8674832ea607ad8a9797d99e