### PR TITLE
Fix RGCN encoder for heterogeneous graphs

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -62,7 +62,9 @@ class RGCNEncoder(nn.Module):
         super().__init__()
 
         node_types, edge_types = metadata
-        self.target_node = target_node or node_types[0]
+        self.node_types = list(node_types)
+        self.ntype_map = {nt: i for i, nt in enumerate(self.node_types)}
+        self.target_node = target_node or self.node_types[0]
         num_relations = len(edge_types)
 
         # -----------------------------------------------------------------
@@ -111,20 +113,26 @@ class RGCNEncoder(nn.Module):
         Tensor
             Shape ``(batch_size, out_dim)``.
         """
-        # 1) Project raw features to hidden_dim per node type
-        x_dict = {
-            nt: self.input_proj[nt](data[nt].x)  # type: ignore[attr-defined]
-            for nt in data.node_types
-        }
+        # 1) Convert input to a homogeneous graph to leverage ``RGCNConv``
+        homo = data.to_homogeneous(node_attrs=["batch"])
 
-        # 2) RGCN layers
+        # 2) Initialise node features after per‑type projection
+        x = homo.x.new_zeros(homo.num_nodes, self.out_proj.in_features)
+        for nt in data.node_types:
+            mask = homo.node_type == self.ntype_map[nt]
+            x[mask] = self.input_proj[nt](data[nt].x)
+
+        # 3) RGCN layers on the homogeneous representation
+        edge_index = homo.edge_index
+        edge_type = homo.edge_type
         for conv in self.convs:
-            x_dict = conv(x_dict, data.edge_index_dict)  # type: ignore[arg-type]
-            x_dict = {k: self.drop(self.act(v)) for k, v in x_dict.items()}
+            x = conv(x, edge_index, edge_type)  # type: ignore[arg-type]
+            x = self.drop(self.act(x))
 
-        # 3) Global mean‑pool over the target node type
-        node_feats = x_dict[self.target_node]
-        batch_vec = data[self.target_node].batch  # type: ignore[attr-defined]
+        # 4) Global mean‑pool over the target node type
+        mask = homo.node_type == self.ntype_map[self.target_node]
+        node_feats = x[mask]
+        batch_vec = homo.batch[mask]
         g_emb = global_mean_pool(node_feats, batch_vec)
 
         # 4) Final projection


### PR DESCRIPTION
## Summary
- handle heterogeneous graphs by converting to a homogeneous representation
- pool embeddings from the converted representation

## Testing
- `pytest -q` *(tests skipped: torch & torch_geometric not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859abd3b174832eac97effe4cbffab8