### PR TITLE
Fix feature initialization in RGCN encoder

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -116,8 +116,12 @@ class RGCNEncoder(nn.Module):
         # 1) Convert input to a homogeneous graph to leverage ``RGCNConv``
         homo = data.to_homogeneous(node_attrs=["batch"])
 
-        # 2) Initialise node features after per‑type projection
-        x = homo.x.new_zeros(homo.num_nodes, self.out_proj.in_features)
+        # 2) Initialise node features after per‑type projection. ``to_homogeneous``
+        #    may drop feature tensors if their dimensions differ across node
+        #    types, so we derive the prototype tensor from the original data
+        #    instead of relying on ``homo.x``.
+        proto = data[data.node_types[0]].x
+        x = proto.new_zeros(homo.num_nodes, self.out_proj.in_features)
         for nt in data.node_types:
             mask = homo.node_type == self.ntype_map[nt]
             x[mask] = self.input_proj[nt](data[nt].x)


### PR DESCRIPTION
## Summary
- avoid relying on `homo.x` when converting heterogeneous graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859adb45390832e9bb9e1f9f7c673c6