### PR TITLE
Fix missing node types when initializing SelfGraphCL encoder

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -288,7 +288,12 @@ def main():
     # --------------------------------------------------------------------- #
     # Model & Optimizer
     # --------------------------------------------------------------------- #
-    model = SelfGraphCL(**_load_model_hparams(args.config, train_ds[0]))
+    # NOTE: Rely on the *collated* dataset representation for encoder metadata
+    # so that node/edge types absent from the very first sample are accounted
+    # for.  Using ``train_ds[0]`` may omit rare types and lead to KeyError.
+    model = SelfGraphCL(
+        **_load_model_hparams(args.config, train_ds.data)
+    )
     if device.type == "cuda" and torch.cuda.device_count() > 1:
         model = torch.nn.DataParallel(model)
     model.to(device)


### PR DESCRIPTION
## Summary
- build encoder metadata from the collated dataset instead of the first sample

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ae9c5d18832eb6149ae786a9ddb0