### PR TITLE
Use collated dataset when initializing SelfGraphCL encoder

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -288,7 +288,10 @@ def main():
     # --------------------------------------------------------------------- #
     # Model & Optimizer
     # --------------------------------------------------------------------- #
-    model = SelfGraphCL(**_load_model_hparams(args.config, train_ds[0]))
+    # ``train_ds.data`` represents the collated dataset containing the union of
+    # node types across all graphs, which ensures the encoder is aware of every
+    # possible node type.
+    model = SelfGraphCL(**_load_model_hparams(args.config, train_ds.data))
     if device.type == "cuda" and torch.cuda.device_count() > 1:
         model = torch.nn.DataParallel(model)
     model.to(device)


### PR DESCRIPTION
## Summary
- initialize `SelfGraphCL` using `train_ds.data` to provide the full union of node types
- document why the collated dataset is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b099ee64832e9bbce7b6e1b20c0d