### PR TITLE
Fix metadata handling for API nodes during self-GCL pretraining

### DIFF
--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -41,11 +41,14 @@ class InjectAPICall(SimpleAug, AugmentBase):
         "Connect",
     ]
 
+    DEFAULT_FEAT_DIM: int = 32
+
     def __init__(
         self,
         api_vocab: List[str] | None = None,
         k: int = 2,
         attach_strategy: str = "random_bb",
+        feat_dim: int = DEFAULT_FEAT_DIM,
         seed: int | None = None,
         **kwargs: Any,
     ) -> None:
@@ -55,16 +58,21 @@ class InjectAPICall(SimpleAug, AugmentBase):
         if attach_strategy not in {"random_bb", "first_bb"}:
             raise ValueError("attach_strategy must be 'random_bb' or 'first_bb'")
 
+        if not isinstance(feat_dim, numbers.Integral) or feat_dim <= 0:
+            raise ValueError("feat_dim must be a positive integer")
+
         self.api_vocab = api_vocab or self._DEFAULT_API_VOCAB
         self.k = int(k)
         self.attach_strategy = attach_strategy
         self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self.feat_dim = int(feat_dim)
 
         super().__init__(
             api_vocab=self.api_vocab,
             k=self.k,
             attach_strategy=self.attach_strategy,
             seed=seed,
+            feat_dim=self.feat_dim,
             **kwargs,
         )
 
@@ -124,6 +132,11 @@ class InjectAPICall(SimpleAug, AugmentBase):
         api_name_feat, dummy_feat = self._make_new_node_feats(device)
         data.api_name = api_name_feat
         data.dummy_feat = dummy_feat
+        if "x" in data:
+            data.x = torch.cat([data.x, dummy_feat], dim=0)
+        else:
+            pad = torch.zeros(num_bb, dummy_feat.size(1), dtype=dummy_feat.dtype, device=device)
+            data.x = torch.cat([pad, dummy_feat], dim=0)
 
         # (2) 엣지 추가 ----------------------------------------------------------------
         new_edges = torch.stack([bb_indices, new_api_idx], dim=0)
@@ -168,9 +181,12 @@ class InjectAPICall(SimpleAug, AugmentBase):
         if "api_name" in api_store:
             api_store["api_name"] = torch.cat([api_store["api_name"], api_name_feat], 0)
             api_store["dummy_feat"] = torch.cat([api_store["dummy_feat"], dummy_feat], 0)
+            if "x" in api_store:
+                api_store["x"] = torch.cat([api_store["x"], dummy_feat], 0)
         else:
             api_store["api_name"] = api_name_feat
             api_store["dummy_feat"] = dummy_feat
+            api_store["x"] = dummy_feat
 
         # (3) 엣지 추가 ---------------------------------------------------------------
         etype: Tuple[str, str, str] = ("bb", "calls", "api")
@@ -219,5 +235,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
                 [vocab2idx[n] for n in api_names], dtype=torch.long, device=device
             )
 
-        dummy_feat = torch.zeros(self.k, 32, dtype=torch.float32, device=device)
+        dummy_feat = torch.zeros(
+            self.k, self.feat_dim, dtype=torch.float32, device=device
+        )
         return api_name_feat, dummy_feat

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -41,7 +41,8 @@ from torch_geometric.loader import DataLoader as PyGLoader
 # Project internal imports ----------------------------------------------------
 from common.utils import set_random_seed, get_logger, ensure_dir
 from graphs.utils import tqdm_wrap
-from graphs.normalizers.schema import NodeType
+from graphs.normalizers.schema import NodeType, EdgeRel
+from augment.ops.inject_call import InjectAPICall
 from augment import auto_aug  # noqa: F401 (registers policies)
 from augment.basic import get_default_graphcl_transforms
 from models.contrast.self_gcl import SelfGraphCL
@@ -395,6 +396,7 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
 
     metadata = graph.metadata() if isinstance(graph, HeteroData) else ([], [])
     if isinstance(graph, HeteroData):
+        node_types, edge_types = map(list, metadata)
         in_dims: dict[str, int] = {}
         for nt in graph.node_types:
             store = graph[nt]
@@ -406,6 +408,14 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
             else:
                 raise AttributeError(f"Node type '{nt}' lacks '.x' or '.feat'")
             in_dims[nt] = feat.size(-1)
+        api_nt = NodeType.API.value
+        if api_nt not in node_types:
+            node_types.append(api_nt)
+            in_dims[api_nt] = InjectAPICall.DEFAULT_FEAT_DIM
+        api_edge = (NodeType.BB.value, EdgeRel.CALLS.value, api_nt)
+        if api_edge not in edge_types:
+            edge_types.append(api_edge)
+        metadata = (tuple(node_types), tuple(edge_types))
     else:
         if hasattr(graph, "x"):
             feat = graph.x


### PR DESCRIPTION
## Summary
- allow InjectAPICall to configure feature dimension instead of hardcoding
- reference InjectAPICall constant when adding API nodes in SelfGraphCL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859b35d0cf4832e81549763fe88a3bf