### PR TITLE
Fix NodeDrop NameError

### DIFF
--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -164,8 +164,8 @@ class NodeDrop(SimpleAug, AugmentBase):
     # ------------------------------------------------------------------ #
     # 에지 필터 및 재인덱싱 --------------------------------------------- #
     # ------------------------------------------------------------------ #
-    @staticmethod
     def _filter_edges(
+        self,
         store: Any,
         src_map: torch.Tensor,
         dst_map: torch.Tensor,


### PR DESCRIPTION
## Summary
- fix NodeDrop's `_filter_edges` to be an instance method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b7dfffb0832e93cf4f1ab13832af