### PR TITLE
Fix NodeDrop edge filtering

### DIFF
--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -174,13 +174,20 @@ class NodeDrop(SimpleAug, AugmentBase):
         edge_index = store.edge_index
         src, dst = edge_index[0], edge_index[1]
         keep = (src_map[src] != -1) & (dst_map[dst] != -1)
-        if not keep.any():  # 모든 에지가 제거 → 최소 1개 보존 안전장치
-            keep[self._rng.randint(0, keep.size(0))] = True
 
         # edge_index 재인덱싱
-        store.edge_index = torch.stack(
+        new_ei = torch.stack(
             [src_map[src[keep]], dst_map[dst[keep]]], dim=0
         )
+
+        # ── 삭제 후 남은 엣지가 없으면 self-loop 생성 ─────────────────────
+        if new_ei.numel() == 0:
+            if torch.equal(src_map, dst_map):
+                num_nodes = int((src_map != -1).sum())
+                idx = torch.arange(num_nodes, device=edge_index.device)
+                new_ei = torch.stack([idx, idx], dim=0)
+
+        store.edge_index = new_ei
 
         # edge-level 특성 동기화
         num_e = keep.size(0)


### PR DESCRIPTION
## Summary
- handle node drop when all edges are removed
- add self-loops if a graph becomes edge-less after filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b9cfae14832e9757a2afdf0f6267