### PR TITLE
Update GraphCL augmentation defaults

### DIFF
--- a/src/augment/basic.py
+++ b/src/augment/basic.py
@@ -31,8 +31,8 @@ __all__ = [
 # ════════════════════════════════════════════════════════════════════════════════
 def get_default_graphcl_transforms(
     *,
-    node_drop_p: float = 0.10,
-    edge_drop_p: float = 0.20,
+    node_drop_p: float = 0.05,
+    edge_drop_p: float = 0.10,
     attr_mask_p: float = 0.10,
     inject_api_dist: str = "popular",
     inject_api_k: int = 2,


### PR DESCRIPTION
## Summary
- tweak default probabilities for node and edge drops
- keep API injection and code block swap only for the second view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d5b64f38832e9343459f6ce85222