### PR TITLE
Add configurable augmentation schedule

### DIFF
--- a/configs/self_gcl.yaml
+++ b/configs/self_gcl.yaml
@@ -45,3 +45,15 @@ checkpoint:
   save_top_k: 3
   monitor: "val_alignment"
   mode: "min"                  ## alignment ↓, uniformity ↓ ― 둘 다 작을수록 좋음
+
+# Progressive augmentation schedule
+aug_schedule:
+  - start: 0
+    end: 10
+    ops: [NodeDrop, EdgeDrop]
+  - start: 11
+    end: 20
+    ops: [NodeDrop, EdgeDrop, CodeBlockSwap]
+  - start: 21
+    end: 300
+    ops: [NodeDrop, EdgeDrop, CodeBlockSwap, InjectAPICall]

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -187,6 +187,7 @@ def train_epoch(
     *,
     optimizer: torch.optim.Optimizer,
     epoch: int,
+    transform,
     log_interval: int = 50,
 ):
     model.train()
@@ -199,7 +200,7 @@ def train_epoch(
         # Apply transforms **per-graph** rather than on the concatenated batch
         # to avoid empty graphs after augmentation, which can lead to mismatched
         # batch sizes for the two views.
-        transform = get_default_graphcl_transforms()
+        # Apply the externally provided transform schedule
         graphs = batch.to_data_list()
         view1_list = []
         view2_list = []
@@ -320,9 +321,17 @@ def main():
     loss_hist: list[float] = []
     align_hist: list[float] = []
     uni_hist: list[float] = []
+    schedule = _load_aug_schedule(args.config)
     for epoch in range(1, args.epochs + 1):
+        ops = _ops_for_epoch(schedule, epoch)
+        transform = _make_transform(ops) if ops else get_default_graphcl_transforms()
         epoch_loss, metrics = train_epoch(
-            model, train_loader, device, optimizer=optimizer, epoch=epoch
+            model,
+            train_loader,
+            device,
+            optimizer=optimizer,
+            epoch=epoch,
+            transform=transform,
         )
         LOGGER.info(
             "Epoch %d finished | AvgLoss %.4f Alignment %.4f Uniformity %.4f",
@@ -446,6 +455,48 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
         "gather_distributed": model_cfg.pop("gather_distributed", False),
     }
     return params
+
+
+def _load_aug_schedule(cfg_path: Path) -> list[dict]:
+    """Return augmentation schedule from YAML or empty list."""
+    try:
+        import yaml
+
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except ModuleNotFoundError:
+        LOGGER.warning("PyYAML not installed - using default augmentation")
+        return []
+
+    schedule = cfg.get("aug_schedule", [])
+    if not isinstance(schedule, list):
+        LOGGER.warning("aug_schedule must be a list of entries")
+        return []
+    return schedule
+
+
+def _make_transform(ops: list[str]):
+    """Return ``StandardPair`` with only selected ops enabled."""
+    from augment.basic import get_default_graphcl_transforms
+    from augment.view_generators.standard_pair import StandardPair
+
+    base = get_default_graphcl_transforms()
+
+    def filter_ops(op_list):
+        return [op for op in op_list if op.__class__.__name__ in ops]
+
+    return StandardPair(filter_ops(base.ops_a), filter_ops(base.ops_b))
+
+
+def _ops_for_epoch(schedule: list[dict], epoch: int) -> list[str]:
+    """Return list of op names active for ``epoch``."""
+    for item in schedule:
+        start = int(item.get("start", 0))
+        end = int(item.get("end", 10**9))
+        if start <= epoch <= end:
+            ops = item.get("ops", [])
+            return [str(op) for op in ops]
+    return []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support staged augmentation ops in pretraining
- new `aug_schedule` section in `self_gcl.yaml`
- train loop chooses ops per epoch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d5d7e64c832ea7fc7d84e12eabcd