### PR TITLE
Add configurable augmentation schedule

### DIFF
--- a/configs/self_gcl.yaml
+++ b/configs/self_gcl.yaml
@@ -45,3 +45,15 @@ checkpoint:
   save_top_k: 3
   monitor: "val_alignment"
   mode: "min"                  ## alignment ↓, uniformity ↓ ― 둘 다 작을수록 좋음
+
+# Progressive augmentation schedule
+aug_schedule:
+  - start: 0
+    end: 10
+    ops: [NodeDrop, EdgeDrop]
+  - start: 11
+    end: 20
+    ops: [NodeDrop, EdgeDrop, CodeBlockSwap]
+  - start: 21
+    end: 300
+    ops: [NodeDrop, EdgeDrop, CodeBlockSwap, InjectAPICall]

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -187,6 +187,7 @@ def train_epoch(
     *,
     optimizer: torch.optim.Optimizer,
     epoch: int,
+    transform,
     log_interval: int = 50,
 ):
     model.train()
@@ -199,7 +200,7 @@ def train_epoch(
         # Apply transforms **per-graph** rather than on the concatenated batch
         # to avoid empty graphs after augmentation, which can lead to mismatched
         # batch sizes for the two views.
-        transform = get_default_graphcl_transforms()
+        # Apply the externally provided transform schedule
         graphs = batch.to_data_list()
         view1_list = []
         view2_list = []
@@ -320,9 +321,17 @@ def main():
     loss_hist: list[float] = []
     align_hist: list[float] = []
     uni_hist: list[float] = []
+    schedule = _load_aug_schedule(args.config)
     for epoch in range(1, args.epochs + 1):
+        ops = _ops_for_epoch(schedule, epoch)
+        transform = _make_transform(ops) if ops else get_default_graphcl_transforms()
         epoch_loss, metrics = train_epoch(
-            model, train_loader, device, optimizer=optimizer, epoch=epoch
+            model,
+            train_loader,
+            device,
+            optimizer=optimizer,
+            epoch=epoch,
+            transform=transform,
         )
         LOGGER.info(
             "Epoch %d finished | AvgLoss %.4f Alignment %.4f Uniformity %.4f",
@@ -446,6 +455,48 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
         "gather_distributed": model_cfg.pop("gather_distributed", False),
     }
     return params
+
+
+def _load_aug_schedule(cfg_path: Path) -> list[dict]:
+    """Return augmentation schedule from YAML or empty list."""
+    try:
+        import yaml
+
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except ModuleNotFoundError:
+        LOGGER.warning("PyYAML not installed - using default augmentation")
+        return []
+
+    schedule = cfg.get("aug_schedule", [])
+    if not isinstance(schedule, list):
+        LOGGER.warning("aug_schedule must be a list of entries")
+        return []
+    return schedule
+
+
+def _make_transform(ops: list[str]):
+    """Return ``StandardPair`` with only selected ops enabled."""
+    from augment.basic import get_default_graphcl_transforms
+    from augment.view_generators.standard_pair import StandardPair
+
+    base = get_default_graphcl_transforms()
+
+    def filter_ops(op_list):
+        return [op for op in op_list if op.__class__.__name__ in ops]
+
+    return StandardPair(filter_ops(base.ops_a), filter_ops(base.ops_b))
+
+
+def _ops_for_epoch(schedule: list[dict], epoch: int) -> list[str]:
+    """Return list of op names active for ``epoch``."""
+    for item in schedule:
+        start = int(item.get("start", 0))
+        end = int(item.get("end", 10**9))
+        if start <= epoch <= end:
+            ops = item.get("ops", [])
+            return [str(op) for op in ops]
+    return []
 
 
 if __name__ == "__main__":

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -311,6 +311,22 @@ def main():
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
 
+    # Warm up projection head to determine feature size
+    dummy = next(iter(train_loader))
+    if isinstance(dummy, dict) and "graph" in dummy:
+        dummy = dummy["graph"]
+    graphs = dummy.to(device).to_data_list()
+    base_t = get_default_graphcl_transforms()
+    v1_list, v2_list = [], []
+    for g in graphs:
+        v1, v2 = base_t(g)
+        v1_list.append(v1)
+        v2_list.append(v2)
+    with torch.no_grad():
+        d1 = Batch.from_data_list(v1_list).to(device)
+        d2 = Batch.from_data_list(v2_list).to(device)
+        model(d1, d2)
+
     # --------------------------------------------------------------------- #
     # Training Loop
     # --------------------------------------------------------------------- #
@@ -325,6 +341,15 @@ def main():
     for epoch in range(1, args.epochs + 1):
         ops = _ops_for_epoch(schedule, epoch)
         transform = _make_transform(ops) if ops else get_default_graphcl_transforms()
+        LOGGER.debug("Epoch %d → %s", epoch, ops if ops else ["default"])
+        train_ds.transform = transform
+        train_loader = PyGLoader(
+            train_ds,
+            batch_size=args.batch_size,
+            shuffle=True,
+            num_workers=args.num_workers,
+            pin_memory=(device.type == "cuda"),
+        )
         epoch_loss, metrics = train_epoch(
             model,
             train_loader,
@@ -472,6 +497,7 @@ def _load_aug_schedule(cfg_path: Path) -> list[dict]:
     if not isinstance(schedule, list):
         LOGGER.warning("aug_schedule must be a list of entries")
         return []
+    schedule.sort(key=lambda x: int(x.get("start", 0)))
     return schedule
 
 
@@ -481,6 +507,11 @@ def _make_transform(ops: list[str]):
     from augment.view_generators.standard_pair import StandardPair
 
     base = get_default_graphcl_transforms()
+
+    all_names = {op.__class__.__name__ for op in base.ops_a + base.ops_b}
+    for name in ops:
+        if name not in all_names:
+            LOGGER.warning("unknown op %s in schedule", name)
 
     def filter_ops(op_list):
         return [op for op in op_list if op.__class__.__name__ in ops]


### PR DESCRIPTION
## Summary
- support staged augmentation ops in pretraining
- new `aug_schedule` section in `self_gcl.yaml`
- train loop chooses ops per epoch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d5d7e64c832ea7fc7d84e12eabcd