### PR TITLE
Fix NodeDrop to preserve pooled node

### DIFF
--- a/src/augment/basic.py
+++ b/src/augment/basic.py
@@ -37,6 +37,7 @@ def get_default_graphcl_transforms(
     inject_api_dist: str = "popular",
     inject_api_k: int = 2,
     swap_prob_pair: float = 0.15,
+    target_node: str | None = None,
 ) -> "StandardPair":
     """Return the **GraphCL** default *two‑view* generator.
     The recipe follows the augmentation mix suggested in the original
@@ -58,6 +59,9 @@ def get_default_graphcl_transforms(
         Number of synthetic API‑call nodes to inject.
     swap_prob_pair
         Probability of swapping a pair of basic blocks (CFG‑level op).
+    target_node
+        Node type that the underlying encoder pools over. When set,
+        :class:`NodeDrop` will always keep at least one node of this type.
     Returns
     -------
     StandardPair
@@ -78,7 +82,7 @@ def get_default_graphcl_transforms(
     # the function arguments.
     # ------------------------------------------------------------------
     ops_a: Sequence = [
-        NodeDrop(node_drop_p),
+        NodeDrop(node_drop_p, target_node=target_node),
         EdgeDrop(edge_drop_p),
         AttrMask(attr_mask_p),
     ]

--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -22,6 +22,7 @@ from torch_geometric.data import Data, HeteroData
 
 from .. import register_op
 from ..base import SimpleAug, AugmentBase
+from ..utils import ensure_target_node
 
 
 def _get_store_device(store: Mapping[str, Any]) -> torch.device:
@@ -44,12 +45,20 @@ class NodeDrop(SimpleAug, AugmentBase):
         Dict 형식이면 각 노드 타입별 개별 확률 지정.
     seed : int | None, default None
         RNG 시드. None이면 전역 NumPy RNG 사용.
+    target_node : str | None, optional
+        When specified, ensures at least one node of this type is kept
+        for heterogeneous graphs.
+    target_index : int | None, optional
+        For homogeneous graphs, index of the node that must be retained.
     """
 
     def __init__(
         self,
         keep_prob: float | Mapping[str, float] = 0.8,
         seed: int | None = None,
+        *,
+        target_node: str | None = None,
+        target_index: int | None = None,
         **kwargs: Any,
     ) -> None:
         # ── keep_prob 검증 및 dict 변환 ────────────────────────────────────
@@ -65,7 +74,16 @@ class NodeDrop(SimpleAug, AugmentBase):
         self.keep_prob: Dict[str, float] = dict(keep_prob)
         self._rng = np.random.RandomState(seed) if seed is not None else np.random
 
-        super().__init__(keep_prob=self.keep_prob, seed=seed, **kwargs)
+        self.target_node = target_node
+        self.target_index = target_index
+
+        super().__init__(
+            keep_prob=self.keep_prob,
+            seed=seed,
+            target_node=self.target_node,
+            target_index=self.target_index,
+            **kwargs,
+        )
 
     # ------------------------------------------------------------------ #
     # AugmentBase 인터페이스
@@ -86,7 +104,11 @@ class NodeDrop(SimpleAug, AugmentBase):
 
         if isinstance(sg, Data):
             p = self.keep_prob.get("*", 1.0)
-            self._drop_nodes_data(sg, p)
+            self._drop_nodes_data(
+                sg,
+                p,
+                target_index=self.target_index,
+            )
 
         elif isinstance(sg, HeteroData):
             # 1) 노드 타입별 keep-mask 및 인덱스 매핑 계산
@@ -95,8 +117,12 @@ class NodeDrop(SimpleAug, AugmentBase):
             for ntype in sg.node_types:
                 p = self.keep_prob.get(ntype, self.keep_prob.get("*", 1.0))
                 device = _get_store_device(sg[ntype])
+                t_idx = 0 if self.target_node == ntype else None
                 mask, mapping = self._make_mask_mapping(
-                    sg[ntype].num_nodes, p, device
+                    sg[ntype].num_nodes,
+                    p,
+                    device,
+                    target_index=t_idx,
                 )
                 masks[ntype], maps[ntype] = mask, mapping
                 self._apply_node_mask(sg[ntype], mask)      # 노드 속성 필터링
@@ -120,9 +146,20 @@ class NodeDrop(SimpleAug, AugmentBase):
     # ------------------------------------------------------------------ #
     # 내부 유틸 (homogeneous) ------------------------------------------- #
     # ------------------------------------------------------------------ #
-    def _drop_nodes_data(self, data: Data, keep_p: float) -> None:
+    def _drop_nodes_data(
+        self,
+        data: Data,
+        keep_p: float,
+        *,
+        target_index: int | None = None,
+    ) -> None:
         """homogeneous Data용 노드 삭제 + 에지 갱신."""
-        mask, mapping = self._make_mask_mapping(data.num_nodes, keep_p, data.device)
+        mask, mapping = self._make_mask_mapping(
+            data.num_nodes,
+            keep_p,
+            data.device,
+            target_index=target_index,
+        )
         # 노드 특성 필터링
         self._apply_node_mask(data, mask)
         # 에지 필터링 및 재인덱싱
@@ -132,9 +169,14 @@ class NodeDrop(SimpleAug, AugmentBase):
     # 마스크 & 매핑 생성 -------------------------------------------------- #
     # ------------------------------------------------------------------ #
     def _make_mask_mapping(
-        self, num_nodes: int, keep_p: float, device: torch.device
+        self,
+        num_nodes: int,
+        keep_p: float,
+        device: torch.device,
+        *,
+        target_index: int | None = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """노드 keep-mask (bool)와 old→new 인덱스 매핑(-1=삭제) 반환."""
+        """노드 keep-mask(bool)와 old→new 인덱스 매핑(-1=삭제) 반환."""
         if num_nodes == 0 or math.isclose(keep_p, 1.0):
             mask = torch.ones(num_nodes, dtype=torch.bool, device=device)
         else:
@@ -142,6 +184,9 @@ class NodeDrop(SimpleAug, AugmentBase):
             if not mask_np.any():                        # 최소 1개 보존
                 mask_np[self._rng.randint(0, num_nodes)] = True
             mask = torch.from_numpy(mask_np).to(device=device, dtype=torch.bool)
+
+        if target_index is not None and num_nodes > 0:
+            mask = ensure_target_node(mask, target_index)
 
         # old → new index (삭제 노드는 -1)
         mapping = -torch.ones(num_nodes, dtype=torch.long, device=device)

--- a/src/augment/utils.py
+++ b/src/augment/utils.py
@@ -113,6 +113,27 @@ def load_yaml(path: str | os.PathLike) -> Any:
         return yaml.safe_load(f)
 
 
+def ensure_target_node(mask: "torch.Tensor", target_idx: int) -> "torch.Tensor":
+    """Ensure ``mask`` keeps the node at ``target_idx``.
+
+    Parameters
+    ----------
+    mask : torch.Tensor
+        Boolean node mask of shape ``(N,)``.
+    target_idx : int
+        Index that must be kept (set to ``True``).
+
+    Returns
+    -------
+    torch.Tensor
+        The updated mask with ``mask[target_idx]`` guaranteed ``True``.
+    """
+    if target_idx < 0 or target_idx >= mask.numel():
+        raise IndexError("target_idx out of range")
+    mask[target_idx] = True
+    return mask
+
+
 # ──────────────────────────────────────────────────────────────
 # 4. import 경로 헬퍼
 # ──────────────────────────────────────────────────────────────
@@ -135,4 +156,5 @@ __all__ = [
     "load_yaml",
     "resolve_path",
     "add_project_root_to_sys_path",
+    "ensure_target_node",
 ]

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -188,6 +188,7 @@ def train_epoch(
     optimizer: torch.optim.Optimizer,
     epoch: int,
     log_interval: int = 50,
+    target_node: str | None = None,
 ):
     model.train()
     total_loss = 0.0
@@ -199,7 +200,7 @@ def train_epoch(
         # Apply transforms **per-graph** rather than on the concatenated batch
         # to avoid empty graphs after augmentation, which can lead to mismatched
         # batch sizes for the two views.
-        transform = get_default_graphcl_transforms()
+        transform = get_default_graphcl_transforms(target_node=target_node)
         graphs = batch.to_data_list()
         view1_list = []
         view2_list = []
@@ -322,7 +323,12 @@ def main():
     uni_hist: list[float] = []
     for epoch in range(1, args.epochs + 1):
         epoch_loss, metrics = train_epoch(
-            model, train_loader, device, optimizer=optimizer, epoch=epoch
+            model,
+            train_loader,
+            device,
+            optimizer=optimizer,
+            epoch=epoch,
+            target_node=model.encoder.target_node,
         )
         LOGGER.info(
             "Epoch %d finished | AvgLoss %.4f Alignment %.4f Uniformity %.4f",


### PR DESCRIPTION
## Summary
- implement `ensure_target_node` helper
- use it in NodeDrop and expose `target_node` option
- keep pooling node type in default GraphCL transforms
- pass pooling node type through training CLI

## Testing
- `pytest -q` *(tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6859d5f2631c832e96cd84de03a2b279