### PR TITLE
Fix NodeDrop to keep pooling node

### DIFF
--- a/src/augment/basic.py
+++ b/src/augment/basic.py
@@ -34,6 +34,7 @@ def get_default_graphcl_transforms(
     node_drop_p: float = 0.05,
     edge_drop_p: float = 0.10,
     attr_mask_p: float = 0.10,
+    target_node: str | None = None,
     inject_api_dist: str = "popular",
     inject_api_k: int = 2,
     swap_prob_pair: float = 0.15,
@@ -51,6 +52,9 @@ def get_default_graphcl_transforms(
         Probability of randomly removing an edge.
     attr_mask_p
         Probability of zero‑ing a node feature vector.
+    target_node
+        Node type reserved from dropping when ``NodeDrop`` is applied. If
+        ``None`` the behaviour is unchanged.
     inject_api_dist
         Sampling strategy for :class:`InjectAPICall` (``"popular"``,
         ``"rarity"`` or ``"uniform"``).
@@ -78,7 +82,7 @@ def get_default_graphcl_transforms(
     # the function arguments.
     # ------------------------------------------------------------------
     ops_a: Sequence = [
-        NodeDrop(node_drop_p),
+        NodeDrop(node_drop_p, target_node=target_node),
         EdgeDrop(edge_drop_p),
         AttrMask(attr_mask_p),
     ]

--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -44,12 +44,16 @@ class NodeDrop(SimpleAug, AugmentBase):
         Dict 형식이면 각 노드 타입별 개별 확률 지정.
     seed : int | None, default None
         RNG 시드. None이면 전역 NumPy RNG 사용.
+    target_node : str | None, optional
+        Node type that must retain at least one instance. Only relevant for
+        ``HeteroData`` graphs.
     """
 
     def __init__(
         self,
         keep_prob: float | Mapping[str, float] = 0.8,
         seed: int | None = None,
+        target_node: str | None = None,
         **kwargs: Any,
     ) -> None:
         # ── keep_prob 검증 및 dict 변환 ────────────────────────────────────
@@ -63,9 +67,10 @@ class NodeDrop(SimpleAug, AugmentBase):
                     raise ValueError("keep_prob dict values must be in [0, 1]")
 
         self.keep_prob: Dict[str, float] = dict(keep_prob)
+        self.target_node = target_node
         self._rng = np.random.RandomState(seed) if seed is not None else np.random
 
-        super().__init__(keep_prob=self.keep_prob, seed=seed, **kwargs)
+        super().__init__(keep_prob=self.keep_prob, seed=seed, target_node=target_node, **kwargs)
 
     # ------------------------------------------------------------------ #
     # AugmentBase 인터페이스
@@ -95,8 +100,9 @@ class NodeDrop(SimpleAug, AugmentBase):
             for ntype in sg.node_types:
                 p = self.keep_prob.get(ntype, self.keep_prob.get("*", 1.0))
                 device = _get_store_device(sg[ntype])
+                target_idx = 0 if ntype == self.target_node else None
                 mask, mapping = self._make_mask_mapping(
-                    sg[ntype].num_nodes, p, device
+                    sg[ntype].num_nodes, p, device, target_idx
                 )
                 masks[ntype], maps[ntype] = mask, mapping
                 self._apply_node_mask(sg[ntype], mask)      # 노드 속성 필터링
@@ -122,7 +128,10 @@ class NodeDrop(SimpleAug, AugmentBase):
     # ------------------------------------------------------------------ #
     def _drop_nodes_data(self, data: Data, keep_p: float) -> None:
         """homogeneous Data용 노드 삭제 + 에지 갱신."""
-        mask, mapping = self._make_mask_mapping(data.num_nodes, keep_p, data.device)
+        target_idx = 0 if self.target_node is not None else None
+        mask, mapping = self._make_mask_mapping(
+            data.num_nodes, keep_p, data.device, target_idx
+        )
         # 노드 특성 필터링
         self._apply_node_mask(data, mask)
         # 에지 필터링 및 재인덱싱
@@ -132,7 +141,11 @@ class NodeDrop(SimpleAug, AugmentBase):
     # 마스크 & 매핑 생성 -------------------------------------------------- #
     # ------------------------------------------------------------------ #
     def _make_mask_mapping(
-        self, num_nodes: int, keep_p: float, device: torch.device
+        self,
+        num_nodes: int,
+        keep_p: float,
+        device: torch.device,
+        target_idx: int | None = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """노드 keep-mask (bool)와 old→new 인덱스 매핑(-1=삭제) 반환."""
         if num_nodes == 0 or math.isclose(keep_p, 1.0):
@@ -144,6 +157,9 @@ class NodeDrop(SimpleAug, AugmentBase):
             mask = torch.from_numpy(mask_np).to(device=device, dtype=torch.bool)
 
         # old → new index (삭제 노드는 -1)
+        if target_idx is not None:
+            mask = ensure_target_node(mask, target_idx)
+
         mapping = -torch.ones(num_nodes, dtype=torch.long, device=device)
         mapping[mask] = torch.arange(mask.sum(), device=device)
         return mask, mapping

--- a/src/augment/utils.py
+++ b/src/augment/utils.py
@@ -15,6 +15,7 @@ import random
 import sys
 from pathlib import Path
 from typing import Any, Dict
+import warnings
 
 import numpy as np
 import yaml
@@ -126,6 +127,39 @@ def add_project_root_to_sys_path(levels_up: int = 1) -> None:
         sys.path.insert(0, str(root))
 
 
+# ---------------------------------------------------------------------------
+# 5. Mask helper
+# ---------------------------------------------------------------------------
+def ensure_target_node(mask: "torch.Tensor", target_idx: int | None) -> "torch.Tensor":
+    """Ensure ``mask[target_idx]`` is ``True`` if index is valid.
+
+    Parameters
+    ----------
+    mask : torch.Tensor
+        Boolean node keep mask of shape ``[num_nodes]``.
+    target_idx : int | None
+        Local index of the node to *preserve* (``None`` ⇒ no-op). For
+        ``HeteroData`` this is the index within the target node type.
+
+    Returns
+    -------
+    torch.Tensor
+        ``mask`` with ``target_idx`` forced to ``True`` when possible.
+    """
+    if target_idx is None:
+        return mask
+    if mask.dtype is not torch.bool:
+        raise TypeError("mask must be a boolean tensor")
+    if not (0 <= target_idx < mask.size(0)):
+        warnings.warn(
+            f"target_idx {target_idx} out of range for mask of size {mask.size(0)}",
+            RuntimeWarning,
+        )
+        return mask
+    mask[target_idx] = True
+    return mask
+
+
 # ──────────────────────────────────────────────────────────────
 # 5. public export
 # ──────────────────────────────────────────────────────────────
@@ -135,4 +169,5 @@ __all__ = [
     "load_yaml",
     "resolve_path",
     "add_project_root_to_sys_path",
+    "ensure_target_node",
 ]

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -304,7 +304,8 @@ def main():
     # ``train_ds.data`` represents the collated dataset containing the union of
     # node types across all graphs, which ensures the encoder is aware of every
     # possible node type.
-    model = SelfGraphCL(**_load_model_hparams(args.config, train_ds.data))
+    params, target_node = _load_model_hparams(args.config, train_ds.data)
+    model = SelfGraphCL(**params)
 
     if device.type == "cuda" and torch.cuda.device_count() > 1:
         # Trigger lazy projection head creation before DataParallel wraps the
@@ -317,7 +318,7 @@ def main():
             if dummy is not None:
                 batch = dummy["graph"] if isinstance(dummy, dict) else dummy
                 batch = batch.to(device)
-                aug = get_default_graphcl_transforms()
+                aug = get_default_graphcl_transforms(target_node=target_node)
                 graphs = batch.to_data_list()
                 v1_list, v2_list = [], []
                 for g in graphs:
@@ -338,7 +339,7 @@ def main():
     if isinstance(dummy, dict) and "graph" in dummy:
         dummy = dummy["graph"]
     graphs = dummy.to(device).to_data_list()
-    base_t = get_default_graphcl_transforms()
+    base_t = get_default_graphcl_transforms(target_node=target_node)
     v1_list, v2_list = [], []
     for g in graphs:
         v1, v2 = base_t(g)
@@ -362,7 +363,7 @@ def main():
     schedule = _load_aug_schedule(args.config)
     for epoch in range(1, args.epochs + 1):
         ops = _ops_for_epoch(schedule, epoch)
-        transform = _make_transform(ops) if ops else get_default_graphcl_transforms()
+        transform = _make_transform(ops, target_node) if ops else get_default_graphcl_transforms(target_node=target_node)
         LOGGER.debug("Epoch %d → %s", epoch, ops if ops else ["default"])
         train_ds.transform = transform
         train_loader = PyGLoader(
@@ -424,7 +425,7 @@ def main():
 # --------------------------------------------------------------------------- #
 
 
-def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
+def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> tuple[dict, str | None]:
     """Return ``SelfGraphCL`` kwargs loaded from ``cfg_path``.
 
     Expected YAML ``model`` keys are a subset of
@@ -493,6 +494,7 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
             raise AttributeError("Graph lacks '.x' or '.feat'")
         in_dims = {"": feat.size(-1)}  # type: ignore[attr-defined]
 
+    target_node = encoder_args.get("target_node")
     encoder = RGCNEncoder(metadata=metadata, in_dims=in_dims, **encoder_args)
 
     params = {
@@ -501,7 +503,7 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> dict:
         "temperature": cfg.get("loss", {}).get("temperature", 0.2),
         "gather_distributed": model_cfg.pop("gather_distributed", False),
     }
-    return params
+    return params, target_node
 
 
 def _load_aug_schedule(cfg_path: Path) -> list[dict]:
@@ -523,12 +525,12 @@ def _load_aug_schedule(cfg_path: Path) -> list[dict]:
     return schedule
 
 
-def _make_transform(ops: list[str]):
+def _make_transform(ops: list[str], target_node: str | None):
     """Return ``StandardPair`` with only selected ops enabled."""
     from augment.basic import get_default_graphcl_transforms
     from augment.view_generators.standard_pair import StandardPair
 
-    base = get_default_graphcl_transforms()
+    base = get_default_graphcl_transforms(target_node=target_node)
 
     all_names = {op.__class__.__name__ for op in base.ops_a + base.ops_b}
     for name in ops:


### PR DESCRIPTION
## Summary
- add `ensure_target_node` helper
- update NodeDrop to keep a required node type
- allow passing `target_node` through `get_default_graphcl_transforms`
- train script forwards encoder target node to augmentation pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859da0e741c832eb99ac76db09ffa70