### PR TITLE
Improve batch handling for pretraining

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -195,6 +195,10 @@ def train_epoch(
     align = Alignment()
     uni = Uniformity()
     for step, batch in enumerate(loader):
+        if isinstance(batch, dict) and "graph" in batch:
+            batch = batch["graph"]
+        elif isinstance(batch, (list, tuple)):
+            batch = Batch.from_data_list(list(batch))
         batch = batch.to(device)
         # GraphCL requires *two* augmented views of the same graph.
         # Apply transforms **per-graph** rather than on the concatenated batch


### PR DESCRIPTION
## Summary
- support dictionary and list batches in `pretrain_selfgcl.py`
- ensure DataLoader outputs are converted to `Batch` before `.to()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dd3a76ec832e927f9069602556a0