### PR TITLE
Add training plot to SupCon finetune CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,14 @@ flowchart TD
 The preprocessing CLI under `src/cli/preprocessing.py` builds the heterogeneous
 graphs. When running the `graphs` subcommand, passing `--with-feats` will insert
 zero vectors for node types that lack a `feat` tensor.
+
+### Example: fine-tuning SupCon head
+
+```bash
+python -m cli.finetune_supcon \
+       --encoder-checkpoint models/gnn/encoder.pt \
+       --split "2023Q4" \
+       --epochs 10 --batch-size 128 \
+       --lr 1e-4 --patience 3 \
+       --plot-path runs/finetune_supcon/train.png
+```

--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -35,6 +35,7 @@ from torch import nn, optim
 from torch.utils.data import DataLoader
 from torch_geometric.data import InMemoryDataset, Batch
 import torch_geometric.transforms as T
+import matplotlib.pyplot as plt
 
 # Local project imports ----------------------------------------------------- #
 from src.common.utils import set_random_seed, get_logger, ensure_dir
@@ -76,6 +77,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--device", type=str, default="cuda:0")
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--logdir", type=Path, default=Path("runs/finetune_supcon"))
+    p.add_argument("--plot-path", type=Path,
+                   help="Where to save training curve PNG; defaults to logdir/train.png")
     p.add_argument("--wandb", action="store_true", help="Enable WandB logging")
 
     # Hydra inspection ------------------------------------------------------ #
@@ -149,6 +152,7 @@ def main() -> None:
     device = torch.device(args.device)
 
     ensure_dir(args.logdir)
+    plot_path = args.plot_path or (args.logdir / "train.png")
     if args.wandb:
         import wandb
         wandb.init(project="robust-malware-graph", name="finetune_supcon", config=vars(args))
@@ -171,9 +175,13 @@ def main() -> None:
     criterion = SupConLoss(temperature=0.07).to(device)
 
     best_val = 0.0; no_improve = 0
+    train_losses, val_aurocs, val_f1s = [], [], []
     for epoch in range(1, args.epochs + 1):
         train_loss = train_one_epoch(model, train_dl, criterion, optimizer, device)
         val_metrics = evaluate(model, val_dl, device)
+        train_losses.append(train_loss)
+        val_aurocs.append(val_metrics["AUROC"].item() if hasattr(val_metrics["AUROC"], 'item') else float(val_metrics["AUROC"]))
+        val_f1s.append(val_metrics["MacroF1"].item() if hasattr(val_metrics["MacroF1"], 'item') else float(val_metrics["MacroF1"]))
 
         LOGGER.info("Epoch %d | train_loss=%.4f | val_AUROC=%.4f | val_F1=%.4f",
                     epoch, train_loss, val_metrics["AUROC"], val_metrics["MacroF1"])
@@ -189,6 +197,17 @@ def main() -> None:
             if no_improve >= args.patience:
                 LOGGER.info("Early stopping at epoch %d", epoch)
                 break
+
+    epochs_r = range(1, len(train_losses) + 1)
+    plt.figure()
+    plt.plot(epochs_r, train_losses, label="train_loss")
+    plt.plot(epochs_r, val_aurocs, label="val_AUROC")
+    plt.plot(epochs_r, val_f1s, label="val_F1")
+    plt.xlabel("Epoch")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(plot_path)
+    plt.close()
 
     LOGGER.info("Finished. Best val AUROC = %.4f", best_val)
     if args.wandb:


### PR DESCRIPTION
## Summary
- add `--plot-path` option to `finetune_supcon` CLI
- track metrics each epoch and plot at the end
- display example CLI usage in README with new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aad832c1c832e94861ef049e3eb28