### PR TITLE
Add scheduler loader for SelfGraphCL training

### DIFF
--- a/configs/self_gcl.yaml
+++ b/configs/self_gcl.yaml
@@ -36,10 +36,10 @@ optimizer:
   weight_decay: 1.0e-4
   betas: [0.9, 0.999]
 
-scheduler:
-  name: "cosine"
-  warmup_epochs: 10
-  total_epochs: 300
+scheduler:                         ## {cosine | cyclic | plateau}
+  name: "cosine"                  ## CosineAnnealing w/ optional warmup
+  warmup_epochs: 10               ## Cyclic: step_size_up, step_size_down
+  total_epochs: 300               ## Plateau: factor, patience
 
 checkpoint:
   save_top_k: 3

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -337,6 +337,7 @@ def main():
     model.to(device)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+    scheduler = _build_scheduler(args.config, optimizer, args.epochs)
 
     # Warm up projection head to determine feature size
     dummy = next(iter(train_loader))
@@ -402,6 +403,19 @@ def main():
             torch.save(model.state_dict(), ckpt_path)
             LOGGER.info("Saved checkpoint → %s", ckpt_path)
         best_loss = min(best_loss, epoch_loss)
+
+        if scheduler is not None:
+            if isinstance(
+                scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau
+            ):
+                scheduler.step(epoch_loss)
+            else:
+                scheduler.step()
+            LOGGER.debug(
+                "Epoch %d | LR %.6f",
+                epoch,
+                optimizer.param_groups[0]["lr"],
+            )
 
     # Plot metrics history
     plt.figure()
@@ -508,6 +522,57 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> tuple[dict,
         "gather_distributed": model_cfg.pop("gather_distributed", False),
     }
     return params, target_node
+
+
+def _build_scheduler(
+    cfg_path: Path, optimizer: torch.optim.Optimizer, epochs: int
+) -> torch.optim.lr_scheduler.LRScheduler | None:
+    """Instantiate LR scheduler from YAML configuration.
+
+    Supported scheduler names are ``cosine``, ``cyclic`` and ``plateau``.  Any
+    additional keys in the ``scheduler`` section of ``cfg_path`` are passed to
+    the underlying PyTorch scheduler.
+    """
+    try:
+        import yaml
+
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except ModuleNotFoundError:
+        LOGGER.warning("PyYAML not installed - no scheduler configured")
+        return None
+
+    sched_cfg = cfg.get("scheduler")
+    if not sched_cfg:
+        return None
+
+    name = str(sched_cfg.get("name", "")).lower()
+    params = {k: v for k, v in sched_cfg.items() if k != "name"}
+
+    if name == "cosine":
+        warmup = int(params.pop("warmup_epochs", 0))
+        total = int(params.pop("total_epochs", epochs))
+        eta_min = float(params.pop("eta_min", 0.0))
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=max(1, total - warmup), eta_min=eta_min, **params
+        )
+        if warmup > 0:
+            linear = torch.optim.lr_scheduler.LinearLR(
+                optimizer, start_factor=0.0, end_factor=1.0, total_iters=warmup
+            )
+            scheduler = torch.optim.lr_scheduler.SequentialLR(
+                optimizer, schedulers=[linear, cosine], milestones=[warmup]
+            )
+        else:
+            scheduler = cosine
+    elif name == "cyclic":
+        scheduler = torch.optim.lr_scheduler.CyclicLR(optimizer, **params)
+    elif name == "plateau":
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, **params)
+    else:
+        LOGGER.warning("Unknown scheduler '%s'", name)
+        return None
+    return scheduler
 
 
 def _load_aug_schedule(cfg_path: Path) -> list[dict]:


### PR DESCRIPTION
## Summary
- add `_build_scheduler` helper to parse scheduler config
- instantiate scheduler in `pretrain_selfgcl.py`
- step scheduler after each epoch and log LR
- document scheduler options in `self_gcl.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aad162b40832ebbc3aa892961de3d