### PR TITLE
Add PPO training plot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ python -m cli.finetune_supcon \
        --lr 1e-4 --patience 3 \
        --plot-path runs/finetune_supcon/train.png
 ```
+
+### Example: PPO rule-agent training
+
+```bash
+python -m cli.rulegen_cli ppo-train \
+       --train-features features.json \
+       --epochs 50000 \
+       --checkpoint models/rulebank/ppo_agent.pt \
+       --plot-path runs/rulegen/ppo_train.png
+```

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -56,6 +56,7 @@ from pathlib import Path
 from typing import List, Sequence
 
 import torch
+import matplotlib.pyplot as plt
 from omegaconf import OmegaConf
 from tqdm import tqdm
 
@@ -146,7 +147,25 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # 3) Agent instantiation & training loop
     # ------------------------------------------------------------------
     agent = PPORuleAgent(cfg, device=device)
-    agent.fit(train_feats, val_data=val_feats, epochs=args.epochs)
+    total_steps = int(cfg.get("scheduler", {}).get("total_updates", args.epochs))
+    log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))
+    history = agent.train(
+        total_timesteps=total_steps,
+        log_interval=log_interval,
+        save_path=args.checkpoint,
+    )
+
+    if args.plot_path:
+        steps, rets = zip(*history) if history else ([], [])
+        Path(args.plot_path).parent.mkdir(parents=True, exist_ok=True)
+        plt.figure()
+        plt.plot(steps, rets)
+        plt.xlabel("Step")
+        plt.ylabel("Avg Return")
+        plt.tight_layout()
+        plt.savefig(args.plot_path)
+        plt.close()
+        logger.info("Training curve saved → %s", args.plot_path)
 
     if args.checkpoint:
         Path(args.checkpoint).parent.mkdir(parents=True, exist_ok=True)
@@ -263,6 +282,7 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
+    pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")
     pt.add_argument("--cpu", action="store_true", help="Force CPU even if CUDA available")
     pt.set_defaults(func=cmd_ppo_train)
 

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -214,10 +214,18 @@ class PPORuleAgent:
         total_timesteps: int,
         log_interval: int = 10_000,
         save_path: str | Path | None = None,
-    ):
+    ) -> List[Tuple[int, float]]:
+        """Run the main PPO loop.
+
+        Returns
+        -------
+        List of ``(step, avg_return)`` logged at each ``log_interval``.
+        """
         obs, _ = self.env.reset()
         global_step = 0
         episode_returns: List[float] = []
+        interval_returns: List[float] = []
+        avg_history: List[Tuple[int, float]] = []
         ep_return = 0.0
 
         while global_step < total_timesteps:
@@ -238,6 +246,7 @@ class PPORuleAgent:
 
                 if done or trunc:
                     episode_returns.append(ep_return)
+                    interval_returns.append(ep_return)
                     ep_return = 0.0
                     obs, _ = self.env.reset()
 
@@ -245,15 +254,19 @@ class PPORuleAgent:
             self._update()
 
             if global_step % log_interval < self.n_steps:
-                avg_ret = np.mean(episode_returns[-10:]) if episode_returns else 0.0
+                avg_ret = float(np.mean(interval_returns)) if interval_returns else 0.0
+                avg_history.append((global_step, avg_ret))
                 _LOG.info(
-                    "[PPO] step:%d | avg_ep_return(10): %.4f | buffer:%d",
+                    "[PPO] step:%d | avg_ep_return: %.4f | buffer:%d",
                     global_step,
                     avg_ret,
                     len(self.obs_buf),
                 )
+                interval_returns.clear()
                 if save_path:
                     self.save(save_path)
+
+        return avg_history
 
     # ─────────────────────────── PPO optimisation steps ─────────
     def _update(self):


### PR DESCRIPTION
## Summary
- extend rulegen_cli `ppo-train` subcommand with `--plot-path`
- track per-interval average return in `PPORuleAgent.train`
- save training curve in `cmd_ppo_train`
- document new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab00225bc832e86aee5969b1f14c8