### PR TITLE
Fix warmup scheduler start factor

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -557,8 +557,9 @@ def _build_scheduler(
             optimizer, T_max=max(1, total - warmup), eta_min=eta_min, **params
         )
         if warmup > 0:
+            # LinearLR requires start_factor > 0
             linear = torch.optim.lr_scheduler.LinearLR(
-                optimizer, start_factor=0.0, end_factor=1.0, total_iters=warmup
+                optimizer, start_factor=1e-6, end_factor=1.0, total_iters=warmup
             )
             scheduler = torch.optim.lr_scheduler.SequentialLR(
                 optimizer, schedulers=[linear, cosine], milestones=[warmup]


### PR DESCRIPTION
## Summary
- tweak LinearLR warmup in pretrain_selfgcl

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ab31c8cec832ebe051c8e4a0ab422