### PR TITLE
Fix missing num_nodes in hetero graphs

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -196,23 +196,34 @@ from ..normalizers.base   import get_normalizer      # optional schema normalise
 from ..utils              import tqdm_wrap, ensure_dir, set_random_seed
 
 
-def fill_missing_node_feats(hetero: HeteroData, dim: int = 128):
-    for ntype, store in hetero.node_items():
-        # ── ① 누락된 노드 수 계산 보정 ──────────────────────────────
-        n = store.num_nodes
-        if n is None:
-            # a) 이미 다른 텐서가 있으면 길이로 대체
+def ensure_num_nodes(hetero: HeteroData) -> None:
+    """Infer and set ``num_nodes`` for every node store in ``hetero``.
+
+    Parameters
+    ----------
+    hetero : HeteroData
+        Graph whose node stores may lack ``num_nodes`` metadata.
+    """
+    for _, store in hetero.node_items():
+        if store.num_nodes is None:
+            n = None
             if len(store) > 0:
                 n = len(store)
-            # b) edge_index만 있을 경우
             elif "edge_index" in store:
                 n = int(store["edge_index"].max()) + 1
             else:
-                n = 0                       # fallback
-            store.num_nodes = n            # 값 보존
-        # ── ② feat 없으면 zero-pad ────────────────────────────────
+                n = 0
+            store.num_nodes = n
+
+
+def fill_missing_node_feats(hetero: HeteroData, dim: int = 128) -> None:
+    """Pad missing node features with zeros after ensuring ``num_nodes``."""
+
+    ensure_num_nodes(hetero)
+
+    for _, store in hetero.node_items():
         if "feat" not in store:
-            store.feat = torch.zeros((n, dim), dtype=torch.float32)
+            store.feat = torch.zeros((store.num_nodes, dim), dtype=torch.float32)
 
 
 
@@ -253,6 +264,7 @@ def _process_one(
         return
 
     hetero = builder.build()
+    ensure_num_nodes(hetero)
     if with_feats:
         fill_missing_node_feats(hetero, feat_dim)
     torch.save(hetero, out_path)

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -6,8 +6,11 @@ pytest.importorskip("torch_geometric")
 import torch
 from torch_geometric.data import Data, HeteroData
 
-from src.graphs.builders.hetero_builder import HeteroGraphBuilder
-from src.graphs.builders.hetero_builder import fill_missing_node_feats
+from src.graphs.builders.hetero_builder import (
+    HeteroGraphBuilder,
+    fill_missing_node_feats,
+    ensure_num_nodes,
+)
 from src.graphs.normalizers.ast_norm import ASTNormalizer
 
 
@@ -43,3 +46,22 @@ def test_fill_missing_feats():
     assert "feat" in g["bb"]
     assert g["bb"].feat.shape == (2, 1)
     assert torch.all(g["bb"].feat.eq(0))
+
+
+def test_ensure_num_nodes_no_warning():
+    g = Data(edge_index=torch.tensor([[0, 1], [1, 2]]), kind_id=torch.tensor([0, 1, 2]))
+    g_norm = ASTNormalizer().normalize(g)
+
+    builder = HeteroGraphBuilder()
+    builder.add_view(g_norm, "ast")
+    hetero = builder.build()
+
+    # before ensuring num_nodes PyG would warn when calling len()
+    with pytest.warns(UserWarning):
+        _ = len(hetero["token"])  # triggers internal inference
+
+    ensure_num_nodes(hetero)
+
+    with pytest.warns(None) as record:
+        _ = len(hetero["token"])
+    assert not record


### PR DESCRIPTION
## Summary
- add `ensure_num_nodes` helper to infer node counts
- call the helper when building datasets
- refactor `fill_missing_node_feats` to reuse `ensure_num_nodes`
- test that the helper prevents PyG num_nodes warnings

## Testing
- `pytest -q` *(fails: 7 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685ab6d174bc832e96762c7c534bfce3