### PR TITLE
Fix SelfGraphCL dataset reference

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -305,10 +305,10 @@ def main():
     # --------------------------------------------------------------------- #
     # Model & Optimizer
     # --------------------------------------------------------------------- #
-    # ``train_ds.data`` represents the collated dataset containing the union of
+    # ``train_ds._data`` represents the collated dataset containing the union of
     # node types across all graphs, which ensures the encoder is aware of every
     # possible node type.
-    params, target_node = _load_model_hparams(args.config, train_ds.data)
+    params, target_node = _load_model_hparams(args.config, train_ds._data)
     model = SelfGraphCL(**params)
 
     if device.type == "cuda" and torch.cuda.device_count() > 1:


### PR DESCRIPTION
## Summary
- in the SelfGraphCL pretraining CLI, use `train_ds._data` when loading model
  hyperparameters so all node types are available
- update explanatory comment accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abd2a0e38832ea247cb2e16ae369f