### PR TITLE
Add embed_corpus stats & empty graph check

### DIFF
--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -40,7 +40,11 @@ from transformers import (
     PreTrainedModel,
 )
 
+from src.common.utils import get_logger
+
 __all__ = ["CodeLLMNodeFeat", "embed_corpus"]
+
+LOGGER = get_logger(__name__)
 
 Pooling = Literal["cls", "mean", "max"]
 
@@ -256,6 +260,9 @@ def embed_corpus(
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    processed = 0
+    skipped = 0
+
     try:
         device = next(encoder.parameters()).device
     except StopIteration:  # encoder with no parameters
@@ -269,6 +276,7 @@ def embed_corpus(
 
         g = torch.load(fp, weights_only=False)
         if "token" not in g.node_types:
+            skipped += 1
             continue
 
         store = g["token"]
@@ -279,6 +287,7 @@ def embed_corpus(
         else:
             texts = store.get("kind_str") or store.get("text")
             if texts is None:
+                skipped += 1
                 continue
             try:
                 from transformers import AutoTokenizer
@@ -308,3 +317,8 @@ def embed_corpus(
 
         feat = torch.cat(embeddings, dim=0)
         save_tensor(out_name, feat, out_dir, overwrite=overwrite)
+        processed += 1
+
+    LOGGER.info("embed_corpus completed: processed=%d skipped=%d", processed, skipped)
+    if processed == 0:
+        raise RuntimeError("No graphs contained token nodes")

--- a/tests/test_embed_stage.py
+++ b/tests/test_embed_stage.py
@@ -32,3 +32,15 @@ def test_embed_corpus(tmp_path):
     feat = load_tensor("sample", out_dir)
     assert feat.shape == (2, 2)
     assert torch.all(feat.eq(torch.tensor([[1., 2.], [3., 4.]])))
+
+
+def test_embed_corpus_no_tokens(tmp_path):
+    hetero_dir = tmp_path / "hetero"
+    hetero_dir.mkdir()
+    g = HeteroData()
+    torch.save(g, hetero_dir / "empty.pt")
+
+    out_dir = tmp_path / "embeds"
+    encoder = DummyEncoder()
+    with pytest.raises(RuntimeError, match="No graphs"):
+        embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)


### PR DESCRIPTION
## Summary
- add a module logger in `llm_embed.py`
- track processed/skipped counts in `embed_corpus`
- log summary and raise when no graphs had token nodes
- test RuntimeError on empty graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac24ff0dc832e86f6faf97c58b40d