### PR TITLE
Refactor SupCon fine‑tune pipeline

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -42,8 +42,7 @@ import matplotlib.pyplot as plt
 from src.common.utils import set_random_seed, get_logger, ensure_dir
 from graphs.dataset.graph_dataset import GraphDataset
 from src.models.gnn.encoder import RGCNEncoder
-from src.models.contrast.sup_con import SupContrastHead, SupConLoss
-from src.evaluation.metrics import AUROC, MacroF1
+from src.models.contrast.sup_con import SupContrastHead
 
 LOGGER = get_logger(__name__)
 
@@ -124,13 +123,13 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
 # Training / Evaluation Loops
 # --------------------------------------------------------------------------- #
 
-def train_one_epoch(model: nn.Module, loader: DataLoader, criterion: nn.Module,
+def train_one_epoch(model: nn.Module, loader: DataLoader,
                     optimizer: optim.Optimizer, device: torch.device) -> float:
     model.train(); running_loss = 0.0
     for batch in loader:
         batch = batch.to(device)
         z = model.encoder(batch)  # (..., 256)
-        loss = criterion(model.head, z, batch.y)
+        loss = model.head(z, batch.y)
 
         optimizer.zero_grad(); loss.backward(); optimizer.step()
         running_loss += loss.item() * batch.num_graphs
@@ -138,15 +137,38 @@ def train_one_epoch(model: nn.Module, loader: DataLoader, criterion: nn.Module,
 
 
 def evaluate(model: nn.Module, loader: DataLoader, device: torch.device) -> dict:
-    model.eval(); auroc = AUROC(); f1 = MacroF1();
+    """Evaluate via a logistic regression on SupCon embeddings."""
+    model.eval()
+    embeds, labels = [], []
     with torch.no_grad():
         for batch in loader:
             batch = batch.to(device)
             z = model.encoder(batch)
-            logits = model.head(z)
-            auroc.update(logits.squeeze(), batch.y)
-            f1.update(logits.squeeze(), batch.y)
-    return {"AUROC": auroc.compute(), "MacroF1": f1.compute()}
+            embeds.append(model.head.embed(z).cpu())
+            labels.append(batch.y.cpu())
+
+    X = torch.cat(embeds).numpy()
+    y = torch.cat(labels).numpy()
+
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.metrics import roc_auc_score, f1_score
+    from sklearn.model_selection import train_test_split
+
+    if len(set(y.tolist())) < 2:
+        return {"AUROC": float("nan"), "MacroF1": float("nan")}
+
+    X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=0.3, random_state=42)
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X_tr, y_tr)
+    prob = clf.predict_proba(X_te)
+    pred = clf.predict(X_te)
+
+    try:
+        auroc = roc_auc_score(y_te, prob, multi_class="ovr" if prob.shape[1] > 2 else "raise")
+    except ValueError:
+        auroc = float("nan")
+    f1 = f1_score(y_te, pred, average="macro")
+    return {"AUROC": float(auroc), "MacroF1": float(f1)}
 
 # --------------------------------------------------------------------------- #
 # Main
@@ -182,12 +204,11 @@ def main() -> None:
 
     # ---------------- Optim / Sched -------------------------------------- #
     optimizer = optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
-    criterion = SupConLoss(temperature=0.07).to(device)
 
     best_val = 0.0; no_improve = 0
     train_losses, val_aurocs, val_f1s = [], [], []
     for epoch in range(1, args.epochs + 1):
-        train_loss = train_one_epoch(model, train_dl, criterion, optimizer, device)
+        train_loss = train_one_epoch(model, train_dl, optimizer, device)
         val_metrics = evaluate(model, val_dl, device)
         train_losses.append(train_loss)
         val_aurocs.append(val_metrics["AUROC"].item() if hasattr(val_metrics["AUROC"], 'item') else float(val_metrics["AUROC"]))


### PR DESCRIPTION
## Summary
- clean up import for SupContrastHead
- compute contrastive loss directly from SupContrastHead
- remove standalone SupCon loss from training loop
- evaluate embeddings using a simple logistic regression

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac3ac9984832e95ff5afc7ac72ba6