### PR TITLE
Fix plot dir handling in finetune_supcon

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -185,6 +185,8 @@ def main() -> None:
 
     ensure_dir(args.logdir)
     plot_path = args.plot_path or (args.logdir / "train.png")
+    # ensure the folder exists for saving plots
+    ensure_dir(plot_path.parent)
     if args.wandb:
         import wandb
         wandb.init(project="robust-malware-graph", name="finetune_supcon", config=vars(args))

--- a/tests/test_plot_path.py
+++ b/tests/test_plot_path.py
@@ -1,0 +1,17 @@
+import pytest
+
+pytest.importorskip("matplotlib")
+import matplotlib.pyplot as plt
+from src.cli.preprocessing import ensure_dir
+
+
+def test_save_plot_when_dir_absent(tmp_path):
+    plot_path = tmp_path / "plots" / "img.png"
+    # ensure the directory is created before saving
+    ensure_dir(plot_path.parent)
+    plt.figure()
+    plt.plot([0, 1], [0, 1])
+    plt.savefig(plot_path)
+    plt.close()
+    assert plot_path.exists()
+


### PR DESCRIPTION
## Summary
- ensure plot directory is created before saving
- add regression test for saving plots when directory doesn't exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ace720670832ebbac6c33ef4d1055