### PR TITLE
Enable spawn multiprocessing for finetune_supcon

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Iterable, Tuple
 
 import torch
+import torch.multiprocessing as mp
 from torch import nn, optim
 from torch.utils.data import DataLoader
 from torch_geometric.data import InMemoryDataset, Batch
@@ -202,6 +203,7 @@ def evaluate(model: nn.Module, loader: DataLoader, device: torch.device) -> dict
 # --------------------------------------------------------------------------- #
 
 def main() -> None:
+    mp.set_start_method("spawn", force=True)  # cross-platform multiprocessing safety
     args = build_parser().parse_args()
 
     if args.cfg == "hydra":


### PR DESCRIPTION
## Summary
- import `torch.multiprocessing` in `finetune_supcon.py`
- set the multiprocessing start method to `spawn` in `finetune_supcon.main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ad6859150832e87b671c41b9f4df4