### PR TITLE
Fix pin_memory crash for GPU dataset

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -108,7 +108,7 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         shuffle=True,
         num_workers=os.cpu_count(),
         collate_fn=GraphDataset.collate_fn,
-        pin_memory=True,
+        pin_memory=False,
     )
     val_dl = DataLoader(
         val_ds,
@@ -116,7 +116,7 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         shuffle=False,
         num_workers=os.cpu_count(),
         collate_fn=GraphDataset.collate_fn,
-        pin_memory=True,
+        pin_memory=False,
     )
     return train_dl, val_dl
 


### PR DESCRIPTION
## Summary
- avoid pinning GPU tensors in `finetune_supcon` dataloaders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad79ecf8c832e83936e59b1e9c901