### PR TITLE
Fix DataLoader pin_memory for GPU-preloaded graphs

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -91,11 +91,20 @@ def build_parser() -> argparse.ArgumentParser:
 # --------------------------------------------------------------------------- #
 
 def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[DataLoader, DataLoader]:
-    """Load GraphDataset splits and wrap in PyG Batch DataLoaders."""
+    """Load GraphDataset splits and wrap in PyG ``DataLoader`` objects.
+
+    ``pin_memory`` only makes sense when data is loaded on the CPU.  The
+    dataset currently moves graphs to the GPU via ``T.ToDevice`` when a CUDA
+    device is available.  Attempting to pin already CUDA-resident tensors
+    results in ``RuntimeError: cannot pin 'torch.cuda.*Tensor'``.  We therefore
+    disable memory pinning whenever data is placed on the GPU.
+    """
     root = splits_dir / split if (splits_dir / split).is_dir() else splits_dir
 
+    use_cuda = torch.cuda.is_available()
+
     transform = T.Compose([
-        T.ToDevice("cuda" if torch.cuda.is_available() else "cpu"),
+        T.ToDevice("cuda" if use_cuda else "cpu"),
         T.NormalizeFeatures(),
     ])
 
@@ -108,7 +117,7 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         shuffle=True,
         num_workers=os.cpu_count(),
         collate_fn=GraphDataset.collate_fn,
-        pin_memory=True,
+        pin_memory=not use_cuda,
     )
     val_dl = DataLoader(
         val_ds,
@@ -116,7 +125,7 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         shuffle=False,
         num_workers=os.cpu_count(),
         collate_fn=GraphDataset.collate_fn,
-        pin_memory=True,
+        pin_memory=not use_cuda,
     )
     return train_dl, val_dl
 


### PR DESCRIPTION
## Summary
- avoid pin memory errors when `ToDevice('cuda')` is used
- disable DataLoader pinning when dataset loads graphs on the GPU

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad79ecf8c832e83936e59b1e9c901