### PR TITLE
Fix dataset to propagate node feats

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -104,6 +104,7 @@ class GraphDataset(Dataset):
     def __getitem__(self, idx: int) -> Tuple[GraphT, int | None, str]:
         sha = self.samples[idx]
         g = self._load_graph(sha)
+        g = self._ensure_x(g)
         if self.transform:
             g = self.transform(g)
         label = self.labels.get(sha, None)
@@ -172,3 +173,16 @@ class GraphDataset(Dataset):
                     return loader.load(fp)
 
         raise FileNotFoundError(f"graph file for '{sha}' not found")
+
+    # --------------------------------------------------------------
+    def _ensure_x(self, g: GraphT) -> GraphT:
+        """Fill missing ``x`` attributes from ``feat`` in each node store."""
+        if isinstance(g, HeteroData):
+            for node_type in g.node_types:
+                store = g[node_type]
+                if "x" not in store and "feat" in store:
+                    store.x = store.feat
+        elif isinstance(g, Data):
+            if not hasattr(g, "x") and hasattr(g, "feat"):
+                g.x = g.feat
+        return g

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -1,0 +1,28 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.graphs.dataset.graph_dataset import GraphDataset
+
+
+def test_graph_dataset_feat_to_x(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["node"].feat = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    g["node"].num_nodes = 2
+
+    torch.save(g, graph_dir / "sample.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    loaded, label, sha = ds[0]
+
+    assert label is None
+    assert sha == "sample"
+    assert "x" in loaded["node"]
+    assert torch.all(loaded["node"].x.eq(g["node"].feat))


### PR DESCRIPTION
## Summary
- patch graphs read from GraphDataset to populate `x` from `feat`
- test that loading HeteroData with only `feat` exposes `.x`

## Testing
- `pytest -q` *(fails: 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685ada8fc110832e814e819969177ee9