### PR TITLE
Enforce labels for supervised contrastive head

### DIFF
--- a/src/models/contrast/sup_con.py
+++ b/src/models/contrast/sup_con.py
@@ -116,6 +116,8 @@ class SupContrastHead(nn.Module):
         """
         if z.dim() != 2:
             raise ValueError(f"Expected z shape [B, D], got {z.shape}")
+        if y is None:
+            raise ValueError("Labels are required for supervised contrastive loss")
         if mask is not None and mask.dim() != 1:
             raise ValueError("mask shape must be [B]")
 

--- a/tests/test_sup_con_head.py
+++ b/tests/test_sup_con_head.py
@@ -1,0 +1,13 @@
+import pytest
+
+pytest.importorskip("torch")
+
+import torch
+from src.models.contrast.sup_con import SupContrastHead
+
+
+def test_forward_requires_labels():
+    head = SupContrastHead(in_dim=2, proj_dim=2)
+    z = torch.randn(4, 2)
+    with pytest.raises(ValueError, match="Labels are required"):
+        head(z, None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- enforce labels in `SupContrastHead.forward`
- add regression test for missing labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae2f458bc832ebb122b65956490af