### PR TITLE
Update README with label and split instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ The preprocessing CLI under `src/cli/preprocessing.py` builds the heterogeneous
 graphs. When running the `graphs` subcommand, passing `--with-feats` will insert
 zero vectors for node types that lack a `feat` tensor.
 
+Before splitting the graphs you must generate a `labels.csv` file summarising
+the raw JSON samples:
+
+```bash
+python -m cli.preprocessing labels \
+       --input-dir data/raw/jsons \
+       --label 1 \
+       --csv data/labels.csv \
+       --date-key virustotal.first_submission_date
+```
+
+Create train/val/test folders that each include `labels.csv` using the
+preprocessing `splits` stage (or the standalone `split_generator` module):
+
+```bash
+python -m cli.preprocessing splits \
+       --strategy time --val-ratio 0.1 --test-ratio 0.1 --out data
+```
+
+```bash
+python -m graphs.dataset.split_generator \
+       --meta data/labels.csv --graphs data/hetero \
+       --out data/splits/time --by-time
+```
+
+The `finetune_supcon` script expects these labeled split directories.
+
 ### Example: fine-tuning SupCon head
 
 ```bash


### PR DESCRIPTION
## Summary
- document `preprocessing labels` to create `labels.csv`
- show how to run `split_generator` or the preprocessing CLI to generate labeled splits
- note that `finetune_supcon` expects these labeled splits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae2f13274832e8e0b6b5761561179