### PR TITLE
Add labels.csv generation for build_time_splits

### DIFF
--- a/src/graphs/dataset/split_generator.py
+++ b/src/graphs/dataset/split_generator.py
@@ -377,6 +377,29 @@ def build_time_splits(
         with json_out.open("w", encoding="utf-8") as f:
             json.dump({"train": train, "val": val, "test": test}, f)
 
+    # ── split별 labels.csv 작성 ────────────────────────────────────────
+    label_map: Dict[str, str] = {}
+    with meta_csv.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            sha = row[id_col]
+            if label_col in row:
+                label_map[sha] = row[label_col]
+
+    for split_name, sha_list in {
+        "train": train,
+        "val": val,
+        "test": test,
+    }.items():
+        path = splits_dir / split_name / "labels.csv"
+        with path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["sha256", "label"])
+            for sha in sha_list:
+                label = label_map.get(sha)
+                if label is not None:
+                    writer.writerow([sha, label])
+
     _LOG.info("✔ build_time_splits complete → %s", splits_dir)
     return train, val, test
 

--- a/tests/test_split_generator.py
+++ b/tests/test_split_generator.py
@@ -78,8 +78,8 @@ def test_split_by_time_overwrite(tmp_path):
 
 def test_build_time_splits_json(tmp_path):
     rows = [
-        {"sha256": "x", "collected_at": "2023-01-01"},
-        {"sha256": "y", "collected_at": "2024-01-02"},
+        {"sha256": "x", "collected_at": "2023-01-01", "label": "0"},
+        {"sha256": "y", "collected_at": "2024-01-02", "label": "1"},
     ]
     meta = _write_meta(tmp_path, rows)
     graph_dir = _make_graph_files(tmp_path, ["x", "y"])
@@ -98,4 +98,13 @@ def test_build_time_splits_json(tmp_path):
     assert js["train"] == train
     assert js["val"] == val
     assert js["test"] == test
+
+    # labels.csv should exist for each split
+    for split, shas in {"train": train, "val": val, "test": test}.items():
+        csv_path = out / split / "labels.csv"
+        assert csv_path.is_file()
+        rows = csv_path.read_text().strip().splitlines()
+        assert rows[0] == "sha256,label"
+        csv_shas = {r.split(",")[0] for r in rows[1:]}
+        assert csv_shas == set(shas)
 


### PR DESCRIPTION
## Summary
- extend `build_time_splits` to write per-split `labels.csv`
- test that `labels.csv` files are produced when calling `build_time_splits`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685ae2f1b460832eaca4419e75570fc5