### PR TITLE
Fix SupCon denom calculation and extend tests

### DIFF
--- a/src/models/contrast/sup_con.py
+++ b/src/models/contrast/sup_con.py
@@ -156,7 +156,8 @@ class SupContrastHead(nn.Module):
         # Loss: average over *anchor* samples having ≥1 positive.
         # ------------------------------------------------------------------
         exp_sim = torch.exp(sim)  # [B, B]
-        denom = exp_sim.sum(dim=1, keepdim=True) - torch.exp(torch.zeros(B, 1, device=device))  # subtract self term which has exp(0)=1
+        denom = exp_sim.sum(dim=1) - 1.0  # subtract self term which has exp(0)=1
+        denom = denom.clamp_min(1e-9)
 
         # Numerator: sum over positives for each anchor
         pos_exp = (exp_sim * M).sum(dim=1)
@@ -167,7 +168,7 @@ class SupContrastHead(nn.Module):
             # Should rarely happen, fallback to zero loss to keep graph
             return torch.zeros([], device=device, requires_grad=True)
 
-        loss = -torch.log(pos_exp[valid_anchor] / denom[valid_anchor].squeeze(1)).mean()
+        loss = -torch.log(pos_exp[valid_anchor] / denom[valid_anchor]).mean()
         return loss
 
     # ------------------------------------------------------------------

--- a/tests/test_sup_con_head.py
+++ b/tests/test_sup_con_head.py
@@ -11,3 +11,22 @@ def test_forward_requires_labels():
     z = torch.randn(4, 2)
     with pytest.raises(ValueError, match="Labels are required"):
         head(z, None)  # type: ignore[arg-type]
+
+
+def test_forward_subset_shared_labels_returns_finite_scalar():
+    head = SupContrastHead(in_dim=4, proj_dim=4)
+    z = torch.randn(4, 4)
+    y = torch.tensor([0, 0, 1, 2])
+    loss = head(z, y)
+    assert loss.dim() == 0
+    assert torch.isfinite(loss).item()
+
+
+def test_forward_unique_labels_returns_zero():
+    head = SupContrastHead(in_dim=4, proj_dim=4)
+    z = torch.randn(4, 4)
+    y = torch.arange(4)
+    loss = head(z, y)
+    assert loss.dim() == 0
+    assert torch.isfinite(loss).item()
+    assert loss.item() == 0.0


### PR DESCRIPTION
## Summary
- clamp supervised contrast denominator to avoid division by zero
- update SupContrast loss ratio calculation
- add tests for partial and absent positive pairs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae89d6318832e990173cb7f35cf82