### PR TITLE
Add batch size validation in SupContrastHead

### DIFF
--- a/src/models/contrast/sup_con.py
+++ b/src/models/contrast/sup_con.py
@@ -118,8 +118,13 @@ class SupContrastHead(nn.Module):
             raise ValueError(f"Expected z shape [B, D], got {z.shape}")
         if y is None:
             raise ValueError("Labels are required for supervised contrastive loss")
-        if mask is not None and mask.dim() != 1:
-            raise ValueError("mask shape must be [B]")
+        if z.size(0) != y.size(0):
+            raise ValueError("z and y must have the same batch size")
+        if mask is not None:
+            if mask.dim() != 1:
+                raise ValueError("mask shape must be [B]")
+            if mask.size(0) != z.size(0):
+                raise ValueError("mask must have the same batch size as z")
 
         device = z.device
         z = _normalize(self.proj(z))  # [B, d]

--- a/tests/test_sup_con_head.py
+++ b/tests/test_sup_con_head.py
@@ -30,3 +30,11 @@ def test_forward_unique_labels_returns_zero():
     assert loss.dim() == 0
     assert torch.isfinite(loss).item()
     assert loss.item() == 0.0
+
+
+def test_forward_mismatched_batch_size_raises():
+    head = SupContrastHead(in_dim=4, proj_dim=4)
+    z = torch.randn(4, 4)
+    y = torch.arange(5)
+    with pytest.raises(ValueError, match="batch size"):
+        head(z, y)


### PR DESCRIPTION
## Summary
- validate batch size in `SupContrastHead.forward`
- test that mismatched batch sizes raise `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aebd97468832eb3b49f3ee36c5c47