### PR TITLE
Fix dataloader device handling

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -93,29 +93,30 @@ def build_parser() -> argparse.ArgumentParser:
 def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[DataLoader, DataLoader]:
     """Load GraphDataset splits and wrap in PyG ``DataLoader`` objects.
 
-    ``pin_memory`` only makes sense when data is loaded on the CPU.  The
-    dataset currently moves graphs to the GPU via ``T.ToDevice`` when a CUDA
-    device is available.  Attempting to pin already CUDA-resident tensors
-    results in ``RuntimeError: cannot pin 'torch.cuda.*Tensor'``.  We therefore
-    disable memory pinning whenever data is placed on the GPU.
+    ``pin_memory`` only makes sense when data is loaded on the CPU.  Graphs are
+    now kept on the CPU and moved to the target device inside the training
+    loops.  Attempting to pin already CUDA-resident tensors results in
+    ``RuntimeError: cannot pin 'torch.cuda.*Tensor'``.  We therefore disable
+    memory pinning whenever data is placed on the GPU and also avoid DataLoader
+    worker processes when using CUDA.
     """
     root = splits_dir / split if (splits_dir / split).is_dir() else splits_dir
 
     use_cuda = torch.cuda.is_available()
 
     transform = T.Compose([
-        T.ToDevice("cuda" if use_cuda else "cpu"),
         T.NormalizeFeatures(),
     ])
 
     train_ds = GraphDataset(root=root, split="train", transform=transform)
     val_ds = GraphDataset(root=root, split="val", transform=transform)
 
+    num_workers = 0 if use_cuda else os.cpu_count()
     train_dl = DataLoader(
         train_ds,
         batch_size=batch_size,
         shuffle=True,
-        num_workers=os.cpu_count(),
+        num_workers=num_workers,
         collate_fn=GraphDataset.collate_fn,
         pin_memory=not use_cuda,
     )
@@ -123,7 +124,7 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         val_ds,
         batch_size=batch_size,
         shuffle=False,
-        num_workers=os.cpu_count(),
+        num_workers=num_workers,
         collate_fn=GraphDataset.collate_fn,
         pin_memory=not use_cuda,
     )


### PR DESCRIPTION
## Summary
- keep graphs on CPU until consumed by training/eval
- disable workers when CUDA is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aebaf31e0832eb3f22f5c5ab08b0d