### PR TITLE
Require labels in finetune_supcon dataloaders

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -108,8 +108,18 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         T.NormalizeFeatures(),
     ])
 
-    train_ds = GraphDataset(root=root, split="train", transform=transform)
-    val_ds = GraphDataset(root=root, split="val", transform=transform)
+    train_ds = GraphDataset(
+        root=root,
+        split="train",
+        transform=transform,
+        require_labels=True,
+    )
+    val_ds = GraphDataset(
+        root=root,
+        split="val",
+        transform=transform,
+        require_labels=True,
+    )
 
     num_workers = 0 if use_cuda else os.cpu_count()
     train_dl = DataLoader(


### PR DESCRIPTION
## Summary
- update `finetune_supcon.make_dataloaders` to pass `require_labels=True` when building the GraphDataset for both train and val splits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aeecb8cf0832ebd075927681476f3