### PR TITLE
Support labeled-only filtering in GraphDataset

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -66,6 +66,8 @@ class GraphDataset(Dataset):
         레이블 파일에서 ID(sha) / label 컬럼명.
     transform : Callable | None
         각 그래프 로딩 후 호출할 transform.
+    require_labels : bool, default=False
+        ``True`` 로 설정하면 레이블이 없는 샘플은 로드 후 즉시 제거한다.
     """
 
     def __init__(
@@ -77,6 +79,7 @@ class GraphDataset(Dataset):
         id_col: str = "sha256",
         label_col: str = "label",
         transform: Optional[Callable[[GraphT], GraphT]] = None,
+        require_labels: bool = False,
     ) -> None:
         self.root = Path(root)
         self.split = split
@@ -84,6 +87,7 @@ class GraphDataset(Dataset):
         self.transform = transform
         self.id_col = id_col
         self.label_col = label_col
+        self.require_labels = require_labels
 
         # ── 파일 목록 & 레이블 로드 ───────────────────────────────
         self.samples: List[str] = sorted(p.stem for p in self.graph_dir.iterdir() if p.is_file())
@@ -92,8 +96,23 @@ class GraphDataset(Dataset):
         if label_file:
             self._load_labels(self.root / split / label_file)
 
-        _LOG.info("GraphDataset [%s]  total=%d  labeled=%d",
-                  split, len(self.samples), len(self.labels))
+        dropped = 0
+        if require_labels:
+            before = len(self.samples)
+            self.samples = [s for s in self.samples if s in self.labels]
+            dropped = before - len(self.samples)
+            if dropped:
+                _LOG.info(
+                    "GraphDataset [%s] dropped %d unlabeled samples", split, dropped
+                )
+
+        _LOG.info(
+            "GraphDataset [%s]  total=%d  labeled=%d  remaining=%d",
+            split,
+            len(self.samples) + dropped,
+            len(self.labels),
+            len(self.samples),
+        )
 
     # ────────────────────────────────────────────────────────────────
     # PyTorch API

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -26,3 +26,31 @@ def test_graph_dataset_feat_to_x(tmp_path):
     assert sha == "sample"
     assert "x" in loaded["node"]
     assert torch.all(loaded["node"].x.eq(g["node"].feat))
+
+
+def test_require_labels_drops_unlabeled(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["n"].x = torch.tensor([[1.0]])
+    g["n"].num_nodes = 1
+    torch.save(g, graph_dir / "a.pt")
+    torch.save(g, graph_dir / "b.pt")
+
+    labels = tmp_path / "train" / "labels.csv"
+    labels.write_text("sha256,label\na,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+
+    assert len(ds) == 1
+    g_loaded, label, sha = ds[0]
+    assert label == 1
+    assert sha == "a"
+
+    from torch.utils.data import DataLoader
+
+    loader = DataLoader(ds, batch_size=2, collate_fn=GraphDataset.collate_fn)
+    batch = next(iter(loader))
+    assert batch["label"] is not None
+    assert torch.equal(batch["label"], torch.tensor([1]))


### PR DESCRIPTION
## Summary
- add `require_labels` parameter to `GraphDataset` and drop unlabeled samples when set
- update logging and documentation for the new behaviour
- test that unlabeled samples are filtered and batches contain labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aeecc7fc4832e9bef20aa648e5588