### PR TITLE
Add label presence checks in finetune_supcon

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -153,9 +153,19 @@ def train_one_epoch(
             y = batch.get("label")
             if y is not None:
                 y = y.to(device)
+            else:
+                raise ValueError(
+                    "Batch contains unlabeled graphs. "
+                    "Use GraphDataset(require_labels=True)."
+                )
         else:  # fallback: Batch directly
             g = batch.to(device)
             y = batch.y
+            if y is None:
+                raise ValueError(
+                    "Batch contains unlabeled graphs. "
+                    "Use GraphDataset(require_labels=True)."
+                )
 
         z = model.encoder(g)  # (..., 256)
         loss = model.head(z, y)
@@ -177,9 +187,19 @@ def evaluate(model: nn.Module, loader: DataLoader, device: torch.device) -> dict
                 y = batch.get("label")
                 if y is not None:
                     y = y.to(device)
+                else:
+                    raise ValueError(
+                        "Batch contains unlabeled graphs. "
+                        "Use GraphDataset(require_labels=True)."
+                    )
             else:
                 g = batch.to(device)
                 y = batch.y
+                if y is None:
+                    raise ValueError(
+                        "Batch contains unlabeled graphs. "
+                        "Use GraphDataset(require_labels=True)."
+                    )
 
             z = model.encoder(g)
             embeds.append(model.head.embed(z).cpu())


### PR DESCRIPTION
## Summary
- raise a clear error when a training or evaluation batch lacks labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aeecc35b0832ea1eb1f093e37ff80