### PR TITLE
Handle variable feature dims in GraphDataset

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -36,6 +36,9 @@ import json
 import pickle
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
+from collections import defaultdict
+
+import torch.nn.functional as F
 
 import torch
 from torch.utils.data import Dataset
@@ -134,12 +137,65 @@ class GraphDataset(Dataset):
     # ────────────────────────────────────────────────────────────────
     @staticmethod
     def collate_fn(batch: List[Tuple[GraphT, int | None, str]]) -> Dict:
+        """Collate a list of graphs with possible feature size mismatch.
+
+        ``torch_geometric.data.Batch.from_data_list`` requires matching
+        feature dimensions for all graphs.  Some datasets may contain
+        graphs with different node feature sizes, which would normally
+        trigger a ``RuntimeError`` during collation.  To provide a more
+        robust batching behaviour we inspect each graph and pad
+        2‑dimensional tensors (typically ``x``/``feat``) so that every
+        graph shares the maximum feature dimension found in the batch.
+        """
+
         graphs, labels, ids = zip(*batch)
-        batch_graph = Batch.from_data_list(list(graphs))
-        if None not in labels:
-            labels_t = torch.tensor(labels, dtype=torch.long)
-        else:
-            labels_t = None
+
+        # --------------------------------------------------------------
+        # Determine max feature dimension for every (node_type, attr)
+        # --------------------------------------------------------------
+        max_dim: Dict[Tuple[str, str], int] = defaultdict(int)
+        for g in graphs:
+            if isinstance(g, HeteroData):
+                for ntype in g.node_types:
+                    store = g[ntype]
+                    for attr, val in store.items():
+                        if isinstance(val, torch.Tensor) and val.dim() == 2:
+                            key = (ntype, attr)
+                            max_dim[key] = max(max_dim[key], val.size(1))
+            else:  # Data
+                for attr, val in g.items():
+                    if isinstance(val, torch.Tensor) and val.dim() == 2:
+                        key = ("", attr)
+                        max_dim[key] = max(max_dim[key], val.size(1))
+
+        # --------------------------------------------------------------
+        # Pad features to the collected max dimension
+        # --------------------------------------------------------------
+        padded_graphs: List[GraphT] = []
+        for g in graphs:
+            if isinstance(g, HeteroData):
+                for ntype in g.node_types:
+                    store = g[ntype]
+                    for attr, val in list(store.items()):
+                        if isinstance(val, torch.Tensor) and val.dim() == 2:
+                            key = (ntype, attr)
+                            target = max_dim[key]
+                            if val.size(1) < target:
+                                pad = target - val.size(1)
+                                store[attr] = F.pad(val, (0, pad))
+            else:
+                for attr, val in list(g.items()):
+                    if isinstance(val, torch.Tensor) and val.dim() == 2:
+                        key = ("", attr)
+                        target = max_dim[key]
+                        if val.size(1) < target:
+                            pad = target - val.size(1)
+                            g[attr] = F.pad(val, (0, pad))
+            padded_graphs.append(g)
+
+        batch_graph = Batch.from_data_list(padded_graphs)
+
+        labels_t = torch.tensor(labels, dtype=torch.long) if None not in labels else None
         return {"graph": batch_graph, "label": labels_t, "ids": ids}
 
     # ════════════════════════════════════════════════════════════════

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -54,3 +54,28 @@ def test_require_labels_drops_unlabeled(tmp_path):
     batch = next(iter(loader))
     assert batch["label"] is not None
     assert torch.equal(batch["label"], torch.tensor([1]))
+
+
+def test_collate_pads_feat_dim(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g1 = HeteroData()
+    g1["n"].x = torch.randn(1, 2)
+    g1["n"].num_nodes = 1
+    g2 = HeteroData()
+    g2["n"].x = torch.randn(1, 1)
+    g2["n"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    labels = tmp_path / "train" / "labels.csv"
+    labels.write_text("sha256,label\na,0\nb,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    from torch.utils.data import DataLoader
+    loader = DataLoader(ds, batch_size=2, collate_fn=GraphDataset.collate_fn)
+    batch = next(iter(loader))
+
+    assert batch["graph"]["n"].x.shape[1] == 2
+    assert torch.equal(batch["label"], torch.tensor([0, 1], dtype=torch.long))


### PR DESCRIPTION
## Summary
- make `GraphDataset.collate_fn` pad features to the largest dimension in the batch
- test padding behavior when graphs have different feature sizes

## Testing
- `pytest tests/test_graph_dataset.py::test_collate_pads_feat_dim -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af088da00832eb6e83bd7fc6c5d85