### PR TITLE
Fix graph_dataset num_nodes inference

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -127,6 +127,7 @@ class GraphDataset(Dataset):
         sha = self.samples[idx]
         g = self._load_graph(sha)
         g = self._ensure_x(g)
+        g = self._ensure_num_nodes(g)
         if self.transform:
             g = self.transform(g)
         label = self.labels.get(sha, None)
@@ -260,4 +261,28 @@ class GraphDataset(Dataset):
         elif isinstance(g, Data):
             if not hasattr(g, "x") and hasattr(g, "feat"):
                 g.x = g.feat
+        return g
+
+    def _ensure_num_nodes(self, g: GraphT) -> GraphT:
+        """Infer ``num_nodes`` for each node store if missing."""
+        if isinstance(g, HeteroData):
+            for _, store in g.node_items():
+                if store.num_nodes is None:
+                    n = None
+                    if len(store) > 0:
+                        n = len(store)
+                    elif "edge_index" in store:
+                        n = int(store["edge_index"].max()) + 1
+                    else:
+                        n = 0
+                    store.num_nodes = n
+        elif isinstance(g, Data):
+            if g.num_nodes is None:
+                if len(g) > 0:
+                    n = len(g)
+                elif hasattr(g, "edge_index"):
+                    n = int(g.edge_index.max()) + 1
+                else:
+                    n = 0
+                g.num_nodes = n
         return g

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -79,3 +79,28 @@ def test_collate_pads_feat_dim(tmp_path):
 
     assert batch["graph"]["n"].x.shape[1] == 2
     assert torch.equal(batch["label"], torch.tensor([0, 1], dtype=torch.long))
+
+
+def test_collate_sets_missing_num_nodes(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g1 = HeteroData()
+    g1["n"].x = torch.randn(2, 1)  # num_nodes inferred from features
+    g2 = HeteroData()
+    g2["n"].edge_index = torch.tensor([[0, 1], [1, 0]])
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    labels = tmp_path / "train" / "labels.csv"
+    labels.write_text("sha256,label\na,0\nb,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    from torch.utils.data import DataLoader
+    loader = DataLoader(ds, batch_size=2, collate_fn=GraphDataset.collate_fn)
+
+    batch = next(iter(loader))
+
+    # num_nodes should be set for both graphs and sum to 4 in the batch
+    assert batch["graph"]["n"].num_nodes == 4


### PR DESCRIPTION
## Summary
- ensure graphs loaded by GraphDataset have `num_nodes`
- account for graphs without `num_nodes` in dataset collate tests

## Testing
- `pytest -q` *(skipped: torch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685afd6b452c832e895ed58afa65d063