### PR TITLE
Ensure num_nodes when collating graphs

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -44,6 +44,8 @@ import torch
 from torch.utils.data import Dataset
 from torch_geometric.data import Batch, Data, HeteroData
 
+from ..builders.hetero_builder import ensure_num_nodes as hetero_ensure_num_nodes
+
 from ..loaders.factory import get_loader   # fallback json 로드용
 from ..utils import get_logger
 
@@ -150,6 +152,9 @@ class GraphDataset(Dataset):
         """
 
         graphs, labels, ids = zip(*batch)
+
+        # ensure num_nodes metadata is present for all graphs
+        graphs = [GraphDataset._ensure_num_nodes(None, g) for g in graphs]
 
         # --------------------------------------------------------------
         # Determine max feature dimension for every (node_type, attr)
@@ -264,25 +269,16 @@ class GraphDataset(Dataset):
         return g
 
     def _ensure_num_nodes(self, g: GraphT) -> GraphT:
-        """Infer ``num_nodes`` for each node store if missing."""
+        """Infer ``num_nodes`` metadata when missing."""
         if isinstance(g, HeteroData):
-            for _, store in g.node_items():
-                if store.num_nodes is None:
-                    n = None
-                    if len(store) > 0:
-                        n = len(store)
-                    elif "edge_index" in store:
-                        n = int(store["edge_index"].max()) + 1
-                    else:
-                        n = 0
-                    store.num_nodes = n
+            # Delegate to shared utility used by builders
+            hetero_ensure_num_nodes(g)
         elif isinstance(g, Data):
             if g.num_nodes is None:
-                if len(g) > 0:
-                    n = len(g)
+                if hasattr(g, "x"):
+                    g.num_nodes = g.x.size(0)
                 elif hasattr(g, "edge_index"):
-                    n = int(g.edge_index.max()) + 1
+                    g.num_nodes = int(g.edge_index.max()) + 1
                 else:
-                    n = 0
-                g.num_nodes = n
+                    g.num_nodes = 0
         return g

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -104,3 +104,27 @@ def test_collate_sets_missing_num_nodes(tmp_path):
 
     # num_nodes should be set for both graphs and sum to 4 in the batch
     assert batch["graph"]["n"].num_nodes == 4
+
+
+def test_collate_sets_missing_num_nodes_data(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    from torch_geometric.data import Data
+
+    g1 = Data(x=torch.randn(2, 1))
+    g2 = Data(edge_index=torch.tensor([[0, 1, 2], [1, 2, 0]]))
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    labels = tmp_path / "train" / "labels.csv"
+    labels.write_text("sha256,label\na,0\nb,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    from torch.utils.data import DataLoader
+    loader = DataLoader(ds, batch_size=2, collate_fn=GraphDataset.collate_fn)
+
+    batch = next(iter(loader))
+
+    assert batch["graph"].num_nodes == 5


### PR DESCRIPTION
## Summary
- infer missing `num_nodes` for both `Data` and `HeteroData` graphs
- call `_ensure_num_nodes` during collation
- add regression test for Data graphs missing `num_nodes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b04af2f0c832e989c3c8836b2da9e