### PR TITLE
Fix RuleGenEnv imports

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -56,8 +56,8 @@ except ModuleNotFoundError:
         return logging.getLogger(name)
 
 
-from ..evaluation.metrics import RuleEvaluator  # type: ignore
-from ..models.gnn.res_wrapper import RESGCLClassifier  # type: ignore
+from evaluation.metrics import RuleEvaluator  # type: ignore
+from models.gnn.res_wrapper import RESGCLClassifier  # type: ignore
 from .feature_miner import FeatureMiner  # 단어 사전
 
 _LOG = get_logger(__name__)


### PR DESCRIPTION
## Summary
- import RuleEvaluator and RESGCLClassifier using absolute paths

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m cli.rulegen_cli feature-mine --graph-dir data/hetero --out features.json --num-workers 0 --seed 42` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685b0c3eb548832ebf2235cdabd908e4