### PR TITLE
Implement __dir__ helper for rulegen package

### DIFF
--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -53,6 +53,11 @@ __all__ = [
     "load_agent",
 ]
 
+
+def __dir__():
+    """Return a sorted list of accessible attributes for autocomplete."""
+    return sorted(set(globals()) | set(__all__))
+
 # ───────────────────────── version info
 try:
     __version__: str = metadata.version("robust-malware-graph")


### PR DESCRIPTION
## Summary
- expose a `__dir__` helper in `src/rulegen` to show all lazily loaded symbols

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1550672c832e8bae6c4d77ba0c4b