### PR TITLE
Add caching to rulegen lazy imports

### DIFF
--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import logging
 from importlib import metadata
 from typing import Any, Dict, Optional
+import importlib
+import sys
 
 import gymnasium as gym
 
@@ -76,6 +78,46 @@ if _ENV_ID not in gym.registry:  # type: ignore[attr-defined]
         max_episode_steps=512,
     )
     _LOG.debug("Gym env '%s' registered", _ENV_ID)
+
+# ───────────────────────── lazy import helper
+_LAZY_ATTRS = {
+    "FeatureMiner": (".feature_miner", "FeatureMiner"),
+    "RuleGenEnv": (".rl_env", "RuleGenEnv"),
+    "PPORuleAgent": (".rl_agent", "PPORuleAgent"),
+    "YaraBuilder": (".yara_builder", "YaraBuilder"),
+    "tokens_to_yara": (".yara_builder", "tokens_to_yara"),
+    "CapaBuilder": (".capa_builder", "CapaBuilder"),
+    "tokens_to_capa": (".capa_builder", "tokens_to_capa"),
+}
+
+_LAZY_MODULES = {
+    "feature_miner": ".feature_miner",
+    "rl_env": ".rl_env",
+    "rl_agent": ".rl_agent",
+    "yara_builder": ".yara_builder",
+    "capa_builder": ".capa_builder",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import heavy submodules or objects."""
+    if name in globals():
+        return globals()[name]
+
+    if name in _LAZY_MODULES:
+        module = importlib.import_module(_LAZY_MODULES[name], __name__)
+        sys.modules[f"{__name__}.{name}"] = module
+        globals()[name] = module
+        return module
+
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = importlib.import_module(module_path, __name__)
+        obj = getattr(module, attr_name)
+        globals()[name] = obj
+        return obj
+
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 # ╔══════════════════════════════════════════════════════════════╗
 # ║                      Convenience helpers                     ║


### PR DESCRIPTION
## Summary
- add importlib and sys for lazy imports
- lazily load heavy rulegen submodules and attributes using `__getattr__`
- cache each import in `globals()` so concurrent calls only import once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b154f3c0c832e98e4f52f7842e989