### PR TITLE
Add RuleEvaluator stub and RL env test

### DIFF
--- a/src/evaluation/__init__.py
+++ b/src/evaluation/__init__.py
@@ -31,6 +31,7 @@ from .metrics import (  # noqa: F401
     Uniformity,
     format_metrics as _format_metrics,
 )
+from .rule_evaluator import RuleEvaluator
 
 __all_metrics = [
     "Accuracy",
@@ -135,5 +136,6 @@ __all__ = (
         "quick_eval",
         "metric_summary",
         "run_ci",
+        "RuleEvaluator",
     ]
 )

--- a/src/evaluation/rule_evaluator.py
+++ b/src/evaluation/rule_evaluator.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import torch
+from torch_geometric.data import HeteroData
+
+from .metrics import Metric
+
+class RuleEvaluator:
+    """Placeholder rule evaluator used by :class:`RuleGenEnv`."""
+
+    def __init__(self, *, clf: torch.nn.Module, device: str | torch.device = "cpu", batch_size: int = 128):
+        self.clf = clf
+        self.device = device
+        self.batch_size = batch_size
+
+    def evaluate_rule(
+        self,
+        rule_text: str,
+        clean_set: Sequence[HeteroData],
+        dummy_set: Sequence[HeteroData],
+    ) -> Tuple[float, float, float]:
+        """Evaluate ``rule_text`` on provided datasets.
+
+        This simplified implementation returns zero scores and does not
+        perform any real rule matching.  Projects may replace this logic
+        with a proper evaluator.
+        """
+        return 0.0, 0.0, 0.0

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -56,7 +56,7 @@ except ModuleNotFoundError:
         return logging.getLogger(name)
 
 
-from evaluation.metrics import RuleEvaluator  # type: ignore
+from evaluation.rule_evaluator import RuleEvaluator  # type: ignore
 from models.gnn.res_wrapper import RESGCLClassifier  # type: ignore
 from .feature_miner import FeatureMiner  # 단어 사전
 

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -1,0 +1,46 @@
+import json
+import pytest
+import sys
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+pytest.importorskip("gymnasium")
+
+import src.evaluation as evaluation
+sys.modules.setdefault("evaluation", evaluation)
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.rulegen.rl_env import RuleGenEnv
+import src.models.gnn.res_wrapper as res_wrapper
+
+
+class DummyClf(torch.nn.Module):
+    def forward(self, data):
+        return torch.zeros(len(data), dtype=torch.float)
+
+dummy_clf = DummyClf()
+res_wrapper.RESGCLClassifier.load_pretrained = classmethod(
+    lambda cls, path, map_location=None: dummy_clf
+)
+
+
+def test_env_instantiates(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=8,
+        device="cpu",
+    )
+
+    assert env.action_space.n == len(env.token2id)


### PR DESCRIPTION
## Summary
- provide a basic `RuleEvaluator` class and export it
- update RL environment to import the new evaluator
- add a unit test ensuring `RuleGenEnv` can be constructed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b15541b84832e9774c94903a4df52