### PR TITLE
Fix rulegen submodule imports

### DIFF
--- a/rulegen/__init__.py
+++ b/rulegen/__init__.py
@@ -1,1 +1,11 @@
+from pathlib import Path
+
+# ensure submodules like rulegen.feature_miner resolve even if the repo root shadows site-packages
+_src_pkg = Path(__file__).resolve().parents[1] / "src" / "rulegen"
+if _src_pkg.exists() and str(_src_pkg) not in __path__:
+    __path__.append(str(_src_pkg))
+
+import src.rulegen
 from src.rulegen import *  # re-export
+
+__all__ = src.rulegen.__all__

--- a/tests/test_rulegen_submodule_import.py
+++ b/tests/test_rulegen_submodule_import.py
@@ -1,0 +1,9 @@
+import importlib
+import pytest
+
+
+def test_feature_miner_submodule_importable():
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+    mod = importlib.import_module("rulegen.feature_miner")
+    assert mod.__name__.endswith("feature_miner")


### PR DESCRIPTION
## Summary
- update top-level `rulegen` package to always expose `src.rulegen`
- re-export `__all__` for API parity
- test that `rulegen.feature_miner` is importable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b18c39d18832e94c2a90053de8fa7