### PR TITLE
Handle JSON decode errors in CLI

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import csv
 import logging
 import sys
 from pathlib import Path
@@ -88,8 +89,33 @@ def _setup_logger(verbose: bool = False) -> None:
 
 def _read_json_lines(path: Path) -> List[dict]:
     """Load a *jsonl* file into a list of dicts."""
+    items: List[dict] = []
     with path.open("r", encoding="utf-8") as fp:
-        return [json.loads(line) for line in fp]
+        for line in fp:
+            try:
+                items.append(json.loads(line))
+            except json.JSONDecodeError as exc:  # pragma: no cover - simple error wrapper
+                raise ValueError(
+                    "labels file must be JSON lines with sha256 and label"
+                ) from exc
+    return items
+
+
+def _read_labels(path: Path) -> List[dict]:
+    """Load labels from a JSONL or CSV file."""
+    if path.suffix == ".csv":
+        items: List[dict] = []
+        with path.open(newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    items.append({"sha256": row["sha256"], "label": int(row["label"])})
+                except KeyError as exc:
+                    raise ValueError(
+                        "labels file must have sha256 and label columns"
+                    ) from exc
+        return items
+    return _read_json_lines(path)
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +131,12 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
     out_path = Path(args.out)
     label_map: dict[str, int] | None = None
     if args.labels:
-        label_map = {item["sha256"]: item["label"] for item in _read_json_lines(Path(args.labels))}
+        try:
+            label_items = _read_labels(Path(args.labels))
+            label_map = {item["sha256"]: item["label"] for item in label_items}
+        except ValueError as exc:
+            logger.error(str(exc))
+            raise SystemExit(1)
         logger.debug("Loaded %d labels for supervision", len(label_map))
 
     dataset = GraphDataset(graph_dir, cache=True)  # type: ignore[arg-type]
@@ -269,7 +300,10 @@ def _build_parser() -> argparse.ArgumentParser:
     # ------------------- feature‑mine ------------------- #
     fm = sub.add_parser("feature-mine", help="Mine discriminative graph features")
     fm.add_argument("--graph-dir", required=True, help="Directory with hetero graphs")
-    fm.add_argument("--labels", help="Optional JSONL (<sha256,label>) for supervision")
+    fm.add_argument(
+        "--labels",
+        help="Optional labels file (.jsonl or .csv) with sha256 and label",
+    )
     fm.add_argument("--out", required=True, help="Output path for mined features (.jsonl)")
     fm.add_argument("--num-workers", type=int, default=4, help="Data‑loader workers")
     fm.add_argument("--seed", type=int, default=42, help="RNG seed")

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("torch")
+
+from src.cli.rulegen_cli import _read_json_lines, _read_labels
+
+
+def test_read_json_lines_invalid(tmp_path):
+    fp = tmp_path / "labels.jsonl"
+    fp.write_text('{"sha256": "a", "label": 1}\n{invalid}\n')
+    with pytest.raises(ValueError):
+        _read_json_lines(fp)
+
+
+def test_read_labels_csv(tmp_path):
+    fp = tmp_path / "labels.csv"
+    fp.write_text("sha256,label\na,1\nb,0\n")
+    items = _read_labels(fp)
+    assert items == [{"sha256": "a", "label": 1}, {"sha256": "b", "label": 0}]


### PR DESCRIPTION
## Summary
- improve `_read_json_lines` error handling
- catch invalid label JSON in `cmd_feature_mine`
- add CSV label support for `feature-mine`
- test CLI helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1f592a94832e9651fc442a7018a3