### PR TITLE
Fix GraphDataset parameter mismatch

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -139,7 +139,8 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
             raise SystemExit(1)
         logger.debug("Loaded %d labels for supervision", len(label_map))
 
-    dataset = GraphDataset(graph_dir, cache=True)  # type: ignore[arg-type]
+    # GraphDataset does not support caching; simple on‑demand loading is fine
+    dataset = GraphDataset(graph_dir)  # type: ignore[arg-type]
     miner = FeatureMiner(num_workers=args.num_workers, seed=args.seed)
 
     all_features: List[dict] = []


### PR DESCRIPTION
## Summary
- remove unsupported `cache` parameter from `rulegen_cli` feature mining

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b21d0597c832eba1bd8a570b44ee7