### PR TITLE
Clarify rulegen dataset directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ python -m graphs.dataset.split_generator \
 
 The `finetune_supcon` script expects these labeled split directories.
 
+Each split directory should contain a `graphs/` subfolder. The rule
+generation CLI expects `--graph-dir` to point to this dataset root so it
+can load graphs from `train/graphs/`, `val/graphs/`, and similar
+subdirectories.
+
 ### Example: fine-tuning SupCon head
 
 ```bash

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -300,7 +300,11 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # ------------------- feature‑mine ------------------- #
     fm = sub.add_parser("feature-mine", help="Mine discriminative graph features")
-    fm.add_argument("--graph-dir", required=True, help="Directory with hetero graphs")
+    fm.add_argument(
+        "--graph-dir",
+        required=True,
+        help="Dataset root with train/graphs/, val/graphs/, etc."
+    )
     fm.add_argument(
         "--labels",
         help="Optional labels file (.jsonl or .csv) with sha256 and label",


### PR DESCRIPTION
## Summary
- update `rulegen_cli` to clarify `--graph-dir` argument expects a dataset root
- document the expected directory layout in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b32305c34832ea7403af25e9c47f6