### PR TITLE
Fix feature mining dataset iteration

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -144,9 +144,14 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
     miner = FeatureMiner()
 
     all_features: List[dict] = []
-    for graph in tqdm(dataset, desc="Mining features", total=len(dataset)):
-        sha = graph.metadata.get("sha256", "<unknown>")  # type: ignore[attr-defined]
-        label = label_map.get(sha) if label_map else None
+    for i in tqdm(range(len(dataset)), desc="Mining features", total=len(dataset)):
+        item = dataset[i]
+        if isinstance(item, tuple) and len(item) == 3:
+            graph, ds_label, sha = item
+        else:  # backward compatibility
+            graph, ds_label, sha = item, None, getattr(item, "sha256", "unknown")
+        assert getattr(graph, "metadata", {}).get("sha256") == sha, "SHA mismatch"
+        label = label_map.get(sha) if label_map else ds_label
         feats = miner.extract(graph, label=label)
         all_features.append({"sha256": sha, "features": feats})
 


### PR DESCRIPTION
## Summary
- handle GraphDataset items that include labels and sha
- verify sha integrity during feature mining
- fall back to dataset-provided label if label map is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3233003c832eab66b3aae60dca51