### PR TITLE
Fix feature-mining dataset compatibility

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -144,18 +144,23 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
     miner = FeatureMiner()
 
     all_features: List[dict] = []
-    for graph, ds_label, sha in tqdm(dataset, desc="Mining features", total=len(dataset)):
+    for i in tqdm(range(len(dataset)), desc="Mining features"):
+        item = dataset[i]
+        if isinstance(item, tuple) and len(item) == 3:
+            graph, ds_label, sha = item
+        else:  # backward compatibility
+            graph, ds_label, sha = item, None, getattr(item, "sha256", "unknown")
+
         meta_sha = getattr(getattr(graph, "metadata", None), "get", lambda *_: None)("sha256")
         if sha == "<unknown>" and meta_sha:
             sha = meta_sha
 
-        label = label_map.get(sha) if label_map else None
+        if meta_sha is not None:
+            assert meta_sha == sha, "SHA mismatch"
+
+        label = label_map.get(sha) if label_map else ds_label
         if label is None:
-            if ds_label is not None:
-                label = ds_label
-                logger.debug("Using dataset label for SHA %s", sha)
-            else:
-                logger.warning("No label found for SHA %s", sha)
+            logger.warning("No label found for SHA %s", sha)
         feats = miner.extract(graph, label=label)
         all_features.append({"sha256": sha, "features": feats})
 


### PR DESCRIPTION
## Summary
- iterate over dataset by index to handle multiple item layouts
- fallback when dataset items aren't triples
- verify graph SHA integrity
- simplify label lookup using labels map or dataset label

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b338fadc0832ebb9c9d016ec5e691