### PR TITLE
Cleanup stray CLI prompt

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -192,9 +192,8 @@ class FeatureMiner:
         local_idx: int,
         meta: torch_geometric.data.Data,
     ) -> List[str]:
-        '''
-        추가 도메인 feature 삽입을 원할 시 이 함수를 수정하여 보강(파일 경로, 레지스트리 키, URL, PE‐섹션 이름 등 추가 도메인 피처)
         """
+        추가 도메인 feature 삽입을 원할 시 이 함수를 수정하여 보강(파일 경로, 레지스트리 키, URL, PE‐섹션 이름 등 추가 도메인 피처)
         개별 노드에서 YARA·CAPA 후보 문자열 생성
         """
         candidates: List[str] = []
@@ -292,4 +291,3 @@ if __name__ == "__main__":
     miner = FeatureMiner(top_k=args.top_k)
     for feat in miner(g, sal):
         print(feat)
-'''


### PR DESCRIPTION
## Summary
- remove the leftover triple quote in `feature_miner.py`
- drop the trailing CLI prompt artifact and ensure a newline at EOF

## Testing
- `pytest tests/test_feature_mine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3b2d61e8832eb851b9fbd98ca0c9