### PR TITLE
Fix mismatched docstring quotes

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -192,10 +192,10 @@ class FeatureMiner:
         local_idx: int,
         meta: torch_geometric.data.Data,
     ) -> List[str]:
-        '''
-        추가 도메인 feature 삽입을 원할 시 이 함수를 수정하여 보강(파일 경로, 레지스트리 키, URL, PE‐섹션 이름 등 추가 도메인 피처)
-        """
-        개별 노드에서 YARA·CAPA 후보 문자열 생성
+        """개별 노드에서 YARA·CAPA 후보 문자열 생성.
+
+        추가 도메인 feature 삽입을 원할 시 이 함수를 수정하여 보강(파일 경로,
+        레지스트리 키, URL, PE‑섹션 이름 등 추가 도메인 피처).
         """
         candidates: List[str] = []
 
@@ -292,4 +292,3 @@ if __name__ == "__main__":
     miner = FeatureMiner(top_k=args.top_k)
     for feat in miner(g, sal):
         print(feat)
-'''


### PR DESCRIPTION
## Summary
- correct docstring quoting in `FeatureMiner._extract_candidates`
- remove stray triple quotes at EOF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3aff8220832e9978276b01fe0053