### PR TITLE
Fix FeatureMiner index error

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -205,7 +205,9 @@ class FeatureMiner:
                 return None
             # StringTensor 또는 List[str]일 수 있음
             if isinstance(x, (list, tuple)):
-                return x[local_idx]
+                if local_idx < len(x):
+                    return x[local_idx]
+                return None
             # torch 텐서 → str
             if torch.is_tensor(x):
                 # assume 1‑D tensor of ints (char codes) or encoded bytes
@@ -217,7 +219,10 @@ class FeatureMiner:
                 except Exception:
                     return None
             # plain python object
-            return x[local_idx] if hasattr(x, "__getitem__") else x
+            try:
+                return x[local_idx] if hasattr(x, "__getitem__") else x
+            except Exception:
+                return None
 
         # 1) API / 함수명
         name = _get("name") or _get("api")

--- a/tests/test_feature_miner_safe_get.py
+++ b/tests/test_feature_miner_safe_get.py
@@ -1,0 +1,20 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_feature_miner_handles_short_attribute_list():
+    g = HeteroData()
+    g["func"].num_nodes = 2
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["CreateFileW"]  # only one entry
+
+    sal = torch.tensor([0.9, 0.8])
+    miner = FeatureMiner(top_k=2)
+    feats = miner(g, sal)
+    assert isinstance(feats, list)


### PR DESCRIPTION
## Summary
- handle short metadata arrays in `FeatureMiner` by safely indexing
- add regression test for missing metadata elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3ea403a4832eaefec9102b0f6c43