### PR TITLE
Handle JSON array input in rulegen CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ python -m cli.finetune_supcon \
 ```
 
 ### Example: PPO rule-agent training
+First run the `feature-mine` command to produce `features.json`. The file
+is a JSON array of objects and can be passed directly to `ppo-train`.
 
 ```bash
 python -m cli.rulegen_cli ppo-train \

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -88,16 +88,25 @@ def _setup_logger(verbose: bool = False) -> None:
 
 
 def _read_json_lines(path: Path) -> List[dict]:
-    """Load a *jsonl* file into a list of dicts."""
+    """Load a ``jsonl`` file or a JSON array into a list of dicts."""
+    text = path.read_text(encoding="utf-8")
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, list):
+            return obj
+    except json.JSONDecodeError:
+        pass
+
     items: List[dict] = []
-    with path.open("r", encoding="utf-8") as fp:
-        for line in fp:
-            try:
-                items.append(json.loads(line))
-            except json.JSONDecodeError as exc:  # pragma: no cover - simple error wrapper
-                raise ValueError(
-                    "labels file must be JSON lines with sha256 and label"
-                ) from exc
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            items.append(json.loads(line))
+        except json.JSONDecodeError as exc:  # pragma: no cover - simple error wrapper
+            raise ValueError(
+                "file must be JSON lines or a JSON array of objects"
+            ) from exc
     return items
 
 
@@ -324,7 +333,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--labels",
         help="Optional labels file (.jsonl or .csv) with sha256 and label",
     )
-    fm.add_argument("--out", required=True, help="Output path for mined features (.jsonl)")
+    fm.add_argument("--out", required=True, help="Output path for mined features (.json)")
     fm.set_defaults(func=cmd_feature_mine)
 
     # ------------------- ppo‑train ------------------- #

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -17,3 +17,10 @@ def test_read_labels_csv(tmp_path):
     fp.write_text("sha256,label\na,1\nb,0\n")
     items = _read_labels(fp)
     assert items == [{"sha256": "a", "label": 1}, {"sha256": "b", "label": 0}]
+
+
+def test_read_json_array(tmp_path):
+    fp = tmp_path / "features.json"
+    fp.write_text('[{"sha": "a"}, {"sha": "b"}]')
+    items = _read_json_lines(fp)
+    assert items == [{"sha": "a"}, {"sha": "b"}]


### PR DESCRIPTION
## Summary
- allow `_read_json_lines` to load JSON array files and improve error message
- clarify feature-mine output help and README example
- test JSON array parsing for `_read_json_lines`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b444ed4d0832e973c1b579eddcafc