### PR TITLE
Update PPO train CLI to build env from dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ is a JSON array of objects and can be passed directly to `ppo-train`.
 ```bash
 python -m cli.rulegen_cli ppo-train \
        --train-features features.json \
+       --dataset-dir data/splits \
        --epochs 50000 \
        --checkpoint models/rulebank/ppo_agent.pt \
        --plot-path runs/rulegen/ppo_train.png

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -66,12 +66,13 @@ from tqdm import tqdm
 # ---------------------------------------------------------------------------
 
 def _lazy_imports():
-    global FeatureMiner, PPORuleAgent, YaraBuilder, CapaBuilder, GraphDataset
+    global FeatureMiner, PPORuleAgent, YaraBuilder, CapaBuilder, GraphDataset, rulegen
     from rulegen.feature_miner import FeatureMiner  # type: ignore
     from rulegen.rl_agent import PPORuleAgent  # type: ignore
     from rulegen.yara_builder import YaraBuilder  # type: ignore
     from rulegen.capa_builder import CapaBuilder  # type: ignore
     from graphs.dataset.graph_dataset import GraphDataset  # type: ignore
+    import rulegen
 
 
 # ---------------------------------------------------------------------------
@@ -194,15 +195,16 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     logger.info("Training on %s", device)
 
     # ------------------------------------------------------------------
-    # 2) Data loading
+    # 2) Data loading (currently unused but kept for compatibility)
     # ------------------------------------------------------------------
     train_feats = _read_json_lines(Path(args.train_features))
     val_feats = _read_json_lines(Path(args.val_features)) if args.val_features else []
 
     # ------------------------------------------------------------------
-    # 3) Agent instantiation & training loop
+    # 3) Environment & agent instantiation
     # ------------------------------------------------------------------
-    agent = PPORuleAgent(cfg, device=device)
+    env = rulegen.make_env(dataset_dir=args.dataset_dir, device=device)
+    agent = rulegen.load_agent(env=env)
     total_steps = int(cfg.get("scheduler", {}).get("total_updates", args.epochs))
     log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))
     history = agent.train(
@@ -341,6 +343,7 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--train-features", required=True, help="JSONL mined features")
     pt.add_argument("--val-features", help="Validation feature file (optional)")
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
+    pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
     pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")


### PR DESCRIPTION
## Summary
- wire up PPO training command to use `rulegen.make_env`
- load PPO agent via `rulegen.load_agent`
- require `--dataset-dir` for PPO training
- document new argument in README example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b47616bf8832ea812262dd6c161dc