### PR TITLE
Validate PPO dataset inputs

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -183,8 +183,14 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
 
 def cmd_ppo_train(args: argparse.Namespace) -> None:
     """Train a PPO agent to convert features into high‑quality rules."""
-    _lazy_imports()
     logger = logging.getLogger("ppo-train")
+
+    dataset_dir = Path(args.dataset_dir).expanduser().resolve()
+    if not (dataset_dir / "clean.pt").exists() or not (dataset_dir / "dummy.pt").exists():
+        logger.error("Dataset directory missing required files clean.pt and dummy.pt")
+        raise SystemExit(1)
+
+    _lazy_imports()
 
     # ------------------------------------------------------------------
     # 1) Configuration & device selection
@@ -203,7 +209,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # ------------------------------------------------------------------
     # 3) Environment & agent instantiation
     # ------------------------------------------------------------------
-    env = rulegen.make_env(dataset_dir=args.dataset_dir, device=device)
+    env = rulegen.make_env(dataset_dir=dataset_dir, device=device)
     agent = rulegen.load_agent(env=env)
     total_steps = int(cfg.get("scheduler", {}).get("total_updates", args.epochs))
     log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -1,0 +1,45 @@
+import argparse
+import logging
+import sys
+import types
+import importlib
+import pytest
+
+
+def test_ppo_train_checks_dataset(tmp_path, caplog, monkeypatch):
+    # Provide dummy modules so rulegen_cli imports without heavy deps
+    torch_stub = types.SimpleNamespace(device=lambda *a, **k: None,
+                                       cuda=types.SimpleNamespace(is_available=lambda: False))
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+    tf = tmp_path / "train.jsonl"
+    tf.write_text("[]")
+
+    args = argparse.Namespace(
+        train_features=tf,
+        val_features=None,
+        config=None,
+        dataset_dir=tmp_path,
+        epochs=1,
+        checkpoint=None,
+        plot_path=None,
+        cpu=True,
+    )
+
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(SystemExit) as exc:
+        rulegen_cli.cmd_ppo_train(args)
+
+    assert exc.value.code == 1
+    assert "Dataset directory missing required files clean.pt and dummy.pt" in caplog.text


### PR DESCRIPTION
## Summary
- add early dataset validation to `cmd_ppo_train`
- cover dataset check with a new unit test

## Testing
- `pytest -q tests/test_ppo_train_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4cd18f78832e814ff7bbf36efd41