### PR TITLE
Fix num_nodes batching bug

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -205,15 +205,15 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
         Graph whose node stores may lack ``num_nodes`` metadata.
     """
     for _, store in hetero.node_items():
-        if store.num_nodes is None:
-            n = None
+        n = store.num_nodes
+        if n is None:
             if len(store) > 0:
                 n = len(store)
             elif "edge_index" in store:
                 n = int(store["edge_index"].max()) + 1
             else:
                 n = 0
-            store.num_nodes = n
+        store.num_nodes = int(n)
 
 
 def fill_missing_node_feats(hetero: HeteroData, dim: int = 128) -> None:

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -311,12 +311,20 @@ class GraphDataset(Dataset):
         if isinstance(g, HeteroData):
             # Delegate to shared utility used by builders
             hetero_ensure_num_nodes(g)
+            # Ensure "num_nodes" exists in every node store's mapping
+            for _, store in g.node_items():
+                n = store.num_nodes
+                if n is None:
+                    n = 0
+                store.num_nodes = int(n)
         elif isinstance(g, Data):
-            if g.num_nodes is None:
+            n = g.num_nodes
+            if n is None:
                 if hasattr(g, "x"):
-                    g.num_nodes = g.x.size(0)
+                    n = g.x.size(0)
                 elif hasattr(g, "edge_index"):
-                    g.num_nodes = int(g.edge_index.max()) + 1
+                    n = int(g.edge_index.max()) + 1
                 else:
-                    g.num_nodes = 0
+                    n = 0
+            g.num_nodes = int(n)
         return g

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -128,3 +128,29 @@ def test_collate_sets_missing_num_nodes_data(tmp_path):
     batch = next(iter(loader))
 
     assert batch["graph"].num_nodes == 5
+
+
+def test_collate_handles_mixed_num_nodes_keys(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    from torch_geometric.data import Data
+
+    # g1 relies on inferred num_nodes from features (no key stored)
+    g1 = Data(x=torch.randn(2, 1))
+    # g2 explicitly stores num_nodes in its mapping
+    g2 = Data(edge_index=torch.tensor([[0, 1, 2], [1, 2, 0]]), num_nodes=3)
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    labels = tmp_path / "train" / "labels.csv"
+    labels.write_text("sha256,label\na,0\nb,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    from torch.utils.data import DataLoader
+    loader = DataLoader(ds, batch_size=2, collate_fn=GraphDataset.collate_fn)
+
+    batch = next(iter(loader))
+
+    assert batch["graph"].num_nodes == 5


### PR DESCRIPTION
## Summary
- ensure every node store explicitly sets `num_nodes`
- always assign `num_nodes` key in `GraphDataset`
- add regression test for mixed num_nodes representations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b51da7908832e8b31452a0293f0e2