### PR TITLE
Add warnings when trimming node feature tensors

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+import warnings
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
@@ -216,14 +217,40 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
         store.num_nodes = int(n)
 
 
-def fill_missing_node_feats(hetero: HeteroData, dim: int = 128) -> None:
-    """Pad missing node features with zeros after ensuring ``num_nodes``."""
+def fill_missing_node_feats(
+    hetero: HeteroData,
+    dim: int = 128,
+    *,
+    mode: str = "PAD",
+) -> None:
+    """Ensure every node store has a ``feat`` tensor matching ``num_nodes``.
+
+    Parameters
+    ----------
+    hetero : HeteroData
+        Graph to operate on.
+    dim : int
+        Feature dimension when creating missing tensors.
+    mode : {'PAD','TRIM'}
+        How to handle existing feature tensors that are longer than
+        ``num_nodes``.
+    """
 
     ensure_num_nodes(hetero)
 
-    for _, store in hetero.node_items():
+    for ntype, store in hetero.node_items():
+        n = store.num_nodes
         if "feat" not in store:
-            store.feat = torch.zeros((store.num_nodes, dim), dtype=torch.float32)
+            store.feat = torch.zeros((n, dim), dtype=torch.float32)
+            continue
+
+        if store.feat.size(0) > n and mode.upper() == "TRIM":
+            extra = store.feat.size(0) - n
+            warnings.warn(
+                f"{ntype}: trimming {extra} feature rows exceeding num_nodes",
+                stacklevel=2,
+            )
+            store.feat = store.feat[:n]
 
 
 

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -39,6 +39,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 from collections import defaultdict
 
 import torch.nn.functional as F
+import warnings
 
 import torch
 from torch.utils.data import Dataset
@@ -73,6 +74,8 @@ class GraphDataset(Dataset):
         각 그래프 로딩 후 호출할 transform.
     require_labels : bool, default=False
         ``True`` 로 설정하면 레이블이 없는 샘플은 로드 후 즉시 제거한다.
+    feat_mode : {'PAD','TRIM'}, default 'PAD'
+        Behaviour when feature tensors are longer than ``num_nodes``.
     """
 
     def __init__(
@@ -85,6 +88,7 @@ class GraphDataset(Dataset):
         label_col: str = "label",
         transform: Optional[Callable[[GraphT], GraphT]] = None,
         require_labels: bool = False,
+        feat_mode: str = "PAD",
     ) -> None:
         self.root = Path(root)
         self.split = split
@@ -93,6 +97,7 @@ class GraphDataset(Dataset):
         self.id_col = id_col
         self.label_col = label_col
         self.require_labels = require_labels
+        self.feat_mode = feat_mode.upper()
 
         # ── 파일 목록 & 레이블 로드 ───────────────────────────────
         self.samples: List[str] = sorted(p.stem for p in self.graph_dir.iterdir() if p.is_file())
@@ -128,8 +133,8 @@ class GraphDataset(Dataset):
     def __getitem__(self, idx: int) -> Tuple[GraphT, int | None, str]:
         sha = self.samples[idx]
         g = self._load_graph(sha)
-        g = self._ensure_x(g)
         g = self._ensure_num_nodes(g)
+        g = self._ensure_x(g)
         if self.transform:
             g = self.transform(g)
         label = self.labels.get(sha, None)
@@ -295,15 +300,39 @@ class GraphDataset(Dataset):
 
     # --------------------------------------------------------------
     def _ensure_x(self, g: GraphT) -> GraphT:
-        """Fill missing ``x`` attributes from ``feat`` in each node store."""
+        """Fill missing ``x`` attributes from ``feat`` and optionally trim."""
         if isinstance(g, HeteroData):
             for node_type in g.node_types:
                 store = g[node_type]
                 if "x" not in store and "feat" in store:
                     store.x = store.feat
+                if (
+                    self.feat_mode == "TRIM"
+                    and "x" in store
+                    and store.num_nodes is not None
+                    and store.x.size(0) > store.num_nodes
+                ):
+                    extra = store.x.size(0) - store.num_nodes
+                    warnings.warn(
+                        f"{node_type}: trimming {extra} feature rows exceeding num_nodes",
+                        stacklevel=2,
+                    )
+                    store.x = store.x[: store.num_nodes]
         elif isinstance(g, Data):
             if not hasattr(g, "x") and hasattr(g, "feat"):
                 g.x = g.feat
+            if (
+                self.feat_mode == "TRIM"
+                and hasattr(g, "x")
+                and g.num_nodes is not None
+                and g.x.size(0) > g.num_nodes
+            ):
+                extra = g.x.size(0) - g.num_nodes
+                warnings.warn(
+                    f"data: trimming {extra} feature rows exceeding num_nodes",
+                    stacklevel=2,
+                )
+                g.x = g.x[: g.num_nodes]
         return g
 
     def _ensure_num_nodes(self, g: GraphT) -> GraphT:

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -154,3 +154,25 @@ def test_collate_handles_mixed_num_nodes_keys(tmp_path):
     batch = next(iter(loader))
 
     assert batch["graph"].num_nodes == 5
+
+
+def test_dataset_trim_warning(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["n"].feat = torch.ones(3, 1)
+    g["n"].num_nodes = 1
+    torch.save(g, graph_dir / "a.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None, feat_mode="TRIM")
+
+    import warnings
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        g_loaded, _, _ = ds[0]
+
+    assert len(record) == 1
+    msg = str(record[0].message)
+    assert "n" in msg and "2" in msg
+    assert g_loaded["n"].x.size(0) == 1

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -48,6 +48,22 @@ def test_fill_missing_feats():
     assert torch.all(g["bb"].feat.eq(0))
 
 
+def test_fill_missing_feats_trim_warning():
+    g = HeteroData()
+    g["bb"].num_nodes = 1
+    g["bb"].feat = torch.ones(3, 2)
+
+    import warnings
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        fill_missing_node_feats(g, dim=2, mode="TRIM")
+
+    assert len(record) == 1
+    msg = str(record[0].message)
+    assert "bb" in msg and "2" in msg
+    assert g["bb"].feat.size(0) == 1
+
+
 def test_ensure_num_nodes_no_warning():
     g = Data(edge_index=torch.tensor([[0, 1], [1, 2]]), kind_id=torch.tensor([0, 1, 2]))
     g_norm = ASTNormalizer().normalize(g)


### PR DESCRIPTION
## Summary
- trim oversize feature tensors in `fill_missing_node_feats`
- allow `GraphDataset` to trim feature tensors when `feat_mode="TRIM"`
- issue warnings describing the node type and rows trimmed
- test warnings for trimming in both builder and dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b57f4b94c832ebd1088d257862205