### PR TITLE
Add feature-length handling policies and tests

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -24,6 +24,8 @@ import logging
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
+import torch.nn.functional as F
+
 import torch
 from torch_geometric.data import Data, HeteroData
 
@@ -216,14 +218,74 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
         store.num_nodes = int(n)
 
 
-def fill_missing_node_feats(hetero: HeteroData, dim: int = 128) -> None:
-    """Pad missing node features with zeros after ensuring ``num_nodes``."""
+def fill_missing_node_feats(
+    hetero: HeteroData,
+    dim: int = 128,
+    *,
+    policy: str = "error",
+    mask_attr: str = "feat_mask",
+) -> None:
+    """Ensure all node stores have ``feat`` tensors with length ``num_nodes``.
+
+    Parameters
+    ----------
+    hetero : HeteroData
+        Target graph.
+    dim : int, default 128
+        Feature dimension used when creating new tensors.
+    policy : {'error','expand','maskpad'}
+        Behaviour when an existing ``feat`` length does not match ``num_nodes``.
+        ``'error'``  – raise ``ValueError``.
+        ``'expand'`` – increase ``num_nodes`` to match ``feat`` length if the
+        tensor is longer.
+        ``'maskpad'`` – keep ``num_nodes`` but pad ``feat`` with zeros and add a
+        boolean mask named ``mask_attr`` marking real nodes.
+    mask_attr : str, default ``'feat_mask'``
+        Attribute name for masks when ``policy='maskpad'``.
+    """
 
     ensure_num_nodes(hetero)
 
-    for _, store in hetero.node_items():
+    pol = policy.lower()
+    for ntype, store in hetero.node_items():
+        # ------------------------------------------------------------------
+        # create feature tensor when missing
+        # ------------------------------------------------------------------
         if "feat" not in store:
             store.feat = torch.zeros((store.num_nodes, dim), dtype=torch.float32)
+            if pol == "maskpad":
+                store[mask_attr] = torch.ones(store.num_nodes, dtype=torch.long)
+            continue
+
+        feat = store.feat
+        n = int(store.num_nodes)
+        if feat.size(0) == n:
+            if pol == "maskpad" and mask_attr not in store:
+                store[mask_attr] = torch.ones(n, dtype=torch.long)
+            continue
+
+        if pol == "error":
+            raise ValueError(f"{ntype} feat rows={feat.size(0)} != num_nodes={n}")
+
+        if pol == "expand" and feat.size(0) > n:
+            store.num_nodes = feat.size(0)
+            if mask_attr in store:
+                del store[mask_attr]
+            continue
+
+        if pol == "maskpad" and feat.size(0) <= n:
+            pad = n - feat.size(0)
+            mask = torch.cat(
+                [torch.ones(feat.size(0)), torch.zeros(pad)], dim=0
+            ).to(torch.long)
+            store.feat = F.pad(feat, (0, 0, 0, pad))
+            store[mask_attr] = mask
+            continue
+
+        # Fallback: unsupported combination
+        raise ValueError(
+            f"Unsupported feat/num_nodes mismatch for policy '{policy}'"
+        )
 
 
 

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -295,15 +295,36 @@ class GraphDataset(Dataset):
 
     # --------------------------------------------------------------
     def _ensure_x(self, g: GraphT) -> GraphT:
-        """Fill missing ``x`` attributes from ``feat`` in each node store."""
+        """Ensure ``x`` exists and matches ``num_nodes`` length."""
+
         if isinstance(g, HeteroData):
             for node_type in g.node_types:
                 store = g[node_type]
-                if "x" not in store and "feat" in store:
-                    store.x = store.feat
+                x = store.get("x")
+                if x is None and "feat" in store:
+                    x = store.feat
+                n = store.num_nodes
+                if isinstance(x, torch.Tensor) and n is not None:
+                    if x.size(0) > n:
+                        x = x[:n]
+                    elif x.size(0) < n:
+                        pad = n - x.size(0)
+                        x = F.pad(x, (0, 0, 0, pad))
+                if x is not None:
+                    store.x = x
         elif isinstance(g, Data):
-            if not hasattr(g, "x") and hasattr(g, "feat"):
-                g.x = g.feat
+            x = getattr(g, "x", None)
+            if x is None and hasattr(g, "feat"):
+                x = g.feat
+            n = g.num_nodes
+            if isinstance(x, torch.Tensor) and n is not None:
+                if x.size(0) > n:
+                    x = x[:n]
+                elif x.size(0) < n:
+                    pad = n - x.size(0)
+                    x = F.pad(x, (0, 0, 0, pad))
+            if x is not None:
+                g.x = x
         return g
 
     def _ensure_num_nodes(self, g: GraphT) -> GraphT:

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -154,3 +154,28 @@ def test_collate_handles_mixed_num_nodes_keys(tmp_path):
     batch = next(iter(loader))
 
     assert batch["graph"].num_nodes == 5
+
+
+def test_ensure_x_trims_and_pads(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    from torch_geometric.data import Data
+
+    # longer than num_nodes → trimmed
+    g1 = Data(feat=torch.tensor([[0.0], [1.0], [2.0]]), num_nodes=2)
+    # shorter than num_nodes → padded
+    g2 = Data(feat=torch.tensor([[5.0]]), num_nodes=2)
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    g_a, _, _ = ds[0]
+    g_b, _, _ = ds[1]
+
+    assert g_a.x.shape == (2, 1)
+    assert torch.allclose(g_a.x.squeeze(), torch.tensor([0.0, 1.0]))
+
+    assert g_b.x.shape == (2, 1)
+    assert torch.allclose(g_b.x.squeeze(), torch.tensor([5.0, 0.0]))

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -66,3 +66,32 @@ def test_ensure_num_nodes_no_warning():
         warnings.simplefilter("always")
         _ = len(hetero["token"])
     assert not record
+
+
+def test_fill_missing_feats_error_policy():
+    g = HeteroData()
+    g["n"].num_nodes = 2
+    g["n"].feat = torch.zeros(3, 1)
+    with pytest.raises(ValueError):
+        fill_missing_node_feats(g, dim=1, policy="error")
+
+
+def test_fill_missing_feats_expand_policy():
+    g = HeteroData()
+    g["n"].num_nodes = 2
+    g["n"].feat = torch.randn(3, 1)
+    fill_missing_node_feats(g, dim=1, policy="expand")
+    assert g["n"].num_nodes == 3
+    assert g["n"].feat.shape == (3, 1)
+
+
+def test_fill_missing_feats_maskpad_policy():
+    g = HeteroData()
+    g["n"].num_nodes = 4
+    g["n"].feat = torch.ones(2, 1)
+    fill_missing_node_feats(g, dim=1, policy="maskpad")
+    assert g["n"].num_nodes == 4
+    assert g["n"].feat.shape == (4, 1)
+    assert torch.all(g["n"].feat[:2].eq(1))
+    assert torch.all(g["n"].feat[2:].eq(0))
+    assert torch.equal(g["n"].feat_mask, torch.tensor([1, 1, 0, 0], dtype=torch.long))


### PR DESCRIPTION
## Summary
- handle feature/num_nodes mismatch with new policies in `fill_missing_node_feats`
- trim or pad node features in `GraphDataset._ensure_x`
- test ERROR/EXPAND/MASKPAD policies
- test loader trimming/padding of node features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b57f3ebc8832eabdd3e07cd8241bb