### PR TITLE
Add placeholder tests for future policies

### DIFF
--- a/tests/test_graph_dataset_loader.py
+++ b/tests/test_graph_dataset_loader.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import Data
+
+from src.graphs.dataset.graph_dataset import GraphDataset
+
+@pytest.mark.xfail(reason="_ensure_x trimming/padding not implemented")
+def test_ensure_x_trim_pad(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = Data(feat=torch.randn(3, 2))
+    g.num_nodes = 2
+    torch.save(g, graph_dir / "a.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    loaded, _, _ = ds[0]
+
+    assert loaded.x.size(0) == 2

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -66,3 +66,31 @@ def test_ensure_num_nodes_no_warning():
         warnings.simplefilter("always")
         _ = len(hetero["token"])
     assert not record
+@pytest.mark.xfail(reason="policy not implemented")
+def test_num_nodes_error_policy():
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 1)
+    g["n"].num_nodes = 1  # mismatch
+    with pytest.raises(ValueError):
+        ensure_num_nodes(g, policy="ERROR")
+
+
+@pytest.mark.xfail(reason="policy not implemented")
+def test_num_nodes_expand_policy():
+    g = HeteroData()
+    g["n"].x = torch.randn(3, 1)
+    g["n"].num_nodes = 1
+    ensure_num_nodes(g, policy="EXPAND")
+    assert g["n"].num_nodes == 3
+
+
+@pytest.mark.xfail(reason="policy not implemented")
+def test_num_nodes_maskpad_policy():
+    g = HeteroData()
+    g["n"].x = torch.randn(3, 1)
+    g["n"].num_nodes = 1
+    ensure_num_nodes(g, policy="MASKPAD")
+    assert g["n"].num_nodes == 3
+    assert torch.equal(g["n"].x[:1], g["n"].x[:1])
+    assert torch.all(g["n"].mask[:1])
+    assert not torch.any(g["n"].mask[1:])


### PR DESCRIPTION
## Summary
- add xfail tests for unimplemented `ensure_num_nodes` policies
- add xfail test for dataset loader `_ensure_x` trimming/padding behaviour

## Testing
- `pytest -q tests/test_hetero_builder.py tests/test_graph_dataset_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_685b5a9ee648832e803d2faa3fa902da