### PR TITLE
Add OverLengthPolicy for handling node feature length

### DIFF
--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -240,10 +240,19 @@ def run_json(args: argparse.Namespace) -> None:
 @register_stage("graphs")
 def run_graphs(args: argparse.Namespace) -> None:
     """Stage 3 – View 통합 → Hetero Graph."""
-    from src.graphs.builders.hetero_builder import build_hetero_dataset
+    from src.graphs.builders.hetero_builder import (
+        build_hetero_dataset,
+        OverLengthPolicy,
+    )
 
     logger = _get_logger(args.log_level)
-    logger.info("[GRAPHS] rebuild=%s  normalise=%s  with_feats=%s", args.rebuild, args.normalise, args.with_feats)
+    logger.info(
+        "[GRAPHS] rebuild=%s  normalise=%s  with_feats=%s  policy=%s",
+        args.rebuild,
+        args.normalise,
+        args.with_feats,
+        args.over_length_policy,
+    )
     try:
         hetero_dir = Path(args.out_dir, "data", "hetero")
         ensure_dir(hetero_dir)
@@ -254,6 +263,7 @@ def run_graphs(args: argparse.Namespace) -> None:
             rebuild=args.rebuild,
             workers=args.workers,
             with_feats=args.with_feats,
+            over_length_policy=OverLengthPolicy(args.over_length_policy),
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Graphs stage failed")
@@ -333,6 +343,7 @@ def run_all(args: argparse.Namespace) -> None:
         "normalise": False,
         "rebuild": False,
         "with_feats": False,
+        "over_length_policy": "trim",
         "strategy": "time",
         "val_ratio": 0.1,
         "test_ratio": 0.1,
@@ -404,6 +415,12 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--normalise", action="store_true")
     p.add_argument("--rebuild", action="store_true")
     p.add_argument("--with-feats", action="store_true", help="Pad missing node features")
+    p.add_argument(
+        "--over-length-policy",
+        default="trim",
+        choices=["error", "trim", "expand", "maskpad"],
+        help="How to handle feature tensors longer than num_nodes",
+    )
     p.set_defaults(func=run_graphs)
 
     # ---------------- splits ---------------- #
@@ -434,6 +451,12 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--normalise", action="store_true", help="Normalise features")
     p.add_argument("--rebuild", action="store_true", help="Rebuild existing graphs")
     p.add_argument("--with-feats", action="store_true", help="Pad missing node features")
+    p.add_argument(
+        "--over-length-policy",
+        default="trim",
+        choices=["error", "trim", "expand", "maskpad"],
+        help="How to handle feature tensors longer than num_nodes",
+    )
     p.add_argument("--strategy", default="time", choices=["time", "stratified", "random"],
                    help="Splitting strategy")
     p.add_argument("--val-ratio", type=float, default=0.1, help="Validation split ratio")

--- a/src/graphs/__init__.py
+++ b/src/graphs/__init__.py
@@ -34,6 +34,7 @@ from .normalizers import get_normalizer, available as norms_available
 # builders
 from .builders import (
     HeteroGraphBuilder,
+    OverLengthPolicy,
     ViewMerger,
     relabel,
     sample_k_hop,
@@ -90,6 +91,7 @@ __all__: List[str] = [
     "get_normalizer",
     # builders
     "HeteroGraphBuilder",
+    "OverLengthPolicy",
     "ViewMerger",
     "relabel",
     "sample_k_hop",

--- a/src/graphs/builders/__init__.py
+++ b/src/graphs/builders/__init__.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import List
 
 # 핵심 빌더
-from .hetero_builder import HeteroGraphBuilder
+from .hetero_builder import HeteroGraphBuilder, OverLengthPolicy
 from .view_merger import ViewMerger
 
 # 유틸리티
@@ -43,6 +43,7 @@ from .graph_sampler import (
 __all__: List[str] = [
     # builders
     "HeteroGraphBuilder",
+    "OverLengthPolicy",
     "ViewMerger",
     # relabel
     "relabel",

--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -23,6 +23,7 @@ import itertools
 import logging
 from collections import defaultdict
 from typing import Dict, List, Tuple
+from enum import Enum
 
 import torch
 from torch_geometric.data import Data, HeteroData
@@ -35,6 +36,15 @@ from ..utils import get_logger
 # ────────────────────────────────────────────────────────────────
 _ViewT = Data | HeteroData
 _NodeKey = Tuple[str, int]  # (node_type, local_id)
+
+
+class OverLengthPolicy(str, Enum):
+    """Policy for handling feature tensors longer than ``num_nodes``."""
+
+    ERROR = "error"  # raise ValueError
+    TRIM = "trim"  # slice features to num_nodes
+    EXPAND = "expand"  # grow num_nodes to feature length
+    MASKPAD = "maskpad"  # keep length and store ``node_mask``
 
 
 class HeteroGraphBuilder:
@@ -216,14 +226,39 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
         store.num_nodes = int(n)
 
 
-def fill_missing_node_feats(hetero: HeteroData, dim: int = 128) -> None:
-    """Pad missing node features with zeros after ensuring ``num_nodes``."""
+def fill_missing_node_feats(
+    hetero: HeteroData,
+    dim: int = 128,
+    *,
+    policy: OverLengthPolicy = OverLengthPolicy.TRIM,
+) -> None:
+    """Pad missing node features and resolve length mismatches."""
 
     ensure_num_nodes(hetero)
 
-    for _, store in hetero.node_items():
+    for ntype, store in hetero.node_items():
         if "feat" not in store:
             store.feat = torch.zeros((store.num_nodes, dim), dtype=torch.float32)
+            continue
+
+        feat = store.feat
+        n = store.num_nodes or 0
+        if feat.size(0) < n:
+            pad = torch.zeros((n - feat.size(0), feat.size(1)), dtype=feat.dtype)
+            store.feat = torch.cat([feat, pad], dim=0)
+        elif feat.size(0) > n:
+            if policy == OverLengthPolicy.ERROR:
+                raise ValueError(
+                    f"{ntype} feat rows {feat.size(0)} exceed num_nodes {n}"
+                )
+            if policy == OverLengthPolicy.TRIM:
+                store.feat = feat[:n]
+            elif policy == OverLengthPolicy.EXPAND:
+                store.num_nodes = feat.size(0)
+            elif policy == OverLengthPolicy.MASKPAD:
+                mask = torch.zeros(feat.size(0), dtype=torch.bool)
+                mask[:n] = True
+                store.node_mask = mask
 
 
 
@@ -238,6 +273,7 @@ def _process_one(
     log_level: int,
     with_feats: bool = False,
     feat_dim: int = 1,
+    policy: OverLengthPolicy = OverLengthPolicy.TRIM,
 ) -> None:
     """Single sample processing for :func:`build_hetero_dataset`."""
     log = get_logger("builder.dataset", log_level)
@@ -266,7 +302,7 @@ def _process_one(
     hetero = builder.build()
     ensure_num_nodes(hetero)
     if with_feats:
-        fill_missing_node_feats(hetero, feat_dim)
+        fill_missing_node_feats(hetero, feat_dim, policy=policy)
     torch.save(hetero, out_path)
 
 def build_hetero_dataset(
@@ -281,6 +317,7 @@ def build_hetero_dataset(
     log_level : int             = logging.INFO,
     with_feats: bool            = False,
     feat_dim  : int             = 1,
+    over_length_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
 ) -> None:
     """
     data/views/<view>/<sha>.json → data/hetero/<sha>.pt   일괄 변환.
@@ -318,6 +355,7 @@ def build_hetero_dataset(
         log_level=log_level,
         with_feats=with_feats,
         feat_dim=feat_dim,
+        policy=over_length_policy,
     )
 
     # ── 3. 실행 (병렬 or 직렬) ───────────────────────────────────────────

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -44,7 +44,10 @@ import torch
 from torch.utils.data import Dataset
 from torch_geometric.data import Batch, Data, HeteroData
 
-from ..builders.hetero_builder import ensure_num_nodes as hetero_ensure_num_nodes
+from ..builders.hetero_builder import (
+    ensure_num_nodes as hetero_ensure_num_nodes,
+    OverLengthPolicy,
+)
 
 from ..loaders.factory import get_loader   # fallback json 로드용
 from ..utils import get_logger
@@ -85,6 +88,7 @@ class GraphDataset(Dataset):
         label_col: str = "label",
         transform: Optional[Callable[[GraphT], GraphT]] = None,
         require_labels: bool = False,
+        over_length_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
     ) -> None:
         self.root = Path(root)
         self.split = split
@@ -93,6 +97,7 @@ class GraphDataset(Dataset):
         self.id_col = id_col
         self.label_col = label_col
         self.require_labels = require_labels
+        self.over_length_policy = over_length_policy
 
         # ── 파일 목록 & 레이블 로드 ───────────────────────────────
         self.samples: List[str] = sorted(p.stem for p in self.graph_dir.iterdir() if p.is_file())
@@ -128,7 +133,7 @@ class GraphDataset(Dataset):
     def __getitem__(self, idx: int) -> Tuple[GraphT, int | None, str]:
         sha = self.samples[idx]
         g = self._load_graph(sha)
-        g = self._ensure_x(g)
+        g = self._ensure_x(g, self.over_length_policy)
         g = self._ensure_num_nodes(g)
         if self.transform:
             g = self.transform(g)
@@ -294,16 +299,50 @@ class GraphDataset(Dataset):
         raise FileNotFoundError(f"graph file for '{sha}' not found")
 
     # --------------------------------------------------------------
-    def _ensure_x(self, g: GraphT) -> GraphT:
-        """Fill missing ``x`` attributes from ``feat`` in each node store."""
+    def _ensure_x(
+        self, g: GraphT, policy: OverLengthPolicy = OverLengthPolicy.TRIM
+    ) -> GraphT:
+        """Fill missing ``x`` and resolve length mismatches."""
         if isinstance(g, HeteroData):
             for node_type in g.node_types:
                 store = g[node_type]
                 if "x" not in store and "feat" in store:
                     store.x = store.feat
+                if "x" in store and store.num_nodes is not None:
+                    x = store.x
+                    n = store.num_nodes
+                    if x.size(0) > n:
+                        if policy == OverLengthPolicy.ERROR:
+                            raise ValueError(
+                                f"{node_type} x rows {x.size(0)} exceed num_nodes {n}"
+                            )
+                        if policy == OverLengthPolicy.TRIM:
+                            store.x = x[:n]
+                        elif policy == OverLengthPolicy.EXPAND:
+                            store.num_nodes = x.size(0)
+                        elif policy == OverLengthPolicy.MASKPAD:
+                            mask = torch.zeros(x.size(0), dtype=torch.bool)
+                            mask[:n] = True
+                            store.node_mask = mask
         elif isinstance(g, Data):
             if not hasattr(g, "x") and hasattr(g, "feat"):
                 g.x = g.feat
+            if hasattr(g, "x") and g.num_nodes is not None:
+                x = g.x
+                n = g.num_nodes
+                if x.size(0) > n:
+                    if policy == OverLengthPolicy.ERROR:
+                        raise ValueError(
+                            f"x rows {x.size(0)} exceed num_nodes {n}"
+                        )
+                    if policy == OverLengthPolicy.TRIM:
+                        g.x = x[:n]
+                    elif policy == OverLengthPolicy.EXPAND:
+                        g.num_nodes = x.size(0)
+                    elif policy == OverLengthPolicy.MASKPAD:
+                        mask = torch.zeros(x.size(0), dtype=torch.bool)
+                        mask[:n] = True
+                        g.node_mask = mask
         return g
 
     def _ensure_num_nodes(self, g: GraphT) -> GraphT:


### PR DESCRIPTION
## Summary
- introduce `OverLengthPolicy` enum for feature-length mismatches
- expand `fill_missing_node_feats` with policy handling
- allow `GraphDataset` to handle over-length features via policy
- expose policy through preprocessing CLI
- export policy in package initializers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b57f54dc0832ea261f2dd7aad4b79