### PR TITLE
Implement OverLengthPolicy handling

### DIFF
--- a/configs/res_gcl.yaml
+++ b/configs/res_gcl.yaml
@@ -6,6 +6,7 @@ run:
 
 data:
   root: "data/hetero/"
+  over_length_policy: "TRIM"
   batch_size: 128
   certified_radius: 2            ## r ≥ 2 보장 목표
   num_workers: 4

--- a/configs/self_gcl.yaml
+++ b/configs/self_gcl.yaml
@@ -6,6 +6,7 @@ run:
 
 data:
   root: "data/hetero/"
+  over_length_policy: "TRIM"
   view_pairs: ["ast", "cfg"]    ## 증강에 사용할 뷰 쌍
   batch_size: 256
   num_workers: 8

--- a/configs/sup_con.yaml
+++ b/configs/sup_con.yaml
@@ -7,6 +7,7 @@ run:
 data:
   split_file: "data/splits/time_split_2024.json"
   batch_size: 512                ## 더 큰 배치로 NT-Xent 안정화
+  over_length_policy: "TRIM"
 
 loss:
   type: "supcon"

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -13,6 +13,8 @@ import multiprocessing as mp
 import os
 import sys
 from pathlib import Path
+
+from src.graphs.builders import OverLengthPolicy
 from typing import Callable, Dict, Sequence
 
 # ────────────────────────────────────────────────────────────────
@@ -243,7 +245,13 @@ def run_graphs(args: argparse.Namespace) -> None:
     from src.graphs.builders.hetero_builder import build_hetero_dataset
 
     logger = _get_logger(args.log_level)
-    logger.info("[GRAPHS] rebuild=%s  normalise=%s  with_feats=%s", args.rebuild, args.normalise, args.with_feats)
+    logger.info(
+        "[GRAPHS] rebuild=%s  normalise=%s  with_feats=%s  feat_policy=%s",
+        args.rebuild,
+        args.normalise,
+        args.with_feats,
+        args.feat_policy,
+    )
     try:
         hetero_dir = Path(args.out_dir, "data", "hetero")
         ensure_dir(hetero_dir)
@@ -254,6 +262,7 @@ def run_graphs(args: argparse.Namespace) -> None:
             rebuild=args.rebuild,
             workers=args.workers,
             with_feats=args.with_feats,
+            feat_policy=OverLengthPolicy[args.feat_policy],
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Graphs stage failed")
@@ -333,6 +342,7 @@ def run_all(args: argparse.Namespace) -> None:
         "normalise": False,
         "rebuild": False,
         "with_feats": False,
+        "feat_policy": "TRIM",
         "strategy": "time",
         "val_ratio": 0.1,
         "test_ratio": 0.1,
@@ -404,6 +414,12 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--normalise", action="store_true")
     p.add_argument("--rebuild", action="store_true")
     p.add_argument("--with-feats", action="store_true", help="Pad missing node features")
+    p.add_argument(
+        "--feat-policy",
+        choices=["ERROR", "TRIM", "EXPAND", "MASKPAD"],
+        default="TRIM",
+        help="Policy for over-length node features",
+    )
     p.set_defaults(func=run_graphs)
 
     # ---------------- splits ---------------- #
@@ -434,6 +450,12 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p.add_argument("--normalise", action="store_true", help="Normalise features")
     p.add_argument("--rebuild", action="store_true", help="Rebuild existing graphs")
     p.add_argument("--with-feats", action="store_true", help="Pad missing node features")
+    p.add_argument(
+        "--feat-policy",
+        choices=["ERROR", "TRIM", "EXPAND", "MASKPAD"],
+        default="TRIM",
+        help="Policy for over-length node features",
+    )
     p.add_argument("--strategy", default="time", choices=["time", "stratified", "random"],
                    help="Splitting strategy")
     p.add_argument("--val-ratio", type=float, default=0.1, help="Validation split ratio")

--- a/src/graphs/builders/__init__.py
+++ b/src/graphs/builders/__init__.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import List
 
 # 핵심 빌더
-from .hetero_builder import HeteroGraphBuilder
+from .hetero_builder import HeteroGraphBuilder, OverLengthPolicy
 from .view_merger import ViewMerger
 
 # 유틸리티
@@ -52,4 +52,5 @@ __all__: List[str] = [
     "sample_edge_drop",
     "sainth_loader",
     "cluster_loader",
+    "OverLengthPolicy",
 ]

--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -37,6 +37,15 @@ _ViewT = Data | HeteroData
 _NodeKey = Tuple[str, int]  # (node_type, local_id)
 
 
+class OverLengthPolicy(Enum):
+    """Behaviour when feature rows exceed ``num_nodes``."""
+
+    ERROR = "ERROR"
+    TRIM = "TRIM"
+    EXPAND = "EXPAND"
+    MASKPAD = "MASKPAD"
+
+
 class HeteroGraphBuilder:
     """
     여러 정규화된 뷰 그래프를 추가 → 최종 HeteroData 로 병합.
@@ -190,6 +199,7 @@ class HeteroGraphBuilder:
 from pathlib import Path
 import multiprocessing as mp
 from functools import partial
+from enum import Enum
 
 from ..loaders.factory    import get_loader          # view JSON → (Hetero)Data
 from ..normalizers.base   import get_normalizer      # optional schema normaliser
@@ -216,14 +226,47 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
         store.num_nodes = int(n)
 
 
-def fill_missing_node_feats(hetero: HeteroData, dim: int = 128) -> None:
-    """Pad missing node features with zeros after ensuring ``num_nodes``."""
+def fill_missing_node_feats(
+    hetero: HeteroData,
+    dim: int = 128,
+    *,
+    policy: OverLengthPolicy = OverLengthPolicy.TRIM,
+) -> None:
+    """Pad missing node features with zeros after ensuring ``num_nodes``.
+
+    Parameters
+    ----------
+    hetero : HeteroData
+    dim : int
+        Feature dimension to use when a node store lacks ``feat``.
+    policy : OverLengthPolicy
+        How to handle cases where existing features are longer than
+        ``num_nodes``.
+    """
 
     ensure_num_nodes(hetero)
 
     for _, store in hetero.node_items():
         if "feat" not in store:
             store.feat = torch.zeros((store.num_nodes, dim), dtype=torch.float32)
+            continue
+
+        n = store.num_nodes
+        feat_len = store.feat.size(0)
+        if n is not None and feat_len > n:
+            if policy is OverLengthPolicy.ERROR:
+                raise ValueError(
+                    f"{feat_len} > num_nodes({n}) for node type; policy=ERROR"
+                )
+            if policy is OverLengthPolicy.TRIM:
+                store.feat = store.feat[:n]
+            elif policy is OverLengthPolicy.EXPAND:
+                store.num_nodes = feat_len
+            elif policy is OverLengthPolicy.MASKPAD:
+                mask = torch.zeros(feat_len, dtype=torch.bool)
+                mask[:n] = True
+                store.mask = mask
+                store.num_nodes = feat_len
 
 
 
@@ -238,6 +281,7 @@ def _process_one(
     log_level: int,
     with_feats: bool = False,
     feat_dim: int = 1,
+    feat_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
 ) -> None:
     """Single sample processing for :func:`build_hetero_dataset`."""
     log = get_logger("builder.dataset", log_level)
@@ -266,7 +310,7 @@ def _process_one(
     hetero = builder.build()
     ensure_num_nodes(hetero)
     if with_feats:
-        fill_missing_node_feats(hetero, feat_dim)
+        fill_missing_node_feats(hetero, feat_dim, policy=feat_policy)
     torch.save(hetero, out_path)
 
 def build_hetero_dataset(
@@ -281,6 +325,7 @@ def build_hetero_dataset(
     log_level : int             = logging.INFO,
     with_feats: bool            = False,
     feat_dim  : int             = 1,
+    feat_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
 ) -> None:
     """
     data/views/<view>/<sha>.json → data/hetero/<sha>.pt   일괄 변환.
@@ -318,6 +363,7 @@ def build_hetero_dataset(
         log_level=log_level,
         with_feats=with_feats,
         feat_dim=feat_dim,
+        feat_policy=feat_policy,
     )
 
     # ── 3. 실행 (병렬 or 직렬) ───────────────────────────────────────────

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -44,7 +44,10 @@ import torch
 from torch.utils.data import Dataset
 from torch_geometric.data import Batch, Data, HeteroData
 
-from ..builders.hetero_builder import ensure_num_nodes as hetero_ensure_num_nodes
+from ..builders.hetero_builder import (
+    ensure_num_nodes as hetero_ensure_num_nodes,
+    OverLengthPolicy,
+)
 
 from ..loaders.factory import get_loader   # fallback json 로드용
 from ..utils import get_logger
@@ -73,6 +76,8 @@ class GraphDataset(Dataset):
         각 그래프 로딩 후 호출할 transform.
     require_labels : bool, default=False
         ``True`` 로 설정하면 레이블이 없는 샘플은 로드 후 즉시 제거한다.
+    over_length_policy : OverLengthPolicy, default=OverLengthPolicy.TRIM
+        Handling strategy when node features exceed ``num_nodes``.
     """
 
     def __init__(
@@ -85,6 +90,7 @@ class GraphDataset(Dataset):
         label_col: str = "label",
         transform: Optional[Callable[[GraphT], GraphT]] = None,
         require_labels: bool = False,
+        over_length_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
     ) -> None:
         self.root = Path(root)
         self.split = split
@@ -93,6 +99,7 @@ class GraphDataset(Dataset):
         self.id_col = id_col
         self.label_col = label_col
         self.require_labels = require_labels
+        self.over_length_policy = over_length_policy
 
         # ── 파일 목록 & 레이블 로드 ───────────────────────────────
         self.samples: List[str] = sorted(p.stem for p in self.graph_dir.iterdir() if p.is_file())
@@ -128,7 +135,7 @@ class GraphDataset(Dataset):
     def __getitem__(self, idx: int) -> Tuple[GraphT, int | None, str]:
         sha = self.samples[idx]
         g = self._load_graph(sha)
-        g = GraphDataset._ensure_x(g)
+        g = GraphDataset._ensure_x(g, policy=self.over_length_policy)
         g = GraphDataset._ensure_num_nodes(g)
         if self.transform:
             g = self.transform(g)
@@ -295,16 +302,44 @@ class GraphDataset(Dataset):
 
     # --------------------------------------------------------------
     @staticmethod
-    def _ensure_x(g: GraphT) -> GraphT:
-        """Fill missing ``x`` attributes from ``feat`` in each node store."""
+    def _ensure_x(g: GraphT, *, policy: OverLengthPolicy = OverLengthPolicy.TRIM) -> GraphT:
+        """Fill missing ``x`` attributes from ``feat`` in each node store.
+
+        Parameters
+        ----------
+        policy : OverLengthPolicy
+            How to handle cases where ``x`` or ``feat`` has more rows than
+            ``num_nodes``.
+        """
+
+        def _handle(store: Data | HeteroData, attr: str, n: int) -> None:
+            tensor = getattr(store, attr)
+            if tensor.size(0) <= n:
+                return
+            if policy is OverLengthPolicy.ERROR:
+                raise ValueError(f"{tensor.size(0)} > num_nodes({n})")
+            if policy is OverLengthPolicy.TRIM:
+                setattr(store, attr, tensor[:n])
+            elif policy is OverLengthPolicy.EXPAND:
+                store.num_nodes = tensor.size(0)
+            elif policy is OverLengthPolicy.MASKPAD:
+                mask = torch.zeros(tensor.size(0), dtype=torch.bool)
+                mask[:n] = True
+                setattr(store, "mask", mask)
+                store.num_nodes = tensor.size(0)
+
         if isinstance(g, HeteroData):
             for node_type in g.node_types:
                 store = g[node_type]
                 if "x" not in store and "feat" in store:
                     store.x = store.feat
+                if "x" in store and store.num_nodes is not None:
+                    _handle(store, "x", store.num_nodes)
         elif isinstance(g, Data):
             if not hasattr(g, "x") and hasattr(g, "feat"):
                 g.x = g.feat
+            if hasattr(g, "x") and getattr(g, "num_nodes", None) is not None:
+                _handle(g, "x", g.num_nodes)
         return g
 
     @staticmethod


### PR DESCRIPTION
## Summary
- add `OverLengthPolicy` enum for feature overflow handling
- extend `fill_missing_node_feats` with policy logic
- support policy in dataset loading via `GraphDataset._ensure_x`
- expose policy through preprocessing CLI and configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5c57ff7c832e94db0ab48a3c7feb