### PR TITLE
Add warnings for trimmed node features

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -23,6 +23,7 @@ import itertools
 import logging
 from collections import defaultdict
 from typing import Dict, List, Tuple
+import warnings
 
 import torch
 from torch_geometric.data import Data, HeteroData
@@ -216,14 +217,41 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
         store.num_nodes = int(n)
 
 
-def fill_missing_node_feats(hetero: HeteroData, dim: int = 128) -> None:
-    """Pad missing node features with zeros after ensuring ``num_nodes``."""
+def fill_missing_node_feats(
+    hetero: HeteroData,
+    dim: int = 128,
+    *,
+    policy: str = "PAD",
+) -> None:
+    """Pad missing node features with zeros after ensuring ``num_nodes``.
+
+    Parameters
+    ----------
+    hetero : HeteroData
+        Graph to modify in-place.
+    dim : int, default=128
+        Feature dimension to use when a node store lacks ``feat``.
+    policy : {'PAD', 'TRIM'}
+        How to handle feature length mismatches. ``TRIM`` will slice
+        extra rows and emit a warning, ``PAD`` will append zeros.
+    """
 
     ensure_num_nodes(hetero)
 
-    for _, store in hetero.node_items():
+    for ntype, store in hetero.node_items():
         if "feat" not in store:
             store.feat = torch.zeros((store.num_nodes, dim), dtype=torch.float32)
+            continue
+
+        rows = store.feat.size(0)
+        num = store.num_nodes or 0
+        if rows > num and policy == "TRIM":
+            excess = rows - num
+            warnings.warn(f"{ntype}: trimmed {excess} feature row(s)")
+            store.feat = store.feat[:num]
+        elif rows < num and policy == "PAD":
+            pad = torch.zeros((num - rows, store.feat.size(1)), dtype=store.feat.dtype)
+            store.feat = torch.cat([store.feat, pad])
 
 
 

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -37,6 +37,7 @@ import pickle
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 from collections import defaultdict
+import warnings
 
 import torch.nn.functional as F
 
@@ -295,16 +296,46 @@ class GraphDataset(Dataset):
 
     # --------------------------------------------------------------
     @staticmethod
-    def _ensure_x(g: GraphT) -> GraphT:
-        """Fill missing ``x`` attributes from ``feat`` in each node store."""
+    def _ensure_x(g: GraphT, *, policy: str = "TRIM") -> GraphT:
+        """Fill missing ``x`` attributes from ``feat`` in each node store.
+
+        Parameters
+        ----------
+        g : Data | HeteroData
+            Graph to modify in-place.
+        policy : {'TRIM', 'PAD'}
+            Behaviour when feature rows mismatch ``num_nodes``.
+        """
         if isinstance(g, HeteroData):
             for node_type in g.node_types:
                 store = g[node_type]
-                if "x" not in store and "feat" in store:
-                    store.x = store.feat
+                if ("feat" in store) and (store.get("x") is None):
+                    x = store.feat
+                    n = store.num_nodes
+                    if n is not None:
+                        rows = x.size(0)
+                        if rows > n and policy == "TRIM":
+                            excess = rows - n
+                            warnings.warn(f"{node_type}: trimmed {excess} feature row(s)")
+                            x = x[:n]
+                        elif rows < n and policy == "PAD":
+                            pad = torch.zeros((n - rows, x.size(1)), dtype=x.dtype)
+                            x = torch.cat([x, pad])
+                    store.x = x
         elif isinstance(g, Data):
-            if not hasattr(g, "x") and hasattr(g, "feat"):
-                g.x = g.feat
+            if getattr(g, "x", None) is None and hasattr(g, "feat"):
+                x = g.feat
+                n = getattr(g, "num_nodes", None)
+                if n is not None:
+                    rows = x.size(0)
+                    if rows > n and policy == "TRIM":
+                        excess = rows - n
+                        warnings.warn(f"data: trimmed {excess} feature row(s)")
+                        x = x[:n]
+                    elif rows < n and policy == "PAD":
+                        pad = torch.zeros((n - rows, x.size(1)), dtype=x.dtype)
+                        x = torch.cat([x, pad])
+                g.x = x
         return g
 
     @staticmethod

--- a/tests/test_graph_dataset_loader.py
+++ b/tests/test_graph_dataset_loader.py
@@ -8,7 +8,6 @@ from torch_geometric.data import Data
 
 from src.graphs.dataset.graph_dataset import GraphDataset
 
-@pytest.mark.xfail(reason="_ensure_x trimming/padding not implemented")
 def test_ensure_x_trim_pad(tmp_path):
     graph_dir = tmp_path / "train" / "graphs"
     graph_dir.mkdir(parents=True)
@@ -18,6 +17,7 @@ def test_ensure_x_trim_pad(tmp_path):
     torch.save(g, graph_dir / "a.pt")
 
     ds = GraphDataset(tmp_path, split="train", label_file=None)
-    loaded, _, _ = ds[0]
+    with pytest.warns(UserWarning, match="trimmed 1"):
+        loaded, _, _ = ds[0]
 
     assert loaded.x.size(0) == 2

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -48,6 +48,17 @@ def test_fill_missing_feats():
     assert torch.all(g["bb"].feat.eq(0))
 
 
+def test_fill_missing_feats_trim_warn():
+    g = HeteroData()
+    g["bb"].feat = torch.randn(3, 2)
+    g["bb"].num_nodes = 2
+
+    with pytest.warns(UserWarning, match="bb.*trimmed 1"):
+        fill_missing_node_feats(g, policy="TRIM")
+
+    assert g["bb"].feat.size(0) == 2
+
+
 def test_ensure_num_nodes_no_warning():
     g = Data(edge_index=torch.tensor([[0, 1], [1, 2]]), kind_id=torch.tensor([0, 1, 2]))
     g_norm = ASTNormalizer().normalize(g)


### PR DESCRIPTION
## Summary
- warn when trimming features in `fill_missing_node_feats`
- warn when trimming features in `GraphDataset._ensure_x`
- add new tests for trimming behaviour

## Testing
- `pytest tests/test_graph_dataset_loader.py tests/test_hetero_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685b5c279f24832e8bd65080b5b75153