### PR TITLE
Add warnings for trimmed features

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -19,6 +19,8 @@ HeteroGraphBuilder
 
 from __future__ import annotations
 
+import warnings
+
 import itertools
 import logging
 from collections import defaultdict
@@ -246,7 +248,7 @@ def fill_missing_node_feats(
 
     ensure_num_nodes(hetero)
 
-    for _, store in hetero.node_items():
+    for node_type, store in hetero.node_items():
         if "feat" not in store:
             store.feat = torch.zeros((store.num_nodes, dim), dtype=torch.float32)
             continue
@@ -259,6 +261,10 @@ def fill_missing_node_feats(
                     f"{feat_len} > num_nodes({n}) for node type; policy=ERROR"
                 )
             if policy is OverLengthPolicy.TRIM:
+                warnings.warn(
+                    f"{node_type}: trimmed {feat_len - n} row(s) from feat",
+                    RuntimeWarning,
+                )
                 store.feat = store.feat[:n]
             elif policy is OverLengthPolicy.EXPAND:
                 store.num_nodes = feat_len

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -36,6 +36,7 @@ import json
 import pickle
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
+import warnings
 from collections import defaultdict
 
 import torch.nn.functional as F
@@ -312,13 +313,17 @@ class GraphDataset(Dataset):
             ``num_nodes``.
         """
 
-        def _handle(store: Data | HeteroData, attr: str, n: int) -> None:
+        def _handle(store: Data | HeteroData, attr: str, n: int, node_type: str) -> None:
             tensor = getattr(store, attr)
             if tensor.size(0) <= n:
                 return
             if policy is OverLengthPolicy.ERROR:
                 raise ValueError(f"{tensor.size(0)} > num_nodes({n})")
             if policy is OverLengthPolicy.TRIM:
+                warnings.warn(
+                    f"{node_type}: trimmed {tensor.size(0) - n} row(s) from {attr}",
+                    RuntimeWarning,
+                )
                 setattr(store, attr, tensor[:n])
             elif policy is OverLengthPolicy.EXPAND:
                 store.num_nodes = tensor.size(0)
@@ -334,12 +339,12 @@ class GraphDataset(Dataset):
                 if "x" not in store and "feat" in store:
                     store.x = store.feat
                 if "x" in store and store.num_nodes is not None:
-                    _handle(store, "x", store.num_nodes)
+                    _handle(store, "x", store.num_nodes, node_type)
         elif isinstance(g, Data):
             if not hasattr(g, "x") and hasattr(g, "feat"):
                 g.x = g.feat
             if hasattr(g, "x") and getattr(g, "num_nodes", None) is not None:
-                _handle(g, "x", g.num_nodes)
+                _handle(g, "x", g.num_nodes, "Data")
         return g
 
     @staticmethod

--- a/tests/test_graph_dataset_loader.py
+++ b/tests/test_graph_dataset_loader.py
@@ -8,7 +8,7 @@ from torch_geometric.data import Data
 
 from src.graphs.dataset.graph_dataset import GraphDataset
 
-@pytest.mark.xfail(reason="_ensure_x trimming/padding not implemented")
+
 def test_ensure_x_trim_pad(tmp_path):
     graph_dir = tmp_path / "train" / "graphs"
     graph_dir.mkdir(parents=True)
@@ -18,6 +18,12 @@ def test_ensure_x_trim_pad(tmp_path):
     torch.save(g, graph_dir / "a.pt")
 
     ds = GraphDataset(tmp_path, split="train", label_file=None)
-    loaded, _, _ = ds[0]
+    import warnings
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        loaded, _, _ = ds[0]
 
     assert loaded.x.size(0) == 2
+    assert record
+    msg = str(record[0].message)
+    assert "Data" in msg or "data" in msg

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -10,6 +10,7 @@ from src.graphs.builders.hetero_builder import (
     HeteroGraphBuilder,
     fill_missing_node_feats,
     ensure_num_nodes,
+    OverLengthPolicy,
 )
 from src.graphs.normalizers.ast_norm import ASTNormalizer
 
@@ -46,6 +47,21 @@ def test_fill_missing_feats():
     assert "feat" in g["bb"]
     assert g["bb"].feat.shape == (2, 1)
     assert torch.all(g["bb"].feat.eq(0))
+
+
+def test_fill_missing_feats_warn_trim():
+    g = HeteroData()
+    g["n"].feat = torch.randn(3, 1)
+    g["n"].num_nodes = 2
+    import warnings
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        fill_missing_node_feats(g, dim=1, policy=OverLengthPolicy.TRIM)
+    assert record
+    msg = str(record[0].message)
+    assert "n" in msg
+    assert "1" in msg
+    assert g["n"].feat.size(0) == 2
 
 
 def test_ensure_num_nodes_no_warning():


### PR DESCRIPTION
## Summary
- warn when trimming oversized features in builder and dataset utilities
- test the new warnings in hetero builder and dataset loader

## Testing
- `pytest -q` *(fails: 17 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685b5e25e530832e9bb5579ac815c01b