### PR TITLE
Fix Enum import order causing preprocessing crash

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -24,6 +24,7 @@ import warnings
 import itertools
 import logging
 from collections import defaultdict
+from enum import Enum
 from typing import Dict, List, Tuple
 
 import torch
@@ -147,7 +148,9 @@ class HeteroGraphBuilder:
                             cols.append(torch.zeros(shape, dtype=ref_store[k].dtype))
                         else:  # list[str] 같은 python obj
                             cols.extend([None] * s.num_nodes)
-                merged_store[k] = torch.cat(cols) if isinstance(cols[0], torch.Tensor) else list(cols)
+                merged_store[k] = (
+                    torch.cat(cols) if isinstance(cols[0], torch.Tensor) else list(cols)
+                )
 
     # -----------------------------------------------------------
     def _merge_edge_stores(self, out: HeteroData) -> None:
@@ -155,10 +158,12 @@ class HeteroGraphBuilder:
         edge_index global remap + concat per (src,rel,dst) 키.
         """
         tmp_edges: Dict[Tuple[str, str, str], List[torch.Tensor]] = defaultdict(list)
-        tmp_attrs: Dict[Tuple[str, str, str], Dict[str, List[torch.Tensor]]] = defaultdict(lambda: defaultdict(list))
+        tmp_attrs: Dict[Tuple[str, str, str], Dict[str, List[torch.Tensor]]] = (
+            defaultdict(lambda: defaultdict(list))
+        )
 
         for view_name, g in self._views.items():
-            for (src_t, rel_t, dst_t) in g.edge_types:
+            for src_t, rel_t, dst_t in g.edge_types:
                 store = g[(src_t, rel_t, dst_t)]
                 # 로컬 -> 글로벌 id 변환
                 src, dst = store.edge_index
@@ -195,17 +200,18 @@ class HeteroGraphBuilder:
                     EDGE_REL_ID[key[1]],
                     dtype=torch.long,
                 )
+
+
 # ────────────────────────────────────────────────────────────────
 # 4. Convenience – batch-builder (views → hetero/*.pt)
 # ────────────────────────────────────────────────────────────────
 from pathlib import Path
 import multiprocessing as mp
 from functools import partial
-from enum import Enum
 
-from ..loaders.factory    import get_loader          # view JSON → (Hetero)Data
-from ..normalizers.base   import get_normalizer      # optional schema normaliser
-from ..utils              import tqdm_wrap, ensure_dir, set_random_seed
+from ..loaders.factory import get_loader  # view JSON → (Hetero)Data
+from ..normalizers.base import get_normalizer  # optional schema normaliser
+from ..utils import tqdm_wrap, ensure_dir, set_random_seed
 
 
 def ensure_num_nodes(hetero: HeteroData) -> None:
@@ -275,7 +281,6 @@ def fill_missing_node_feats(
                 store.num_nodes = feat_len
 
 
-
 def _process_one(
     sha: str,
     *,
@@ -319,18 +324,19 @@ def _process_one(
         fill_missing_node_feats(hetero, feat_dim, policy=feat_policy)
     torch.save(hetero, out_path)
 
+
 def build_hetero_dataset(
     *,
-    views_dir : Path,
+    views_dir: Path,
     hetero_dir: Path,
-    views     : Tuple[str, ...] = ("ast", "cfg", "fcg", "syscall"),
-    normalise : bool            = True,
-    rebuild   : bool            = False,
-    workers   : int | None      = 0,
-    seed      : int             = 42,
-    log_level : int             = logging.INFO,
-    with_feats: bool            = False,
-    feat_dim  : int             = 1,
+    views: Tuple[str, ...] = ("ast", "cfg", "fcg", "syscall"),
+    normalise: bool = True,
+    rebuild: bool = False,
+    workers: int | None = 0,
+    seed: int = 42,
+    log_level: int = logging.INFO,
+    with_feats: bool = False,
+    feat_dim: int = 1,
     feat_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
 ) -> None:
     """
@@ -373,7 +379,7 @@ def build_hetero_dataset(
     )
 
     # ── 3. 실행 (병렬 or 직렬) ───────────────────────────────────────────
-    iterable = tqdm_wrap(all_ids, desc="[hetero]")           # tqdm 없으면 no-op
+    iterable = tqdm_wrap(all_ids, desc="[hetero]")  # tqdm 없으면 no-op
     if workers and workers > 1:
         with mp.Pool(workers) as pool:
             list(pool.imap_unordered(process_one, iterable))


### PR DESCRIPTION
## Summary
- import `Enum` before defining `OverLengthPolicy`
- remove duplicate import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5fb5e51c832eaa1baa4c201ea770