### PR TITLE
Update NodeDrop num_nodes tracking

### DIFF
--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -91,7 +91,8 @@ class NodeDrop(SimpleAug, AugmentBase):
 
         if isinstance(sg, Data):
             p = self.keep_prob.get("*", 1.0)
-            self._drop_nodes_data(sg, p)
+            mask = self._drop_nodes_data(sg, p)
+            sg.num_nodes = int(mask.sum())
 
         elif isinstance(sg, HeteroData):
             # 1) 노드 타입별 keep-mask 및 인덱스 매핑 계산
@@ -126,7 +127,7 @@ class NodeDrop(SimpleAug, AugmentBase):
     # ------------------------------------------------------------------ #
     # 내부 유틸 (homogeneous) ------------------------------------------- #
     # ------------------------------------------------------------------ #
-    def _drop_nodes_data(self, data: Data, keep_p: float) -> None:
+    def _drop_nodes_data(self, data: Data, keep_p: float) -> torch.Tensor:
         """homogeneous Data용 노드 삭제 + 에지 갱신."""
         target_idx = 0 if self.target_node is not None else None
         mask, mapping = self._make_mask_mapping(
@@ -136,6 +137,7 @@ class NodeDrop(SimpleAug, AugmentBase):
         self._apply_node_mask(data, mask)
         # 에지 필터링 및 재인덱싱
         self._filter_edges(data, mapping, mapping)
+        return mask
 
     # ------------------------------------------------------------------ #
     # 마스크 & 매핑 생성 -------------------------------------------------- #
@@ -176,6 +178,7 @@ class NodeDrop(SimpleAug, AugmentBase):
                 continue
             if torch.is_tensor(val) and val.size(0) == num_nodes:
                 store[key] = val[mask]
+        store.num_nodes = int(mask.sum())
 
     # ------------------------------------------------------------------ #
     # 에지 필터 및 재인덱싱 --------------------------------------------- #

--- a/tests/test_node_drop.py
+++ b/tests/test_node_drop.py
@@ -1,0 +1,35 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+pytest.importorskip("numpy")
+
+import torch
+import numpy as np
+from torch_geometric.data import Data
+
+from src.augment.ops.drop_node import NodeDrop
+
+
+def test_node_drop_updates_num_nodes():
+    num_nodes = 10
+    g = Data(
+        x=torch.randn(num_nodes, 2),
+        edge_index=torch.stack(
+            [torch.arange(num_nodes - 1), torch.arange(1, num_nodes)],
+            dim=0,
+        ),
+        num_nodes=num_nodes,
+    )
+
+    aug = NodeDrop(keep_prob=0.5, seed=42)
+    result = aug(g)
+
+    rng = np.random.RandomState(42)
+    mask_np = rng.rand(num_nodes) < 0.5
+    if not mask_np.any():
+        mask_np[rng.randint(0, num_nodes)] = True
+    expected = int(mask_np.sum())
+
+    assert result.num_nodes == expected
+    assert result.num_nodes == result.x.size(0)


### PR DESCRIPTION
## Summary
- track remaining node count when applying NodeDrop
- return node mask from `_drop_nodes_data` so caller can update `num_nodes`
- add regression test for NodeDrop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b61f58a94832e897c3e174a31c21d