### PR TITLE
Support alias fields for rulegen FeatureMiner

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -192,9 +192,18 @@ class FeatureMiner:
         local_idx: int,
         meta: torch_geometric.data.Data,
     ) -> List[str]:
-        """
-        추가 도메인 feature 삽입을 원할 시 이 함수를 수정하여 보강(파일 경로, 레지스트리 키, URL, PE‐섹션 이름 등 추가 도메인 피처)
-        개별 노드에서 YARA·CAPA 후보 문자열 생성
+        """한 노드에서 YARA·CAPA 후보 문자열을 추출한다.
+
+        노드 메타필드는 다음 키 중 하나 이상을 가정한다.
+
+        - ``name`` / ``api``            : 함수 호출명
+        - ``value`` / ``string``        : 문자열 리터럴
+        - ``import`` / ``dll``          : 의존 DLL 이름
+        - ``bytes``                     : Raw byte 시퀀스
+        - ``syscall`` / ``name``        : 시스템 호출명
+
+        추가 도메인 feature 삽입을 원할 시 이 함수를 수정하여 보강
+        (파일 경로, 레지스트리 키, URL, PE‑섹션 이름 등).
         """
         candidates: List[str] = []
 
@@ -239,7 +248,7 @@ class FeatureMiner:
                 candidates.append(yara)
 
         # 3) import library
-        lib = _get("import")
+        lib = _get("import") or _get("dll")
         if isinstance(lib, str) and lib.lower().endswith(".dll"):
             candidates.append(f"import:{lib}")
 
@@ -251,8 +260,10 @@ class FeatureMiner:
                 candidates.append(f"byte[{len(byte_arr)}]:{hx}")
 
         # 5) 기타 Heuristic
-        #    예) ntype == 'syscall' etc.
+        #    예) ntype == 'syscall' 등
         syscall = _get("syscall")
+        if syscall is None and ntype == "syscall":
+            syscall = _get("name")
         if isinstance(syscall, str):
             candidates.append(f"syscall:{syscall}")
 

--- a/tests/test_feature_miner_alt_fields.py
+++ b/tests/test_feature_miner_alt_fields.py
@@ -1,0 +1,26 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_miner_accepts_dll_field():
+    g = HeteroData()
+    g["import"].x = torch.zeros(1, 1)
+    g["import"].dll = ["WS2_32.dll"]
+    sal = torch.tensor([0.9])
+    feats = FeatureMiner(top_k=1)(g, sal)
+    assert "import:WS2_32.dll" in feats
+
+
+def test_miner_accepts_name_as_syscall():
+    g = HeteroData()
+    g["syscall"].x = torch.zeros(1, 1)
+    g["syscall"].name = ["NtCreateFile"]
+    sal = torch.tensor([0.8])
+    feats = FeatureMiner(top_k=1)(g, sal)
+    assert "syscall:NtCreateFile" in feats


### PR DESCRIPTION
## Summary
- expand `_extract_candidates` to handle `dll` and `name` fields
- describe expected node attributes in docstring
- add tests for alias fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b66cb17f0832e86b193a8d31c87ba