### PR TITLE
Improve FeatureMiner alias lookup

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -198,31 +198,42 @@ class FeatureMiner:
         """
         candidates: List[str] = []
 
+        alias_map = {
+            "name": ["name", "api"],
+            "value": ["value", "string"],
+            "import": ["import", "import_"],
+            "bytes": ["bytes"],
+            "syscall": ["syscall", "syscall_name"],
+        }
+
         # 메타 필드 단일 접근 헬퍼
         def _get(attr: str):
-            x = meta.get(attr, None)
-            if x is None:
-                return None
-            # StringTensor 또는 List[str]일 수 있음
-            if isinstance(x, (list, tuple)):
-                if local_idx < len(x):
-                    return x[local_idx]
-                return None
-            # torch 텐서 → str
-            if torch.is_tensor(x):
-                # assume 1‑D tensor of ints (char codes) or encoded bytes
+            keys = alias_map.get(attr, [attr])
+            for key in keys:
+                x = meta.get(key, None)
+                if x is None:
+                    continue
+                # StringTensor 또는 List[str]일 수 있음
+                if isinstance(x, (list, tuple)):
+                    if local_idx < len(x):
+                        return x[local_idx]
+                    continue
+                # torch 텐서 → str
+                if torch.is_tensor(x):
+                    # assume 1‑D tensor of ints (char codes) or encoded bytes
+                    try:
+                        arr = x[local_idx]
+                        if arr.ndim == 0:  # scalar id
+                            return str(arr.item())
+                        return bytes(arr.tolist()).decode(errors="ignore")
+                    except Exception:
+                        continue
+                # plain python object
                 try:
-                    arr = x[local_idx]
-                    if arr.ndim == 0:  # scalar id
-                        return str(arr.item())
-                    return bytes(arr.tolist()).decode(errors="ignore")
+                    return x[local_idx] if hasattr(x, "__getitem__") else x
                 except Exception:
-                    return None
-            # plain python object
-            try:
-                return x[local_idx] if hasattr(x, "__getitem__") else x
-            except Exception:
-                return None
+                    continue
+            return None
 
         # 1) API / 함수명
         name = _get("name") or _get("api")

--- a/tests/test_feature_miner_safe_get.py
+++ b/tests/test_feature_miner_safe_get.py
@@ -18,3 +18,15 @@ def test_feature_miner_handles_short_attribute_list():
     miner = FeatureMiner(top_k=2)
     feats = miner(g, sal)
     assert isinstance(feats, list)
+
+
+def test_feature_miner_resolves_alias_fields():
+    g = HeteroData()
+    g["import"].num_nodes = 1
+    g["import"].x = torch.zeros(1, 1)
+    g["import"].import_ = ["WS2_32.dll"]  # field uses alias
+
+    sal = torch.tensor([1.0])
+    miner = FeatureMiner(top_k=1)
+    feats = miner(g, sal)
+    assert "import:WS2_32.dll" in feats


### PR DESCRIPTION
## Summary
- support attribute aliases when extracting feature candidates
- ensure alias lookup works on `import_` fields

## Testing
- `pytest tests/test_feature_miner_safe_get.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b66da4bb0832e8db2e473f2a152d8