### PR TITLE
Add explainer training CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,11 @@ python -m cli.rulegen_cli ppo-train \
        --epochs 50000 \
        --checkpoint models/rulebank/ppo_agent.pt \
        --plot-path runs/rulegen/ppo_train.png
+# XAI selector 학습
+
+python -m cli.explainer_train cfg.pt \
+       --model models/gnn/res_gcl.pt \
+       --output models/selector.pt \
+       --epochs 500
 # 평가
 ```

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -49,6 +49,7 @@ _COMMANDS: Final[Dict[str, str]] = {
     "finetune-supcon": "finetune_supcon",
     "detect": "detect",
     "certify-res": "certify_res",
+    "train-explainer": "explainer_train",
 }
 
 # Expose publicly in case external plugins need to introspect

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""robust-malware-graph – CFGExplainer *Selector* Training CLI
+=================================================================
+Train the Gumbel-Mask selector used for CFG explanations.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import torch
+
+from robust_malware_graph.explain import train_selector
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Train Gumbel-Mask selector for a single CFG graph",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("cfg_graph", type=Path, help="Path to CFG *.pt graph")
+    p.add_argument("--model", type=Path, required=True, help="Classifier checkpoint")
+    p.add_argument("--output", type=Path, required=True, help="Where to save trained selector")
+    p.add_argument("--device", type=str, default="cpu")
+    p.add_argument("--epochs", type=int, default=1000)
+    p.add_argument("--lr", type=float, default=2e-3)
+    p.add_argument("--alpha", type=float, default=1.0)
+    p.add_argument("--beta", type=float, default=2e-2)
+    return p
+
+
+def _load_model(path: Path, device: torch.device):
+    obj = torch.load(path, map_location=device)
+    if isinstance(obj, dict) and "model" in obj:
+        model = obj["model"]
+    else:
+        model = obj
+    if hasattr(model, "to"):
+        model.to(device)
+    if hasattr(model, "eval"):
+        model.eval()
+    return model
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+    device = torch.device(args.device)
+
+    cfg_graph = torch.load(args.cfg_graph, map_location="cpu")
+    model = _load_model(args.model, device)
+
+    selector = train_selector(
+        cfg_graph,
+        model,
+        device=device,
+        epochs=args.epochs,
+        lr=args.lr,
+        alpha=args.alpha,
+        beta=args.beta,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(selector.state_dict(), args.output)
+    print(f"[OK] Saved selector -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -1,0 +1,46 @@
+import importlib
+import pytest
+from pathlib import Path
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import Data
+
+
+def test_cli_invokes_train_selector(tmp_path, monkeypatch):
+    cfg = Data(x=torch.zeros(1, 1), edge_index=torch.tensor([[0], [0]]), num_nodes=1)
+    gpath = tmp_path / "cfg.pt"
+    torch.save(cfg, gpath)
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    dummy_model = object()
+    orig_load = torch.load
+
+    def fake_load(path, map_location=None):
+        if Path(path) == gpath:
+            return cfg
+        if Path(path) == mpath:
+            return dummy_model
+        return orig_load(path, map_location=map_location)
+
+    monkeypatch.setattr(torch, "load", fake_load)
+
+    captured = {}
+
+    def fake_train_selector(graph, model, **kw):
+        captured["graph"] = graph
+        captured["model"] = model
+        return "selector"
+
+    monkeypatch.setattr("robust_malware_graph.explain.train_selector", fake_train_selector)
+
+    mod = importlib.import_module("src.cli.explainer_train")
+    out = tmp_path / "out.pt"
+    mod.main([str(gpath), "--model", str(mpath), "--output", str(out), "--epochs", "1"])
+
+    assert captured["graph"] is cfg
+    assert captured["model"] is dummy_model
+    assert out.exists()


### PR DESCRIPTION
## Summary
- implement `explainer_train` CLI that wraps `train_selector`
- register `train-explainer` subcommand
- document usage in README
- test invoking the new CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2fec442c832e9ad0a1c5bae9c1f2