### PR TITLE
Support HeteroData models in explainer utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,15 @@ python -m cli.rulegen_cli ppo-train \
        --checkpoint models/rulebank/ppo_agent.pt \
        --plot-path runs/rulegen/ppo_train.png
 # XAI selector 학습
+# 분류기가 HeteroData 그래프를 입력으로 받아도 동일하게 사용할 수 있습니다.
 
 python -m cli.explainer_train cfg.pt \
        --model models/gnn/res_gcl.pt \
        --output models/selector.pt \
        --epochs 500
+# HeteroData 기반 분류기 예시
+python -m cli.explainer_train hetero_cfg.pt \
+       --model models/gnn/hetero_classifier.pt \
+       --output models/selector.pt
 # 평가
 ```

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import torch
 
 from robust_malware_graph.explain import train_selector
+from torch_geometric.data import HeteroData
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -49,6 +50,11 @@ def main(argv: list[str] | None = None) -> None:
     cfg_graph = torch.load(args.cfg_graph, map_location="cpu")
     model = _load_model(args.model, device)
 
+    if isinstance(cfg_graph, HeteroData):
+        score_fn = lambda g: model(g.to(device)).squeeze()
+    else:
+        score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
+
     selector = train_selector(
         cfg_graph,
         model,
@@ -58,6 +64,7 @@ def main(argv: list[str] | None = None) -> None:
         alpha=args.alpha,
         beta=args.beta,
         plot_path=args.plot_path,
+        score_fn=score_fn,
     )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/src/explain/cfg_explainer/__init__.py
+++ b/src/explain/cfg_explainer/__init__.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import Dict, List, Sequence
 
 import torch
-from torch_geometric.data import Data
+from torch_geometric.data import Data, HeteroData
 from pathlib import Path
 
 from .aggregator import CFGPathAggregator, aggregate_paths
@@ -65,6 +65,7 @@ def train_selector(
     alpha: float = 1.0,
     beta: float = 2e-2,
     plot_path: Path | str | None = None,
+    score_fn=None,
     **selector_kwargs,
 ) -> GumbelMaskSelector:
     """
@@ -84,12 +85,20 @@ def train_selector(
         If given, save training curves (fidelity/sparsity/deletion) as PNG.
     selector_kwargs
         Extra args → `GumbelMaskSelector` (e.g., init_bias, tau_start …).
+    score_fn : callable, optional
+        Custom graph scoring function. If ``None``, it is built from ``model``
+        assuming ``Data`` inputs with ``x`` and ``edge_index`` or ``HeteroData``
+        inputs for heterogeneous graphs.
 
     Returns
     -------
     GumbelMaskSelector (trained)
     """
-    score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
+    if score_fn is None:
+        if isinstance(cfg_graph, HeteroData):
+            score_fn = lambda g: model(g.to(device)).squeeze()
+        else:
+            score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
 
     selector = GumbelMaskSelector(cfg_graph.num_nodes, device=device, **selector_kwargs)
     selector.train_loop(
@@ -114,6 +123,7 @@ def explain_cfg(
     selector_kwargs: Dict | None = None,
     ranker_kwargs: Dict | None = None,
     top_k: int | None = 20,
+    score_fn=None,
 ) -> Dict[str, object]:
     """
     End-to-end explanation pipeline.
@@ -140,15 +150,26 @@ def explain_cfg(
     selector_kwargs = selector_kwargs or {}
     ranker_kwargs = ranker_kwargs or {}
 
+    if score_fn is None:
+        if isinstance(cfg_graph, HeteroData):
+            score_fn = lambda g: model(g.to(device)).squeeze()
+        else:
+            score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
+
     # ── 1. Selector
-    selector = train_selector(cfg_graph, model, device=device, **selector_kwargs)
+    selector = train_selector(
+        cfg_graph,
+        model,
+        device=device,
+        score_fn=score_fn,
+        **selector_kwargs,
+    )
     sel_nodes = selector.hard_selection().tolist()
 
     # ── 2. Aggregator
     paths = aggregate_paths(cfg_graph, sel_nodes)
 
     # ── 3. Ranker
-    score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
     ranked = quick_rank(
         cfg_graph.to(device),
         score_fn,


### PR DESCRIPTION
## Summary
- update `train_selector` and `explain_cfg` so that the scoring function works with `HeteroData`
- allow custom `score_fn` parameter
- update `explainer_train` CLI to build the score function depending on input graph type
- document usage with HeteroData models in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4407d34c832e8cfa95467337b3cf