### PR TITLE
Remove TODO marker

### DIFF
--- a/src/explain/cfg_explainer/mapper.py
+++ b/src/explain/cfg_explainer/mapper.py
@@ -203,4 +203,3 @@ class CFGASTMapper:
 
     def __len__(self) -> int:
         return len(self._cfg_to_tok)
-"""TODO"""


### PR DESCRIPTION
## Summary
- remove stray TODO string from `src/explain/cfg_explainer/mapper.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4e77b354832ea8caccdffdf5acb5