### PR TITLE
Update selector for hetero graphs

### DIFF
--- a/src/explain/cfg_explainer/selector.py
+++ b/src/explain/cfg_explainer/selector.py
@@ -17,7 +17,7 @@
 #    – α, β       : trade-off hyper-params (default α=1, β=2e-2)
 #
 #  • 사용 예
-#      >>> selector = GumbelMaskSelector(num_nodes=cfg_g.num_nodes).to("cuda")
+#      >>> selector = GumbelMaskSelector(view="cfg").to("cuda")
 #      >>> optim = torch.optim.Adam(selector.parameters(), lr=2e-3)
 #      >>> for step in range(1_000):
 #      ...     loss, m_prob = selector.step(cfg_g, score_fn, optim)
@@ -36,6 +36,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch_geometric.data import Data
+from torch_geometric.data import HeteroData
 
 try:
     from tqdm.auto import tqdm  # type: ignore
@@ -69,25 +70,32 @@ def gumbel_sigmoid(logits: torch.Tensor, tau: float, hard: bool) -> torch.Tensor
 
 
 # --------------------------------------------------------------------------- #
+#                        Hetero graph edge helpers                            #
+# --------------------------------------------------------------------------- #
+def iter_edge_types(g: HeteroData, view: str):
+    """Yield edge types in ``g`` whose relation matches ``view``."""
+    for etype in g.edge_types:
+        if etype[1] == view:
+            yield etype
+
+
+def edge_mask_to_global(g: HeteroData, masks: dict[str, torch.Tensor], view: str) -> torch.Tensor:
+    """Concatenate per-edge-type masks following ``iter_edge_types`` order."""
+    outs = []
+    for et in iter_edge_types(g, view):
+        outs.append(masks[str(et)])
+    return torch.cat(outs) if outs else torch.empty(0)
+
+
+# --------------------------------------------------------------------------- #
 #                             Main Selector class                             #
 # --------------------------------------------------------------------------- #
 class GumbelMaskSelector(nn.Module):
-    """
-    Trainable node mask using Concrete Bernoulli.
-
-    Parameters
-    ----------
-    num_nodes : int
-        #nodes in CFG. Fixed during selector training.
-    init_bias : float | None
-        logit bias. 0 ⇒ p=0.5. Use negative value to start sparser.
-    tau_start / tau_min / tau_decay
-        Temperature annealing schedule: tau ← max(tau_min, tau * tau_decay).
-    """
+    """Trainable **edge** mask using Concrete Bernoulli."""
 
     def __init__(
         self,
-        num_nodes: int,
+        view: str = "cfg",
         *,
         init_bias: float | None = -1.0,
         tau_start: float = 2.0,
@@ -96,33 +104,43 @@ class GumbelMaskSelector(nn.Module):
         device: str | torch.device | None = None,
     ) -> None:
         super().__init__()
-        self.num_nodes = num_nodes
-        self.logits = nn.Parameter(
-            torch.full((num_nodes,), float(init_bias) if init_bias is not None else 0.0)
-        )
+        self.view = view
+        self.init_bias = init_bias
+        self.logits = nn.ParameterDict()
         self.register_buffer("tau", torch.tensor(tau_start))
         self.tau_min = tau_min
         self.tau_decay = tau_decay
         self.to(device or "cpu")
 
     # ------------------------------------------------------------------ #
+    @property
+    def initialized(self) -> bool:
+        return len(self.logits) > 0
+
+    # ------------------------------------------------------------------ #
+    def _init_params(self, g: "HeteroData") -> None:
+        """Create per-edge-type logits if missing."""
+        for etype in iter_edge_types(g, self.view):
+            key = str(etype)
+            if key not in self.logits:
+                num_edges = g[etype].edge_index.size(1)
+                bias = float(self.init_bias) if self.init_bias is not None else 0.0
+                self.logits[key] = nn.Parameter(torch.full((num_edges,), bias))
+
+    # ------------------------------------------------------------------ #
     #                     Core forward / sample / loss                   #
     # ------------------------------------------------------------------ #
-    def forward(
-        self,
-        sample: bool = True,
-        hard: bool = False,
-        tau: float | None = None,
-    ) -> torch.Tensor:
-        """
-        Return node mask ∈ (0,1)^N or {0,1}^N.
+    def forward(self, g: "HeteroData", tau: float | None = None) -> torch.Tensor:
+        """Sample a probabilistic edge mask for ``self.view``."""
+        if not self.initialized:
+            self._init_params(g)
 
-        sample=False ⇒ deterministic sigmoid(logits).
-        """
         τ = float(self.tau if tau is None else tau)
-        if sample:
-            return gumbel_sigmoid(self.logits, τ, hard)
-        return torch.sigmoid(self.logits)
+        masks = {}
+        for etype in iter_edge_types(g, self.view):
+            logits = self.logits[str(etype)]
+            masks[str(etype)] = gumbel_sigmoid(logits, τ, False)
+        return edge_mask_to_global(g, masks, self.view)
 
     # ------------------------------- loss --------------------------------- #
     def loss(
@@ -151,8 +169,8 @@ class GumbelMaskSelector(nn.Module):
     # --------------------------- single step API -------------------------- #
     def step(
         self,
-        graph: Data,
-        score_fn: Callable[[Data], torch.Tensor],
+        graph: Data | HeteroData,
+        score_fn: Callable[[Data | HeteroData], torch.Tensor],
         optimizer: torch.optim.Optimizer,
         *,
         alpha: float = 1.0,
@@ -166,6 +184,9 @@ class GumbelMaskSelector(nn.Module):
 
         • score_fn : Data → scalar logit/score Tensor (shape [])
         """
+        if not self.initialized:
+            self._init_params(graph)
+
         optimizer.zero_grad()
 
         # full graph score (computationally cheap to cache outside)
@@ -173,28 +194,27 @@ class GumbelMaskSelector(nn.Module):
         if detach_full:
             full_score = full_score.detach()
 
-        # sample mask & build masked subgraph
-        m_prob = self(sample=True, hard=hard)  # (N,)
-        keep_nodes = (m_prob > 0.5) if hard else (m_prob > 0)  # bool mask
-        if keep_nodes.sum() == 0:  # avoid empty graph
-            keep_nodes[m_prob.argmax()] = True
+        # sample mask per edge-type & build subgraph
+        masks = {}
+        τ = float(self.tau)
+        for etype in iter_edge_types(graph, self.view):
+            logits = self.logits[str(etype)]
+            masks[str(etype)] = gumbel_sigmoid(logits, τ, hard)
+        m_prob = edge_mask_to_global(graph, masks, self.view)
 
-        # subgraph relabeling
-        from torch_geometric.utils import subgraph as pyg_subgraph
-
-        node_idx = keep_nodes.nonzero(as_tuple=False).view(-1)
-        edge_index, _ = pyg_subgraph(node_idx, graph.edge_index, relabel_nodes=True)
-
-        sub_x = graph.x[node_idx]
-        sub_g = Data(x=sub_x, edge_index=edge_index)
-        for k in graph.keys:
-            if k in {"x", "edge_index"}:
-                continue
-            v = graph[k]
-            if torch.is_tensor(v) and v.size(0) == graph.num_nodes:
-                sub_g[k] = v[node_idx]
-            else:
-                sub_g[k] = v
+        sub_g = graph.clone()
+        for etype in iter_edge_types(sub_g, self.view):
+            mask = masks[str(etype)]
+            keep = (mask > 0.5) if hard else (mask > 0)
+            if keep.sum() == 0:
+                keep[mask.argmax()] = True
+            store = sub_g[etype]
+            store.edge_index = store.edge_index[:, keep]
+            for k, v in list(store.items()):
+                if k == "edge_index":
+                    continue
+                if torch.is_tensor(v) and v.size(0) == mask.size(0):
+                    store[k] = v[keep]
 
         masked_score = score_fn(sub_g)
 
@@ -225,8 +245,8 @@ class GumbelMaskSelector(nn.Module):
     # ------------------------------------------------------------------ #
     def train_loop(
         self,
-        graph: Data,
-        score_fn: Callable[[Data], torch.Tensor],
+        graph: Data | HeteroData,
+        score_fn: Callable[[Data | HeteroData], torch.Tensor],
         epochs: int = 1_000,
         *,
         lr: float = 2e-3,
@@ -242,6 +262,9 @@ class GumbelMaskSelector(nn.Module):
 
         Returns final mask probability Tensor.
         """
+        if not self.initialized:
+            self._init_params(graph)
+
         optim = torch.optim.Adam(self.parameters(), lr=lr)
         iterator = tqdm(range(epochs), disable=not show_progress, desc="Selector train")
 
@@ -283,12 +306,21 @@ class GumbelMaskSelector(nn.Module):
         return m_prob
 
     # ---------------------- export to hard index mask --------------------- #
-    def hard_selection(self, thresh: float = 0.5) -> torch.Tensor:
-        """Return indices of selected nodes after training."""
-        prob = torch.sigmoid(self.logits)
-        return (prob > thresh).nonzero(as_tuple=False).view(-1)
+    def hard_selection(self, g: "HeteroData", thresh: float = 0.5) -> dict[str, torch.Tensor]:
+        """Return selected edge indices per edge type."""
+        if not self.initialized:
+            self._init_params(g)
+        out: dict[str, torch.Tensor] = {}
+        for etype in iter_edge_types(g, self.view):
+            prob = torch.sigmoid(self.logits[str(etype)])
+            out[str(etype)] = (prob > thresh).nonzero(as_tuple=False).view(-1)
+        return out
 
     # -------------------------- dunder helpers ---------------------------- #
     def __repr__(self) -> str:  # pragma: no cover
-        p = torch.sigmoid(self.logits).mean().item()
-        return f"{self.__class__.__name__}(N={self.num_nodes}, p≈{p:.2%}, τ={float(self.tau):.2f})"
+        if self.initialized:
+            probs = torch.cat([torch.sigmoid(p) for p in self.logits.values()])
+            p_mean = probs.mean().item()
+        else:
+            p_mean = float("nan")
+        return f"{self.__class__.__name__}(view={self.view}, p≈{p_mean:.2%}, τ={float(self.tau):.2f})"

--- a/tests/test_selector_init.py
+++ b/tests/test_selector_init.py
@@ -1,0 +1,25 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.explain.cfg_explainer.selector import GumbelMaskSelector
+
+
+def test_selector_initializes_on_hetero():
+    g = HeteroData()
+    g["bb"].num_nodes = 3
+    ei = torch.tensor([[0, 1], [1, 2]], dtype=torch.long)
+    g[("bb", "cfg", "bb")].edge_index = ei
+
+    selector = GumbelMaskSelector(view="cfg")
+    assert not selector.initialized
+    mask = selector(g)
+    assert selector.initialized
+    key = str(("bb", "cfg", "bb"))
+    assert key in selector.logits
+    assert selector.logits[key].shape == (ei.size(1),)
+    assert mask.numel() == ei.size(1)
+


### PR DESCRIPTION
## Summary
- support hetero graphs in `GumbelMaskSelector`
- store per-edge-type logits
- initialise parameters lazily from graph
- adapt training step for edge masks
- test selector initialisation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4f0efa58832eb497d0144d69fc49