### PR TITLE
Add hetero graph utility helpers

### DIFF
--- a/src/explain/__init__.py
+++ b/src/explain/__init__.py
@@ -45,6 +45,11 @@ from .cfg_explainer import (  # noqa: F401
 )
 from .cf_generator import CFResult, CounterFactualGenerator  # noqa: F401
 from .report import render as render_report  # noqa: F401
+from .utils import (  # noqa: F401
+    edge_mask_to_global,
+    get_edge_store,
+    iter_edge_types,
+)
 
 __all__ = [
     # cfg_explainer
@@ -61,6 +66,10 @@ __all__ = [
     "CounterFactualGenerator",
     # report util
     "render_report",
+    # util helpers
+    "get_edge_store",
+    "edge_mask_to_global",
+    "iter_edge_types",
     # high-level
     "run_full_pipeline",
 ]

--- a/src/explain/utils/__init__.py
+++ b/src/explain/utils/__init__.py
@@ -1,0 +1,10 @@
+"""Utility helpers for explainability components."""
+from __future__ import annotations
+
+from .hetero import get_edge_store, edge_mask_to_global, iter_edge_types
+
+__all__ = [
+    "get_edge_store",
+    "edge_mask_to_global",
+    "iter_edge_types",
+]

--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -1,0 +1,52 @@
+"""Light-weight helpers for :class:`torch_geometric.data.HeteroData`."""
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from typing import Iterable, Tuple
+
+import torch
+from torch_geometric.data import HeteroData
+
+EdgeType = Tuple[str, str, str]
+
+
+def get_edge_store(
+    g: HeteroData, etype: EdgeType
+) -> Tuple[torch.Tensor, HeteroData, torch.Tensor]:
+    """Return ``(edge_index, store, edge_id)`` for ``etype``.
+
+    If the edge store already defines ``edge_id`` it is returned. Otherwise a
+    global index is constructed by summing ``num_edges`` of preceding edge
+    types in ``g.edge_types``.
+    """
+    store = g[etype]
+    edge_index = store.edge_index
+
+    if "edge_id" in store:
+        global_idx = store.edge_id
+    else:
+        offset = 0
+        for key in g.edge_types:
+            if key == etype:
+                break
+            offset += g[key].edge_index.size(1)
+        global_idx = torch.arange(
+            offset, offset + edge_index.size(1), dtype=torch.long, device=edge_index.device
+        )
+    return edge_index, store, global_idx
+
+
+def edge_mask_to_global(
+    mask_local: torch.Tensor, global_idx: torch.Tensor, num_total: int
+) -> torch.Tensor:
+    """Expand a local edge mask into a graph-level tensor."""
+    out = torch.zeros(num_total, dtype=mask_local.dtype, device=mask_local.device)
+    out[global_idx] = mask_local
+    return out
+
+
+def iter_edge_types(g: HeteroData, view: str) -> Iterable[EdgeType]:
+    """Yield edge types whose relation matches ``view`` (supports ``fnmatch``)."""
+    for key in g.edge_types:
+        if fnmatch(key[1], view):
+            yield key

--- a/tests/test_hetero_utils.py
+++ b/tests/test_hetero_utils.py
@@ -1,0 +1,49 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.explain.utils.hetero import (
+    get_edge_store,
+    edge_mask_to_global,
+    iter_edge_types,
+)
+
+
+def _make_graph():
+    g = HeteroData()
+    g["a"].num_nodes = 3
+    g["b"].num_nodes = 2
+    g[("a", "rel", "a")].edge_index = torch.tensor([[0, 1], [1, 2]])
+    g[("a", "rel2", "b")].edge_index = torch.tensor([[0], [1]])
+    return g
+
+
+def test_get_edge_store_global_index():
+    g = _make_graph()
+    ei, store, gid = get_edge_store(g, ("a", "rel", "a"))
+    assert store is g[("a", "rel", "a")]
+    assert torch.equal(ei, g[("a", "rel", "a")].edge_index)
+    assert gid.tolist() == [0, 1]
+
+    _, _, gid2 = get_edge_store(g, ("a", "rel2", "b"))
+    assert gid2.tolist() == [2]
+
+
+def test_edge_mask_to_global():
+    g = _make_graph()
+    _, _, gid = get_edge_store(g, ("a", "rel", "a"))
+    mask = torch.tensor([1, 0], dtype=torch.float)
+    out = edge_mask_to_global(mask, gid, 3)
+    assert out.tolist() == [1, 0, 0]
+
+
+def test_iter_edge_types_wildcard():
+    g = _make_graph()
+    etypes = list(iter_edge_types(g, "rel*"))
+    assert set(etypes) == {("a", "rel", "a"), ("a", "rel2", "b")}
+    etypes = list(iter_edge_types(g, "rel2"))
+    assert etypes == [("a", "rel2", "b")]


### PR DESCRIPTION
## Summary
- helper utilities for edge stores in heterogeneous graphs
- expose `get_edge_store`, `edge_mask_to_global`, `iter_edge_types`
- unit tests for the new helpers

## Testing
- `pytest -q tests/test_hetero_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685c4f15aab0832e8dafe03c9409e4e4