### PR TITLE
Support HeteroData in CFGPathAggregator

### DIFF
--- a/src/explain/cfg_explainer/aggregator.py
+++ b/src/explain/cfg_explainer/aggregator.py
@@ -8,9 +8,14 @@
 #        ─ Topological sort (DAG) → fallback: BFS 레벨/addr 오름차순.
 #
 #  반환값은:
-#      List[ dict ]  # ↳ { "nodes": List[int],
-#                       "edges": Tensor[2, E],
-#                       "subgraph": torch_geometric.data.Data }
+#      List[ dict ]  # ↳ {
+#                       "nodes"    : List[int],          # ordered (global)
+#                       "edges"    : Tensor[2, E],      # local indices
+#                       "edge_ids" : Tensor[E],         # global edge ids
+#                       "node_map" : List[Tuple[str,int]],
+#                       "edge_map" : List[Tuple],
+#                       "feat"     : Tensor | None,     # path feature
+#                       "subgraph" : torch_geometric.data.Data }
 #
 #  Down-stream (Ranker / Report) 에서 경로별 중요도 합산, 코드 하이라이트 등에 사용.
 #
@@ -19,12 +24,36 @@
 # --------------------------------------------------------------------------- #
 from __future__ import annotations
 
-from typing import Dict, List, Sequence
+from typing import Dict, List, Sequence, Tuple, Iterable, Optional
 
 import networkx as nx
 import torch
-from torch_geometric.data import Data
+from torch_geometric.data import Data, HeteroData
 from torch_geometric.utils import to_networkx
+
+
+# --------------------------------------------------------------------------- #
+#                               Helper utils                                  #
+# --------------------------------------------------------------------------- #
+def iter_edge_types(g: Data | HeteroData, rel: str) -> Iterable[Tuple[Tuple[str, str, str] | None, Data]]:
+    """Yield edge stores whose relation matches ``rel``.
+
+    For ``HeteroData`` this filters all ``edge_types`` where the relation part
+    equals ``rel`` or, when ``rel`` is ``"cfg"``, includes the common CFG
+    variants (``jump``, ``conditional``, ``fallthrough``).
+
+    ``Data`` instances yield a single ``(None, g)`` pair.
+    """
+
+    if isinstance(g, Data):
+        if rel == "cfg":
+            yield None, g
+        return
+
+    cfg_alias = {"cfg", "jump", "conditional", "fallthrough"}
+    for etype in g.edge_types:
+        if rel == etype[1] or (rel == "cfg" and etype[1] in cfg_alias):
+            yield etype, g[etype]
 
 
 # --------------------------------------------------------------------------- #
@@ -36,8 +65,9 @@ class CFGPathAggregator:
 
     Parameters
     ----------
-    graph : torch_geometric.data.Data
-        전체 CFG 그래프. edge_index 0-행→1-행 방향 = control-flow 방향.
+    graph : torch_geometric.data.Data | torch_geometric.data.HeteroData
+        전체 CFG 그래프. HeteroData일 경우 ``cfg`` 연관 모든 edge store를
+        합쳐 하나의 DiGraph로 변환한다.
     undirected : bool, default False
         컴포넌트 탐색 시 방향 무시 여부 (weakly vs. strongly).
     min_path_len : int, default 1
@@ -46,21 +76,88 @@ class CFGPathAggregator:
 
     def __init__(
         self,
-        graph: Data,
+        graph: Data | HeteroData,
         *,
         undirected: bool = False,
         min_path_len: int = 1,
+        edge_emb: Optional[torch.nn.Embedding] = None,
     ) -> None:
-        self.g = graph
+        self.orig_graph = graph
         self.undirected = undirected
         self.min_len = min_path_len
+        self.edge_emb = edge_emb
 
-        # addr(시작 주소) 가 있으면 path 정렬 tie-break 용으로 보관
-        self._addr = graph.get("addr", None)  # (N,2) or (N,) Tensor | None
+        # --------------------------------------------------------------
+        # Flatten possibly multiple CFG edge stores into a single Data
+        # --------------------------------------------------------------
+        if isinstance(graph, HeteroData):
+            node_offsets: Dict[str, int] = {}
+            global2local: Dict[int, Tuple[str, int]] = {}
+            cursor = 0
+            for ntype in graph.node_types:
+                node_offsets[ntype] = cursor
+                for i in range(graph[ntype].num_nodes):
+                    global2local[cursor + i] = (ntype, i)
+                cursor += graph[ntype].num_nodes
 
-        # NetworkX 변환(방향 유지).  note: PyG→nx 는 node indexing 동일.
-        self._nx_digraph: nx.DiGraph = to_networkx(
-            graph, to_undirected=False, node_attrs=[]
+            edges: List[torch.Tensor] = []
+            edge_types: List[torch.Tensor] = []
+            edge_map: List[Tuple[Tuple[str, str, str], int]] = []
+            for etype, store in iter_edge_types(graph, "cfg"):
+                src_off = node_offsets[etype[0]]
+                dst_off = node_offsets[etype[2]]
+                ei = store.edge_index
+                edges.append(torch.stack([ei[0] + src_off, ei[1] + dst_off]))
+                if "edge_type" in store:
+                    edge_types.append(store.edge_type.clone())
+                else:
+                    from src.graphs.normalizers.schema import EDGE_REL_ID
+
+                    edge_types.append(
+                        torch.full((ei.size(1),), EDGE_REL_ID.get(etype[1], 0), dtype=torch.long)
+                    )
+                edge_map.extend([(etype, int(i)) for i in range(ei.size(1))])
+
+            edge_index = torch.cat(edges, dim=1) if edges else torch.empty((2, 0), dtype=torch.long)
+            edge_type = torch.cat(edge_types) if edge_types else torch.empty((0,), dtype=torch.long)
+
+            # concatenate node features (feat or x)
+            feats: List[torch.Tensor] = []
+            addrs: List[torch.Tensor] = []
+            for ntype in graph.node_types:
+                store = graph[ntype]
+                if "x" in store:
+                    feats.append(store.x)
+                elif "feat" in store:
+                    feats.append(store.feat)
+                else:
+                    feats.append(torch.zeros((store.num_nodes, 1), dtype=torch.float))
+                if "addr" in store:
+                    addrs.append(torch.as_tensor(store.addr))
+
+            x = torch.cat(feats, dim=0) if feats else torch.empty((cursor, 0))
+            if addrs:
+                addr = torch.cat(addrs, dim=0)
+            else:
+                addr = None
+
+            data = Data(x=x, edge_index=edge_index, edge_type=edge_type, num_nodes=cursor)
+            if addr is not None:
+                data.addr = addr
+            self.g = data
+            self._node_map = global2local
+            self._edge_map = edge_map
+        else:
+            self.g = graph
+            self._node_map = {i: ("node", i) for i in range(graph.num_nodes)}
+            self._edge_map = [("cfg", int(i)) for i in range(graph.edge_index.size(1))]
+
+        self._addr = self.g.get("addr", None)
+
+        self._nx_digraph = to_networkx(
+            Data(edge_index=self.g.edge_index, num_nodes=self.g.num_nodes),
+            to_undirected=False,
+            node_attrs=[],
         )
 
     # ------------------------------------------------------------------ #
@@ -109,8 +206,8 @@ class CFGPathAggregator:
                 node_idx = torch.tensor(seq, dtype=torch.long)
                 from torch_geometric.utils import subgraph as pyg_subgraph
 
-                edge_index, _ = pyg_subgraph(
-                    node_idx, self.g.edge_index, relabel_nodes=True
+                edge_index, edge_mask = pyg_subgraph(
+                    node_idx, self.g.edge_index, relabel_nodes=True, return_edge_mask=True
                 )
                 sub_x = self.g.x[node_idx]
                 sub_data = Data(x=sub_x, edge_index=edge_index)
@@ -124,11 +221,24 @@ class CFGPathAggregator:
                     else:
                         sub_data[k] = v
 
+                global_eids = edge_mask.nonzero(as_tuple=False).view(-1)
+                node_map = [self._node_map[n] for n in seq]
+                edge_map = [self._edge_map[int(i)] for i in global_eids]
+
+                path_feat = None
+                if self.edge_emb is not None and len(global_eids) > 0:
+                    et = self.g.edge_type[global_eids]
+                    path_feat = self.edge_emb(et).mean(dim=0)
+
                 paths_out.append(
                     {
                         "nodes": seq,
                         "edges": edge_index,
                         "subgraph": sub_data,
+                        "edge_ids": global_eids,
+                        "node_map": node_map,
+                        "edge_map": edge_map,
+                        "feat": path_feat,
                     }
                 )
 
@@ -183,12 +293,12 @@ class CFGPathAggregator:
 #                               Quick helper                                  #
 # --------------------------------------------------------------------------- #
 def aggregate_paths(
-    graph: Data,
+    graph: Data | HeteroData,
     selected_nodes: Sequence[int],
     *,
     undirected: bool = False,
     min_path_len: int = 1,
-) -> List[Dict]:
+    ) -> List[Dict]:
     """
     Convenience wrapper :: one-shot aggregation.
     """

--- a/tests/test_cfg_path_aggregator.py
+++ b/tests/test_cfg_path_aggregator.py
@@ -1,0 +1,39 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+from src.explain.cfg_explainer.aggregator import CFGPathAggregator
+
+def build_graph():
+    g = HeteroData()
+    g["bb"].num_nodes = 4
+    g["bb"].feat = torch.zeros(4, 1)
+    ei1 = torch.tensor([[0, 1], [1, 2]], dtype=torch.long)
+    g[("bb", "jump", "bb")].edge_index = ei1
+    g[("bb", "jump", "bb")].edge_type = torch.zeros(ei1.size(1), dtype=torch.long)
+    ei2 = torch.tensor([[0, 2], [2, 3]], dtype=torch.long)
+    g[("bb", "fallthrough", "bb")].edge_index = ei2
+    g[("bb", "fallthrough", "bb")].edge_type = torch.ones(ei2.size(1), dtype=torch.long)
+    return g
+
+def test_aggregator_hetero_paths():
+    g = build_graph()
+    agg = CFGPathAggregator(g)
+    paths = agg.aggregate([0, 1, 2, 3])
+    assert len(paths) == 1
+    p = paths[0]
+    assert p["nodes"] == [0, 1, 2, 3]
+    assert p["edge_ids"].tolist() == [0, 1, 2, 3]
+    assert p["edge_map"][0][0] == ("bb", "jump", "bb")
+    assert p["edge_map"][2][0] == ("bb", "fallthrough", "bb")
+
+def test_edge_embedding_feat():
+    g = build_graph()
+    emb = torch.nn.Embedding(2, 3)
+    torch.nn.init.constant_(emb.weight, 1.0)
+    agg = CFGPathAggregator(g, edge_emb=emb)
+    paths = agg.aggregate([0, 1, 2, 3])
+    assert paths[0]["feat"].shape == (3,)


### PR DESCRIPTION
## Summary
- add helper `iter_edge_types`
- extend `CFGPathAggregator` to consume HeteroData and flatten multiple CFG edge stores
- return node/edge mappings and optional edge-type features
- provide tests for heterogeneous CFG graphs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c4f10f194832ea189145d859e3944