### PR TITLE
Extend ranker and mapper features

### DIFF
--- a/src/explain/cfg_explainer/mapper.py
+++ b/src/explain/cfg_explainer/mapper.py
@@ -61,6 +61,7 @@ class CFGASTMapper:
         *,
         span_key_cfg: str = "addr",
         span_key_ast: str = "span",
+        cfg_node_type: str = "bb",
     ) -> None:
         self.cfg_g = cfg_graph
         self.ast_g = ast_graph
@@ -68,8 +69,10 @@ class CFGASTMapper:
         self.span_key_ast = span_key_ast
 
         # 내부 인덱스
-        self._cfg_to_tok: Dict[int, Set[int]] = {}
-        self._tok_to_cfg: Dict[int, Set[int]] = {}
+        self.cfg_node_type = cfg_node_type
+
+        self._cfg_to_tok: Dict[tuple[str, int], Set[int]] = {}
+        self._tok_to_cfg: Dict[int, Set[tuple[str, int]]] = {}
 
         self._build_index()
 
@@ -104,27 +107,32 @@ class CFGASTMapper:
                     break  # no further overlap possible
 
                 if self._overlap(bb_start, bb_end, tok_start, tok_end):
-                    self._cfg_to_tok.setdefault(bb_idx, set()).add(tok_idx)
-                    self._tok_to_cfg.setdefault(tok_idx, set()).add(bb_idx)
+                    key = (self.cfg_node_type, int(bb_idx))
+                    self._cfg_to_tok.setdefault(key, set()).add(tok_idx)
+                    self._tok_to_cfg.setdefault(tok_idx, set()).add(key)
 
         # ensure empty sets for nodes with zero overlap
         for bb_idx in range(self.cfg_g.num_nodes):
-            self._cfg_to_tok.setdefault(bb_idx, set())
+            self._cfg_to_tok.setdefault((self.cfg_node_type, int(bb_idx)), set())
 
         for tok_idx in range(self.ast_g.num_nodes):
             self._tok_to_cfg.setdefault(tok_idx, set())
 
     # --------------------------- public API ---------------------------------
-    def cfg_nodes_to_tokens(self, bb_indices: Sequence[int]) -> List[int]:
-        """Return a deduplicated list of AST token indices overlapped by given CFG bb nodes."""
+    def cfg_nodes_to_tokens(self, bb_indices: Sequence[tuple[str, int] | int]) -> List[int]:
+        """Return a deduplicated list of AST token indices overlapped by given CFG nodes."""
         toks: Set[int] = set()
         for bb in bb_indices:
-            toks.update(self._cfg_to_tok.get(int(bb), set()))
+            if isinstance(bb, tuple):
+                key = (bb[0], int(bb[1]))
+            else:
+                key = (self.cfg_node_type, int(bb))
+            toks.update(self._cfg_to_tok.get(key, set()))
         return sorted(toks)
 
-    def tokens_to_cfg_nodes(self, tok_indices: Sequence[int]) -> List[int]:
-        """Inverse lookup: AST token indices → related CFG bb nodes."""
-        bbs: Set[int] = set()
+    def tokens_to_cfg_nodes(self, tok_indices: Sequence[int]) -> List[tuple[str, int]]:
+        """Inverse lookup: AST token indices → related CFG nodes."""
+        bbs: Set[tuple[str, int]] = set()
         for tok in tok_indices:
             bbs.update(self._tok_to_cfg.get(int(tok), set()))
         return sorted(bbs)
@@ -133,8 +141,9 @@ class CFGASTMapper:
     def to_dict(self) -> Dict[str, Dict[str, List[int]]]:
         """Return JSON-serialisable mapping."""
         return {
-            "cfg_to_tok": {str(k): sorted(v) for k, v in self._cfg_to_tok.items()},
-            "tok_to_cfg": {str(k): sorted(v) for k, v in self._tok_to_cfg.items()},
+            "cfg_node_type": self.cfg_node_type,
+            "cfg_to_tok": {f"{t}:{i}": sorted(v) for (t, i), v in self._cfg_to_tok.items()},
+            "tok_to_cfg": {str(k): [f"{t}:{i}" for (t, i) in v] for k, v in self._tok_to_cfg.items()},
         }
 
     @classmethod
@@ -146,8 +155,14 @@ class CFGASTMapper:
         obj.ast_g = ast_graph
         obj.span_key_cfg = "addr"
         obj.span_key_ast = "span"
-        obj._cfg_to_tok = {int(k): set(v) for k, v in mapping["cfg_to_tok"].items()}
-        obj._tok_to_cfg = {int(k): set(v) for k, v in mapping["tok_to_cfg"].items()}
+        obj.cfg_node_type = mapping.get("cfg_node_type", "bb")
+        obj._cfg_to_tok = {}
+        for k, v in mapping["cfg_to_tok"].items():
+            t, idx = k.split(":")
+            obj._cfg_to_tok[(t, int(idx))] = set(v)
+        obj._tok_to_cfg = {}
+        for k, v in mapping["tok_to_cfg"].items():
+            obj._tok_to_cfg[int(k)] = {(p.split(":")[0], int(p.split(":")[1])) for p in v}
         return obj
 
     # file-based convenience wrappers
@@ -197,8 +212,8 @@ class CFGASTMapper:
         html_path.write_text(html, encoding="utf-8")
 
     # ----------------------- dunder convenience -----------------------------
-    def __getitem__(self, bb_idx: int) -> List[int]:
-        """shorthand mapper[bb_idx] → tokens list."""
+    def __getitem__(self, bb_idx: tuple[str, int] | int) -> List[int]:
+        """shorthand mapper[(type,id)] → tokens list."""
         return self.cfg_nodes_to_tokens([bb_idx])
 
     def __len__(self) -> int:

--- a/src/explain/cfg_explainer/ranker.py
+++ b/src/explain/cfg_explainer/ranker.py
@@ -100,6 +100,7 @@ class ShapleyNodeRanker:
         drop_fn: Callable[[Data, Sequence[int]], Data] | None = None,
         background: float = 0.0,
         seed: int | None = None,
+        edge_types: torch.Tensor | None = None,
     ) -> None:
         self.g = graph
         self.score_fn = score_fn
@@ -110,6 +111,7 @@ class ShapleyNodeRanker:
 
         # cache: f(G) (full graph) ← 불변이므로 한 번만
         self.full_score = score_fn(graph)
+        self.edge_types = edge_types if edge_types is not None else graph.get("edge_type", None)
 
     # --------------------------------------------------------------------- #
     #                           Shapley estimation                           #
@@ -153,6 +155,9 @@ class ShapleyNodeRanker:
         *,
         num_permutations: int = 256,
         progress: bool = True,
+        edge_mask: torch.Tensor | None = None,
+        edge_types: torch.Tensor | None = None,
+        sparsity_beta: float = 0.0,
     ) -> Dict[int, float]:
         """
         Shapley value φ_i for each node in `candidates` (or all nodes).
@@ -183,6 +188,19 @@ class ShapleyNodeRanker:
         for node in φ:
             φ[node] /= num_permutations
 
+        if edge_mask is not None:
+            et = edge_types if edge_types is not None else self.edge_types
+            if et is not None:
+                uniq = torch.unique(et)
+                reg = 0.0
+                for t in uniq:
+                    reg += edge_mask[et == t].float().mean().item()
+                reg /= len(uniq) if len(uniq) > 0 else 1
+            else:
+                reg = edge_mask.float().mean().item()
+            for node in φ:
+                φ[node] -= sparsity_beta * reg
+
         return dict(φ)
 
     def rank(
@@ -192,6 +210,9 @@ class ShapleyNodeRanker:
         num_permutations: int = 256,
         candidates: Sequence[int] | None = None,
         progress: bool = True,
+        edge_mask: torch.Tensor | None = None,
+        edge_types: torch.Tensor | None = None,
+        sparsity_beta: float = 0.0,
     ) -> List[tuple[int, float]]:
         """
         Top-k 랭킹 반환.
@@ -200,7 +221,14 @@ class ShapleyNodeRanker:
         -------
         list[ (node_idx, score) ] – 내림차순.
         """
-        φ = self.shapley_values(candidates, num_permutations=num_permutations, progress=progress)
+        φ = self.shapley_values(
+            candidates,
+            num_permutations=num_permutations,
+            progress=progress,
+            edge_mask=edge_mask,
+            edge_types=edge_types,
+            sparsity_beta=sparsity_beta,
+        )
         ranked = sorted(φ.items(), key=lambda x: x[1], reverse=True)
         return ranked if k is None else ranked[:k]
 
@@ -215,6 +243,9 @@ def quick_rank(
     selector_mask: Sequence[int] | None = None,
     k: int = 20,
     num_permutations: int = 256,
+    edge_mask: torch.Tensor | None = None,
+    edge_types: torch.Tensor | None = None,
+    sparsity_beta: float = 0.0,
 ) -> List[tuple[int, float]]:
     """
     One-liner helper often used in notebooks / pipelines.
@@ -229,4 +260,7 @@ def quick_rank(
         k=k,
         num_permutations=num_permutations,
         candidates=selector_mask,
+        edge_mask=edge_mask,
+        edge_types=edge_types,
+        sparsity_beta=sparsity_beta,
     )

--- a/tests/test_cfg_explainer_mapper_ranker.py
+++ b/tests/test_cfg_explainer_mapper_ranker.py
@@ -1,0 +1,49 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import Data
+
+from src.explain.cfg_explainer.mapper import CFGASTMapper
+from src.explain.cfg_explainer.ranker import ShapleyNodeRanker
+
+
+def test_cfgastmapper_tuple_keys():
+    cfg = Data(
+        addr=torch.tensor([[0, 1], [2, 3]], dtype=torch.long),
+        x=torch.zeros(2, 1),
+        num_nodes=2,
+    )
+    ast = Data(
+        span=torch.tensor([[0, 0], [1, 1], [2, 2], [3, 3]], dtype=torch.long),
+        num_nodes=4,
+    )
+    mapper = CFGASTMapper(cfg, ast, cfg_node_type="bb")
+    assert mapper.cfg_nodes_to_tokens([("bb", 0)]) == [0, 1]
+    assert mapper.tokens_to_cfg_nodes([0]) == [("bb", 0)]
+
+    d = mapper.to_dict()
+    restored = CFGASTMapper.from_dict(d, cfg, ast)
+    assert restored.cfg_nodes_to_tokens([("bb", 1)]) == [2, 3]
+
+
+def test_ranker_edge_regularisation():
+    g = Data(
+        x=torch.ones(2, 1),
+        edge_index=torch.tensor([[0, 1], [1, 0]], dtype=torch.long),
+        edge_type=torch.tensor([0, 0], dtype=torch.long),
+        num_nodes=2,
+    )
+
+    ranker = ShapleyNodeRanker(g, score_fn=lambda d: float(d.num_nodes), seed=0)
+    mask = torch.tensor([1.0, 0.0])
+    phi = ranker.shapley_values(
+        num_permutations=2,
+        progress=False,
+        edge_mask=mask,
+        edge_types=g.edge_type,
+        sparsity_beta=1.0,
+    )
+    for v in phi.values():
+        assert pytest.approx(0.5, rel=1e-5) == v


### PR DESCRIPTION
## Summary
- extend ShapleyNodeRanker to support edge sparsity regularisation
- update CFGASTMapper to use `(node_type, node_id)` keys
- add tests for new mapper and ranker behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4f125e30832e8b79c72f5eb2606a