### PR TITLE
Ensure selector initialization for hetero graphs

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import torch
 
 from robust_malware_graph.explain import train_selector
+from robust_malware_graph.explain.utils import ensure_edgeaware_selector
 from torch_geometric.data import HeteroData
 
 
@@ -66,6 +67,7 @@ def main(argv: list[str] | None = None) -> None:
         plot_path=args.plot_path,
         score_fn=score_fn,
     )
+    ensure_edgeaware_selector(selector, cfg_graph)
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     torch.save(selector, args.output)

--- a/src/explain/cfg_explainer/__init__.py
+++ b/src/explain/cfg_explainer/__init__.py
@@ -35,6 +35,7 @@ from .aggregator import CFGPathAggregator, aggregate_paths
 from .mapper import CFGASTMapper
 from .ranker import ShapleyNodeRanker, quick_rank
 from .selector import GumbelMaskSelector
+from ..utils import ensure_edgeaware_selector
 
 __all__ = [
     # core classes
@@ -101,6 +102,7 @@ def train_selector(
             score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
 
     selector = GumbelMaskSelector(cfg_graph.num_nodes, device=device, **selector_kwargs)
+    ensure_edgeaware_selector(selector, cfg_graph)
     selector.train_loop(
         cfg_graph.to(device),
         score_fn,
@@ -164,6 +166,7 @@ def explain_cfg(
         score_fn=score_fn,
         **selector_kwargs,
     )
+    ensure_edgeaware_selector(selector, cfg_graph)
     sel_nodes = selector.hard_selection().tolist()
 
     # ── 2. Aggregator

--- a/src/explain/utils/__init__.py
+++ b/src/explain/utils/__init__.py
@@ -1,10 +1,16 @@
 """Utility helpers for explainability components."""
 from __future__ import annotations
 
-from .hetero import get_edge_store, edge_mask_to_global, iter_edge_types
+from .hetero import (
+    get_edge_store,
+    edge_mask_to_global,
+    iter_edge_types,
+    ensure_edgeaware_selector,
+)
 
 __all__ = [
     "get_edge_store",
     "edge_mask_to_global",
     "iter_edge_types",
+    "ensure_edgeaware_selector",
 ]

--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -50,3 +50,19 @@ def iter_edge_types(g: HeteroData, view: str) -> Iterable[EdgeType]:
     for key in g.edge_types:
         if fnmatch(key[1], view):
             yield key
+
+
+def ensure_edgeaware_selector(selector, g: HeteroData) -> None:
+    """Ensure ``selector`` has initialized parameters for ``g``.
+
+    If ``g`` is a :class:`~torch_geometric.data.HeteroData` graph and the
+    selector declares an ``initialized`` attribute evaluating to ``False``, the
+    selector's private ``_init_params`` method is invoked.  This mirrors the
+    lazy initialisation performed inside the selector's forward pass but allows
+    callers to guarantee the parameters exist *before* any forward operation.
+    """
+
+    if isinstance(g, HeteroData) and not getattr(selector, "initialized", True):
+        # ``_init_params`` is an internal helper on ``GumbelMaskSelector``.  It
+        # creates per-edge-type parameters based on the provided graph.
+        selector._init_params(g)

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -7,6 +7,7 @@ pytest.importorskip("torch_geometric")
 
 import torch
 from torch_geometric.data import Data
+from torch_geometric.data import HeteroData
 
 
 def test_cli_invokes_train_selector(tmp_path, monkeypatch):
@@ -43,4 +44,37 @@ def test_cli_invokes_train_selector(tmp_path, monkeypatch):
 
     assert captured["graph"] is cfg
     assert captured["model"] is dummy_model
+    assert out.exists()
+
+
+def test_cli_handles_heterodata(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "cfg.pt"
+    torch.save(g, gpath)
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    dummy_model = object()
+    orig_load = torch.load
+
+    def fake_load(path, map_location=None):
+        if Path(path) == gpath:
+            return g
+        if Path(path) == mpath:
+            return dummy_model
+        return orig_load(path, map_location=map_location)
+
+    monkeypatch.setattr(torch, "load", fake_load)
+
+    monkeypatch.setattr(
+        "robust_malware_graph.explain.train_selector",
+        lambda *a, **kw: "selector",
+    )
+
+    mod = importlib.import_module("src.cli.explainer_train")
+    out = tmp_path / "out.pt"
+    mod.main([str(gpath), "--model", str(mpath), "--output", str(out), "--epochs", "1"])
+
     assert out.exists()


### PR DESCRIPTION
## Summary
- add `ensure_edgeaware_selector` helper
- export helper in `explain.utils`
- invoke helper from training helpers and CLI
- regression test for CLI with `HeteroData`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c52091544832ebb48cfa66c34ae56