### PR TITLE
Support dict edges in syscall loader

### DIFF
--- a/src/graphs/loaders/syscall_loader.py
+++ b/src/graphs/loaders/syscall_loader.py
@@ -53,11 +53,20 @@ class SysCallLoader(GraphLoaderBase):
 
         # -------- 3) edge_index ---------------------------------- #
         raw_edges = js.get("edges", [])
-        edge_index = (
-            torch.tensor(raw_edges, dtype=torch.long).t().contiguous()
-            if raw_edges
-            else torch.empty((2, 0), dtype=torch.long)
-        )
+        if raw_edges:
+            first = raw_edges[0]
+            if isinstance(first, dict):
+                edges: List[List[int]] = []
+                for e in raw_edges:
+                    try:
+                        edges.append([e["src"], e["dst"]])
+                    except KeyError as err:
+                        raise ValueError(f"edge missing key: {err}") from None
+                edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
+            else:
+                edge_index = torch.tensor(raw_edges, dtype=torch.long).t().contiguous()
+        else:
+            edge_index = torch.empty((2, 0), dtype=torch.long)
 
         # -------- 4) PyG Data ------------------------------------ #
         data = Data(edge_index=edge_index, sc_id=sc_id)
@@ -83,7 +92,7 @@ class SysCallLoader(GraphLoaderBase):
           • open            (id=0)
           • map_section[i]  (id=1..N)
           • close           (id=N+1)
-          • edges : 선형 시퀀스 (0→1→…→N+1)
+          • edges : {src,dst,type='seq'} 선형 시퀀스 (0→1→…→N+1)
         """
         syscalls: List[dict] = []
 
@@ -108,7 +117,10 @@ class SysCallLoader(GraphLoaderBase):
         syscalls.append({"id": last_id, "name": "close", "feat": []})
 
         # 4) linear edges
-        edges = [[i, i + 1] for i in range(last_id)]
+        edges = [
+            {"src": i, "dst": i + 1, "type": "seq"}
+            for i in range(last_id)
+        ]
 
         # 5) start_time / puid 보존(가능 시)
         meta: Dict[str, Union[int, float]] = {}


### PR DESCRIPTION
## Summary
- allow `SysCallLoader` to parse edges as dictionaries
- output dictionary edges in `_convert_pejson_to_syscalls`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c72fb4388832e94c60d0279e737d3