### PR TITLE
Fix FCG conversion output

### DIFF
--- a/src/graphs/loaders/fcg_loader.py
+++ b/src/graphs/loaders/fcg_loader.py
@@ -130,7 +130,7 @@ class FCGLoader(GraphLoaderBase):
                     "feat": [vsize],
                 }
             )
-            calls.append({"src": 0, "dst": idx, "type": "section"})
+            calls.append({"src": 0, "dst": idx, "type": "calls"})
 
         return {"functions": functions, "calls": calls, "entry_id": 0}
 

--- a/tests/test_fcg_loader.py
+++ b/tests/test_fcg_loader.py
@@ -29,5 +29,5 @@ def test_convert_pejson_to_fcg():
     assert len(section_funcs) == num_sections
 
     for idx in range(1, num_sections + 1):
-        assert fcg["calls"][idx - 1] == {"src": 0, "dst": idx, "type": "section"}
+        assert fcg["calls"][idx - 1] == {"src": 0, "dst": idx, "type": "calls"}
 


### PR DESCRIPTION
## Summary
- adjust FCG PE-JSON conversion call type to `calls`
- update test expectation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c72fbe684832e814f5e632fbbbf66