### PR TITLE
Fix CFG edge type constant

### DIFF
--- a/src/graphs/loaders/cfg_loader.py
+++ b/src/graphs/loaders/cfg_loader.py
@@ -14,7 +14,7 @@ from .base import GraphLoaderBase, register_loader
 #  공통 상수
 # ──────────────────────────────────────────────────────────────────────────────
 _EDGE_KIND_CONTAINS = "contains"          # file → section / section → entry
-_EDGE_KIND_LINEAR   = "linear_fallthrough"  # 섹션 내 BB 선형 연결
+_EDGE_KIND_LINEAR   = "cfg"                 # 섹션 내 BB 선형 연결
 
 
 @register_loader("cfg")
@@ -103,7 +103,7 @@ class CFGLoader(GraphLoaderBase):
 
           • root(node kind=file) → section 노드(edge=contains)
           • 각 section 내부에 1개의 BB 노드(fake BB) 생성
-          • section BB들을 linear_fallthrough로 연결 (PE 섹션 순서)
+         • section BB들을 cfg로 연결 (PE 섹션 순서)
           • entry_point address가 해당 section BB라면 entry 지정
         """
         nodes: List[dict] = []


### PR DESCRIPTION
## Summary
- rename `_EDGE_KIND_LINEAR` constant value to `"cfg"`
- keep using the constant when connecting basic blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c72fcbcbc832e8bc6607499161f0a