### PR TITLE
Add AST token normalisation

### DIFF
--- a/src/graphs/loaders/ast_loader.py
+++ b/src/graphs/loaders/ast_loader.py
@@ -5,6 +5,24 @@ import json
 from pathlib import Path
 from typing import Dict, List, Sequence, Union
 
+# --------------------------------------------------------------------------- #
+#  Token leaf kinds to be collapsed into a single 'token' category
+# --------------------------------------------------------------------------- #
+_TOKEN_LEAF_KINDS = {
+    "identifier",
+    "string_literal",
+    "number_literal",
+    "char_literal",
+    "comment",
+}
+
+
+def _normalise_ast(nodes: Sequence[dict], edges: Sequence) -> None:
+    """Normalize AST nodes in-place."""
+    for n in nodes:
+        if n.get("kind") in _TOKEN_LEAF_KINDS:
+            n["kind"] = "token"
+
 import torch
 from torch_geometric.data import Data
 
@@ -39,6 +57,8 @@ class ASTLoader(GraphLoaderBase):
         # -------- A) 스키마 감지 & 필요 시 변환 -------------------- #
         if "nodes" not in js:  # = PE 메타 형식
             js = self._convert_pejson_to_ast(js)
+
+        _normalise_ast(js["nodes"], js.get("edges", []))
 
         # -------- B) 공통 AST 처리(기존 코드) ---------------------- #
         nodes: Sequence[dict] = js["nodes"]


### PR DESCRIPTION
## Summary
- recognise leaf node kinds for AST graphs
- map token leaves to the unified `token` type when loading graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c72fd77c0832e91986c1b166c1538