### PR TITLE
Enable token extraction from code in AST loader

### DIFF
--- a/src/graphs/loaders/ast_loader.py
+++ b/src/graphs/loaders/ast_loader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gzip
 import json
+import re
 from pathlib import Path
 from typing import Dict, List, Sequence, Union
 
@@ -14,7 +15,11 @@ _TOKEN_LEAF_KINDS = {
     "number_literal",
     "char_literal",
     "comment",
+    "token",
 }
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,60}")
+_MAX_TOKENS = 512
 
 
 def _normalise_ast(nodes: Sequence[dict], edges: Sequence) -> None:
@@ -104,8 +109,9 @@ class ASTLoader(GraphLoaderBase):
     @staticmethod
     def _convert_pejson_to_ast(js: dict) -> dict:
         """
-        PE 분석 JSON(역‑공학 도구 출력)을 AST 스키마
-        { "nodes": [...], "edges": [...] } 로 변환한다.
+        PE 분석 JSON(역‑공학 도구 출력)을 간이 AST 스키마로 변환
+        또한 c_code/asm_code/llvm_ir 필드에서 토큰을 추출하여
+        file 노드의 자식으로 연결한다.
         """
         nodes: List[dict] = []
         edges: List[List[int]] = []
@@ -145,14 +151,34 @@ class ASTLoader(GraphLoaderBase):
             nodes.append({"id": nid, "kind": "current_function", "feat": [size]})
             edges.append([root, nid])
 
+
         # 5) 파일 엔트로피
         if js.get("file_entropy") is not None:
             nid = next_id
             next_id += 1
-            nodes.append(
-                {"id": nid, "kind": "entropy", "feat": [float(js["file_entropy"])]}
-            )
+            nodes.append({"id": nid, "kind": "entropy", "feat": [float(js["file_entropy"])]})
             edges.append([root, nid])
+
+        # 6) 코드 문자열에서 토큰 추출
+        code_fields = ("c_code", "asm_code", "llvm_ir")
+        lines: List[str] = []
+        for field in code_fields:
+            lines.extend(js.get(field, []))
+
+        if lines:
+            seen: set[str] = set()
+            for line in lines:
+                for tok in _TOKEN_RE.findall(line):
+                    if tok in seen:
+                        continue
+                    seen.add(tok)
+                    nodes.append({"id": next_id, "kind": "token", "text": tok, "feat": []})
+                    edges.append([root, next_id])
+                    next_id += 1
+                    if len(seen) >= _MAX_TOKENS:
+                        break
+                if len(seen) >= _MAX_TOKENS:
+                    break
 
         return {"nodes": nodes, "edges": edges}
 

--- a/tests/test_ast_loader.py
+++ b/tests/test_ast_loader.py
@@ -1,0 +1,20 @@
+import pytest
+pytest.importorskip("torch")
+
+from src.graphs.loaders.ast_loader import ASTLoader
+
+
+def test_convert_pejson_extracts_tokens():
+    sample = {
+        "pe_headers": {},
+        "c_code": ["int main() { sub_1003A53B(); }"]
+    }
+    ast = ASTLoader._convert_pejson_to_ast(sample)
+    token_nodes = [n for n in ast["nodes"] if n["kind"] == "token"]
+    texts = {n["text"] for n in token_nodes}
+    assert "main" in texts
+    assert "sub_1003A53B" in texts
+    for n in token_nodes:
+        root_edges = [e for e in ast["edges"] if e[1] == n["id"]]
+        assert root_edges and root_edges[0][0] == 0
+


### PR DESCRIPTION
## Summary
- extract unique tokens from `c_code`, `asm_code`, and `llvm_ir` in AST loader
- normalize tokens with a small regex and limit node count
- add regression test for `_convert_pejson_to_ast`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8766dd94832eb72d1ee61b26b05d