### PR TITLE
Add token extraction to CFG loader

### DIFF
--- a/src/graphs/loaders/cfg_loader.py
+++ b/src/graphs/loaders/cfg_loader.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from typing import Dict, List, Sequence, Tuple, Union
 
+from .common_token_utils import TOKEN_RE, MAX_TOKENS
+
 import torch
 from torch_geometric.data import Data
 
@@ -15,6 +17,11 @@ from .base import GraphLoaderBase, register_loader
 # ──────────────────────────────────────────────────────────────────────────────
 _EDGE_KIND_CONTAINS = "contains"          # file → section / section → entry
 _EDGE_KIND_LINEAR   = "cfg"                 # 섹션 내 BB 선형 연결
+
+
+def _extract_tokens(line: str) -> List[str]:
+    """Return identifier-like tokens from a code line."""
+    return TOKEN_RE.findall(line)
 
 
 @register_loader("cfg")
@@ -86,6 +93,10 @@ class CFGLoader(GraphLoaderBase):
             data.x = x
         data.addr = addrs
         data.node_id = torch.tensor(list(id2idx.keys()), dtype=torch.long)
+        data.kind_str = [n.get("kind", "") for n in nodes]
+        texts = [n.get("text") for n in nodes]
+        if any(t is not None for t in texts):
+            data.text = texts
         if "entry" in js:                                 # 기존 엔트리 필드
             data.entry_id = torch.tensor([id2idx[js["entry"]]], dtype=torch.long)
         elif "entry_id" in js:                             # 변환 시 추가한 필드
@@ -133,6 +144,7 @@ class CFGLoader(GraphLoaderBase):
 
         # 2) 섹션마다 ‘대표 BB’ 노드(fake basic block)
         bb_nodes: List[int] = []
+        total_tokens = 0
         for sid, sec in sec_nodes:
             bid = next_id
             next_id += 1
@@ -145,6 +157,22 @@ class CFGLoader(GraphLoaderBase):
             # section → BB (포함) edge
             edges.append({"src": sid, "dst": bid, "type": _EDGE_KIND_CONTAINS})
             bb_nodes.append(bid)
+
+            tok_count = 0
+            for field in ("asm_code", "code"):
+                for line in sec.get(field, []):
+                    for tok in _extract_tokens(line):
+                        if tok_count >= 64 or total_tokens >= MAX_TOKENS:
+                            break
+                        nodes.append({"id": next_id, "kind": "token", "text": tok})
+                        edges.append({"src": bid, "dst": next_id, "type": _EDGE_KIND_CONTAINS})
+                        next_id += 1
+                        tok_count += 1
+                        total_tokens += 1
+                    if tok_count >= 64 or total_tokens >= MAX_TOKENS:
+                        break
+                if tok_count >= 64 or total_tokens >= MAX_TOKENS:
+                    break
 
         # 3) BB 사이 연속 edge (섹션 순서대로 fall‑through 가정)
         for a, b in zip(bb_nodes, bb_nodes[1:]):

--- a/src/graphs/loaders/common_token_utils.py
+++ b/src/graphs/loaders/common_token_utils.py
@@ -1,0 +1,7 @@
+import re
+
+# Common regex for C/ASM identifiers (1-61 chars) used across loaders
+TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,60}")
+
+# Hard cap for number of tokens extracted from a single graph
+MAX_TOKENS = 512

--- a/tests/test_cfg_loader.py
+++ b/tests/test_cfg_loader.py
@@ -1,0 +1,57 @@
+import json
+import pytest
+
+pytest.importorskip("torch")
+
+from src.graphs.loaders.cfg_loader import CFGLoader, _EDGE_KIND_CONTAINS
+
+
+def test_convert_pejson_to_cfg_extracts_tokens():
+    sample = {
+        "pe_headers": {
+            "sections": [
+                {
+                    "virtual_address": "0x1000",
+                    "virtual_size": "0x200",
+                    "asm_code": ["mov eax, ebx", "call sub_1000"],
+                },
+                {
+                    "virtual_address": "0x2000",
+                    "virtual_size": "0x200",
+                    "code": ["int main() { return 0; }"]
+                },
+            ]
+        }
+    }
+
+    cfg = CFGLoader._convert_pejson_to_cfg(sample)
+    token_nodes = [n for n in cfg["nodes"] if n.get("kind") == "token"]
+    texts = {n["text"] for n in token_nodes}
+    assert "mov" in texts
+    assert "sub_1000" in texts
+    assert "main" in texts
+    bb_ids = {n["id"] for n in cfg["nodes"] if n["kind"] == "bb"}
+    for t in token_nodes:
+        edge = next(e for e in cfg["edges"] if e["dst"] == t["id"])
+        assert edge["src"] in bb_ids
+        assert edge["type"] == _EDGE_KIND_CONTAINS
+
+
+def test_parse_preserves_kind_and_text():
+    sample = {
+        "pe_headers": {
+            "sections": [
+                {
+                    "virtual_address": "0x1000",
+                    "virtual_size": "0x200",
+                    "code": ["int main() {}"]
+                }
+            ]
+        }
+    }
+    raw = json.dumps(sample).encode()
+    loader = CFGLoader()
+    data = loader._parse(raw)
+    assert hasattr(data, "kind_str")
+    assert hasattr(data, "text")
+    assert "main" in data.text


### PR DESCRIPTION
## Summary
- share token utils used by loaders
- extract tokens for each section while converting PE metadata to CFG
- preserve node `kind_str` and `text` info in CFG loader
- test PE JSON conversion and parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8ae9748c832e9bd06c5d8eadf997