### PR TITLE
Add token extraction to FCG loader

### DIFF
--- a/src/graphs/loaders/common_token_utils.py
+++ b/src/graphs/loaders/common_token_utils.py
@@ -1,0 +1,9 @@
+import re
+
+TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,60}")
+MAX_TOKENS = 512
+
+
+def split_name(name: str) -> list[str]:
+    """Split identifier/name into token components."""
+    return TOKEN_RE.findall(name)

--- a/src/graphs/loaders/fcg_loader.py
+++ b/src/graphs/loaders/fcg_loader.py
@@ -9,6 +9,12 @@ import torch
 from torch_geometric.data import Data
 
 from .base import GraphLoaderBase, register_loader
+from .common_token_utils import TOKEN_RE, MAX_TOKENS, split_name
+
+# --------------------------------------------------------------------------- #
+#  Shared constants
+# --------------------------------------------------------------------------- #
+_EDGE_KIND_CONTAINS = "contains"
 
 
 @register_loader("fcg")
@@ -32,25 +38,54 @@ class FCGLoader(GraphLoaderBase):
         if "functions" not in js:          # ⇒ PE 메타 형식
             js = self._convert_pejson_to_fcg(js)
 
-        funcs: Sequence[dict] = js["functions"]
-        id2idx: Dict[int, int] = {f["id"]: i for i, f in enumerate(funcs)}
-        n_nodes = len(funcs)
+        functions: List[dict] = list(js["functions"])
+        calls: List[Dict[str, Union[int, str]]] = list(js.get("calls", []))
+
+        # -------- B) 함수명 토큰 노드 추가 ---------------------- #
+        next_id = max((f["id"] for f in functions), default=-1) + 1
+        token_cnt = 0
+        orig_funcs = list(functions)
+        for fn in orig_funcs:
+            for tok in split_name(fn.get("name", "")):
+                if token_cnt >= MAX_TOKENS:
+                    break
+                functions.append({"id": next_id, "kind": "token", "text": tok})
+                calls.append(
+                    {"src": fn["id"], "dst": next_id, "type": _EDGE_KIND_CONTAINS}
+                )
+                next_id += 1
+                token_cnt += 1
+            if token_cnt >= MAX_TOKENS:
+                break
+
+        js["functions"] = functions
+        js["calls"] = calls
+
+        id2idx: Dict[int, int] = {f["id"]: i for i, f in enumerate(functions)}
+        n_nodes = len(functions)
 
         # -------- 1) 노드 메타 & feat ------------------------- #
-        names: List[str] = [f.get("name", f"fn_{f['id']}") for f in funcs]
+        names: List[str] = [f.get("name", f.get("text", f"fn_{f['id']}") ) for f in functions]
         addrs: List[int] = []
-        for f in funcs:
+        for f in functions:
             try:
                 addrs.append(_hex_to_int(f.get("addr", 0)))
             except Exception:  # noqa: BLE001 -- non-numeric addr
                 addrs.append(0)
-        is_ext = torch.tensor([bool(f.get("external", False)) for f in funcs])
+        is_ext = torch.tensor([bool(f.get("external", False)) for f in functions])
+
+        kind_str: List[str] = [
+            "token" if f.get("kind") == "token" else "function" for f in functions
+        ]
+        texts: List[str] = [
+            f.get("text", f.get("name", f"fn_{f['id']}") ) for f in functions
+        ]
 
         # --- feat 행렬 (있을 때만) ---------------------------- #
-        if any("feat" in f and f["feat"] for f in funcs):
-            feat_dim = max(len(f.get("feat", [])) for f in funcs)
+        if any("feat" in f and f["feat"] for f in functions):
+            feat_dim = max(len(f.get("feat", [])) for f in functions)
             x = torch.zeros((n_nodes, feat_dim), dtype=torch.float)
-            for i, f in enumerate(funcs):
+            for i, f in enumerate(functions):
                 if f.get("feat"):
                     v = torch.as_tensor(f["feat"], dtype=torch.float)
                     x[i, : v.numel()] = v
@@ -86,6 +121,8 @@ class FCGLoader(GraphLoaderBase):
         data.addr = addrs
         data.is_external = is_ext.bool()
         data.node_id = torch.tensor(list(id2idx.keys()), dtype=torch.long)
+        data.kind_str = kind_str
+        data.text = texts
 
         # 엔트리 필드
         if "entry" in js:
@@ -131,6 +168,22 @@ class FCGLoader(GraphLoaderBase):
                 }
             )
             calls.append({"src": 0, "dst": idx, "type": "calls"})
+
+        # ---- 함수명 토큰 추출 -----------------------------------
+        next_id = len(functions)
+        token_cnt = 0
+        for fn in list(functions):
+            for tok in split_name(fn.get("name", "")):
+                if token_cnt >= MAX_TOKENS:
+                    break
+                functions.append({"id": next_id, "kind": "token", "text": tok})
+                calls.append(
+                    {"src": fn["id"], "dst": next_id, "type": _EDGE_KIND_CONTAINS}
+                )
+                next_id += 1
+                token_cnt += 1
+            if token_cnt >= MAX_TOKENS:
+                break
 
         return {"functions": functions, "calls": calls, "entry_id": 0}
 

--- a/tests/test_fcg_loader.py
+++ b/tests/test_fcg_loader.py
@@ -31,3 +31,16 @@ def test_convert_pejson_to_fcg():
     for idx in range(1, num_sections + 1):
         assert fcg["calls"][idx - 1] == {"src": 0, "dst": idx, "type": "calls"}
 
+    token_nodes = [n for n in fcg["functions"] if n.get("kind") == "token"]
+    texts = {n["text"] for n in token_nodes}
+    assert "entry_start" in texts
+
+
+def test_parse_adds_token_nodes():
+    js = {"functions": [{"id": 0, "name": "foo"}], "calls": []}
+    g = FCGLoader()._parse(json.dumps(js))
+    assert g.kind_str[0] == "function"
+    assert "token" in g.kind_str[1]
+    assert g.text[1] == "foo"
+    assert g.edge_type.numel() == 1
+


### PR DESCRIPTION
## Summary
- share token helper utils for loaders
- augment FCG loader to generate token nodes from function names
- expose node kind/text fields in FCG Data
- test token extraction via loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8aeaf630832ebe8871f0a241876f