### PR TITLE
Enhance Syscall loader with token nodes

### DIFF
--- a/src/graphs/loaders/common_token_utils.py
+++ b/src/graphs/loaders/common_token_utils.py
@@ -1,0 +1,1 @@
+MAX_TOKENS = 512

--- a/src/graphs/loaders/syscall_loader.py
+++ b/src/graphs/loaders/syscall_loader.py
@@ -9,6 +9,9 @@ import torch
 from torch_geometric.data import Data
 
 from .base import GraphLoaderBase, register_loader
+from .common_token_utils import MAX_TOKENS
+
+_EDGE_KIND_CONTAINS = "contains"
 
 
 @register_loader("syscall")
@@ -32,8 +35,20 @@ class SysCallLoader(GraphLoaderBase):
         if "syscalls" not in js:          # ⇒ PE 메타 형식
             js = self._convert_pejson_to_syscalls(js)
 
-        calls = js["syscalls"]
+        calls = list(js["syscalls"])
         n_nodes = len(calls)
+
+        token_nodes: List[dict] = []
+        token_edges: List[dict] = []
+        for sc in calls:
+            if len(token_nodes) >= MAX_TOKENS:
+                break
+            tid = n_nodes + len(token_nodes)
+            token_nodes.append({"id": tid, "kind": "token", "text": sc["name"]})
+            token_edges.append({"src": sc["id"], "dst": tid, "type": _EDGE_KIND_CONTAINS})
+
+        js["syscalls"].extend(token_nodes)
+        js.setdefault("edges", []).extend(token_edges)
 
         # -------- 1) syscall 이름 → 정수 인코딩 -------------------- #
         names: List[str] = [c["name"] for c in calls]
@@ -73,6 +88,7 @@ class SysCallLoader(GraphLoaderBase):
         if x is not None:
             data.x = x
         data.sc_name = names
+        data.token_text = [sc["name"] for sc in calls[:MAX_TOKENS]]
 
         # -------- 5) (선택) 메타 필드 ----------------------------- #
         if "start_time" in js:


### PR DESCRIPTION
## Summary
- add `common_token_utils` for shared MAX_TOKENS constant
- extend `SysCallLoader` to create token nodes per syscall
- keep token list under `token_text` in returned Data

## Testing
- `pytest tests/test_ast_loader.py tests/test_fcg_loader.py tests/test_normalizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8aec823c832e9abc44578d81be0d