### PR TITLE
Add token node support in syscall loader

### DIFF
--- a/src/graphs/loaders/syscall_loader.py
+++ b/src/graphs/loaders/syscall_loader.py
@@ -9,6 +9,12 @@ import torch
 from torch_geometric.data import Data
 
 from .base import GraphLoaderBase, register_loader
+from .common_token_utils import MAX_TOKENS
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+_EDGE_KIND_CONTAINS = "contains"
 
 
 @register_loader("syscall")
@@ -33,12 +39,29 @@ class SysCallLoader(GraphLoaderBase):
             js = self._convert_pejson_to_syscalls(js)
 
         calls = js["syscalls"]
+        syscall_names = [c["name"] for c in calls]
+        n_nodes = len(calls)
+
+        # -------- B) syscall 이름을 토큰 노드로 변환 ----------------- #
+        token_nodes: List[dict] = []
+        token_edges: List[Dict[str, Union[int, str]]] = []
+        for sc in calls:
+            if len(token_nodes) >= MAX_TOKENS:
+                break
+            tid = n_nodes + len(token_nodes)
+            token_nodes.append({"id": tid, "kind": "token", "text": sc["name"]})
+            token_edges.append(
+                {"src": sc["id"], "dst": tid, "type": _EDGE_KIND_CONTAINS}
+            )
+
+        calls.extend(token_nodes)
+        js.setdefault("edges", []).extend(token_edges)
         n_nodes = len(calls)
 
         # -------- 1) syscall 이름 → 정수 인코딩 -------------------- #
-        names: List[str] = [c["name"] for c in calls]
-        name2id: Dict[str, int] = {n: i for i, n in enumerate(sorted(set(names)))}
-        sc_id = torch.tensor([name2id[n] for n in names], dtype=torch.long)
+        names_all: List[str] = [c.get("name", c.get("text", "")) for c in calls]
+        name2id: Dict[str, int] = {n: i for i, n in enumerate(sorted(set(names_all)))}
+        sc_id = torch.tensor([name2id[n] for n in names_all], dtype=torch.long)
 
         # -------- 2) (선택) 노드 특성 행렬 ------------------------ #
         if any("feat" in c and c["feat"] for c in calls):
@@ -72,7 +95,8 @@ class SysCallLoader(GraphLoaderBase):
         data = Data(edge_index=edge_index, sc_id=sc_id)
         if x is not None:
             data.x = x
-        data.sc_name = names
+        data.sc_name = syscall_names
+        data.token_text = [t["text"] for t in token_nodes]
 
         # -------- 5) (선택) 메타 필드 ----------------------------- #
         if "start_time" in js:

--- a/tests/test_syscall_loader.py
+++ b/tests/test_syscall_loader.py
@@ -1,0 +1,31 @@
+import json
+import pytest
+
+pytest.importorskip("torch")
+
+from src.graphs.loaders.syscall_loader import SysCallLoader
+
+
+def test_parse_adds_token_nodes_and_edges():
+    sample = {
+        "syscalls": [
+            {"id": 0, "name": "open"},
+            {"id": 1, "name": "read"},
+        ],
+        "edges": [
+            {"src": 0, "dst": 1, "type": "seq"}
+        ],
+    }
+    raw = json.dumps(sample).encode()
+    loader = SysCallLoader()
+    data = loader._parse(raw)
+    # original syscall names preserved
+    assert data.sc_name == ["open", "read"]
+    # token texts added
+    assert hasattr(data, "token_text")
+    assert set(data.token_text) >= {"open", "read"}
+    # token nodes increase node count
+    assert data.num_nodes == 4
+    # edges include seq edge and token edges
+    assert data.edge_index.size(1) == 3
+


### PR DESCRIPTION
## Summary
- attach token nodes extracted from syscall names
- expose `_EDGE_KIND_CONTAINS` and import `MAX_TOKENS`
- store syscall tokens in `token_text`
- test `SysCallLoader` token extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c8e7c8184832ebb702b6475fc20a2