### PR TITLE
Add token node support in FCG loader

### DIFF
--- a/src/graphs/loaders/common_token_utils.py
+++ b/src/graphs/loaders/common_token_utils.py
@@ -1,7 +1,18 @@
 import re
+from typing import List
 
 # Common regex for C/ASM identifiers (1-61 chars) used across loaders
 TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,60}")
 
 # Hard cap for number of tokens extracted from a single graph
 MAX_TOKENS = 512
+
+
+def split_name(name: str) -> List[str]:
+    """Return identifier-like parts of a symbol name."""
+    parts = re.sub(r"[^A-Za-z0-9_]", " ", name).split()
+    tokens: List[str] = []
+    for part in parts:
+        tokens.extend(TOKEN_RE.findall(part))
+    return tokens
+

--- a/src/graphs/loaders/fcg_loader.py
+++ b/src/graphs/loaders/fcg_loader.py
@@ -9,6 +9,12 @@ import torch
 from torch_geometric.data import Data
 
 from .base import GraphLoaderBase, register_loader
+from .common_token_utils import TOKEN_RE, MAX_TOKENS, split_name
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+_EDGE_KIND_CONTAINS = "contains"
 
 
 @register_loader("fcg")
@@ -33,6 +39,23 @@ class FCGLoader(GraphLoaderBase):
             js = self._convert_pejson_to_fcg(js)
 
         funcs: Sequence[dict] = js["functions"]
+
+        # -------- B) 함수 이름을 토큰 노드로 변환 -------------- #
+        next_id = max((f["id"] for f in funcs), default=-1) + 1
+        token_cnt = 0
+        for fn in list(funcs):
+            for tok in split_name(fn.get("name", "")):
+                if token_cnt >= MAX_TOKENS:
+                    break
+                funcs.append({"id": next_id, "kind": "token", "text": tok})
+                js.setdefault("calls", []).append(
+                    {"src": fn["id"], "dst": next_id, "type": _EDGE_KIND_CONTAINS}
+                )
+                next_id += 1
+                token_cnt += 1
+            if token_cnt >= MAX_TOKENS:
+                break
+
         id2idx: Dict[int, int] = {f["id"]: i for i, f in enumerate(funcs)}
         n_nodes = len(funcs)
 
@@ -86,6 +109,10 @@ class FCGLoader(GraphLoaderBase):
         data.addr = addrs
         data.is_external = is_ext.bool()
         data.node_id = torch.tensor(list(id2idx.keys()), dtype=torch.long)
+        data.kind_str = [f.get("kind", "function") for f in funcs]
+        texts = [f.get("text") for f in funcs]
+        if any(t is not None for t in texts):
+            data.text = texts
 
         # 엔트리 필드
         if "entry" in js:
@@ -131,6 +158,20 @@ class FCGLoader(GraphLoaderBase):
                 }
             )
             calls.append({"src": 0, "dst": idx, "type": "calls"})
+
+        # 3) 함수 이름 토큰 노드
+        next_id = len(functions)
+        token_cnt = 0
+        for fn in list(functions):
+            for tok in split_name(fn["name"]):
+                if token_cnt >= MAX_TOKENS:
+                    break
+                functions.append({"id": next_id, "kind": "token", "text": tok})
+                calls.append({"src": fn["id"], "dst": next_id, "type": _EDGE_KIND_CONTAINS})
+                next_id += 1
+                token_cnt += 1
+            if token_cnt >= MAX_TOKENS:
+                break
 
         return {"functions": functions, "calls": calls, "entry_id": 0}
 

--- a/tests/test_fcg_loader.py
+++ b/tests/test_fcg_loader.py
@@ -3,7 +3,7 @@ import json
 
 pytest.importorskip("torch")
 
-from src.graphs.loaders.fcg_loader import FCGLoader
+from src.graphs.loaders.fcg_loader import FCGLoader, _EDGE_KIND_CONTAINS
 
 
 def test_convert_pejson_to_fcg():
@@ -30,4 +30,42 @@ def test_convert_pejson_to_fcg():
 
     for idx in range(1, num_sections + 1):
         assert fcg["calls"][idx - 1] == {"src": 0, "dst": idx, "type": "calls"}
+
+
+def test_convert_pejson_to_fcg_adds_tokens():
+    sample = {
+        "pe_headers": {
+            "entry_point": "0x1000",
+            "sections": [
+                {"name": ".text", "virtual_address": "0x1000", "virtual_size": "0x100"}
+            ],
+        },
+        "get_current_function": {"size": "0x50"},
+    }
+
+    fcg = FCGLoader._convert_pejson_to_fcg(sample)
+    tokens = [f for f in fcg["functions"] if f.get("kind") == "token"]
+    assert tokens
+    token_ids = {t["id"] for t in tokens}
+    for t in tokens:
+        edge = next(e for e in fcg["calls"] if e["dst"] == t["id"])
+        assert edge["type"] == _EDGE_KIND_CONTAINS
+        assert edge["src"] not in token_ids
+
+
+def test_parse_preserves_kind_and_text():
+    sample = {
+        "functions": [
+            {"id": 0, "name": "main", "addr": "0x0"},
+            {"id": 1, "name": "helper_func", "addr": "0x10"},
+        ],
+        "calls": [{"src": 0, "dst": 1, "type": "calls"}],
+        "entry": 0,
+    }
+    raw = json.dumps(sample).encode()
+    data = FCGLoader()._parse(raw)
+    assert hasattr(data, "kind_str")
+    assert hasattr(data, "text")
+    assert "main" in data.text
+    assert any(k == "token" for k in data.kind_str)
 


### PR DESCRIPTION
## Summary
- extract tokens from function names in FCG loader
- provide helper `split_name` for common token utils
- include token edges and metadata fields in parsed data
- add tests for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c90135c5c832e8c8f3f569801709c