### PR TITLE
Add token nodes support in graph normalizers

### DIFF
--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -41,51 +41,84 @@ class CFGNormalizer(NormalizerBase):
 
         new_g = HeteroData()
 
+        kinds = getattr(g, "kind_str", None)
+        texts = getattr(g, "text", None)
+
+        bb_idx = [i for i, k in enumerate(kinds) if k == "bb"] if kinds else list(range(g.num_nodes))
+        tok_idx = [i for i, k in enumerate(kinds) if k == "token"] if kinds else []
+
+        bb_map = {old: i for i, old in enumerate(bb_idx)}
+        tok_map = {old: i for i, old in enumerate(tok_idx)}
+
         # ────────────────────────────────────────────────────────────
         # 1) 노드 - BasicBlock
         # ────────────────────────────────────────────────────────────
         bb_store = new_g[NodeType.BB.value]
 
-        # (1-a) 기본 feature
         if hasattr(g, "x") and g.x is not None:
-            bb_store.feat = g.x.clone()
+            bb_store.feat = g.x[bb_idx].clone()
 
-        # (1-b) 주소 문자열
         if hasattr(g, "addr"):
-            bb_store.addr = list(g.addr)
+            bb_store.addr = [g.addr[i] for i in bb_idx]
 
-        # (1-c) inst_cnt : 없는 경우 0 으로 패딩
-        n_nodes = g.num_nodes
-        bb_store.num_nodes = n_nodes
+        n_nodes = len(bb_idx)
         if hasattr(g, "inst_cnt"):
-            bb_store.inst_cnt = torch.as_tensor(g.inst_cnt)
+            bb_store.inst_cnt = torch.as_tensor(g.inst_cnt)[bb_idx]
         else:
             bb_store.inst_cnt = torch.zeros(n_nodes, dtype=torch.long)
-        # 명시적으로 설정해 PyG 경고 방지
         bb_store.num_nodes = n_nodes
 
         # ────────────────────────────────────────────────────────────
-        # 2) 엣지 – ('bb', 'cfg', 'bb')
+        # 2) 토큰 노드 (선택)
+        # ────────────────────────────────────────────────────────────
+        if tok_idx:
+            tok_store = new_g[NodeType.TOKEN.value]
+            if texts:
+                tok_store.text = [texts[i] for i in tok_idx]
+            tok_store.num_nodes = len(tok_idx)
+
+        # ────────────────────────────────────────────────────────────
+        # 3) 엣지 – ('bb', 'cfg', 'bb') + ('bb','child','token')
         # ────────────────────────────────────────────────────────────
         rel_key = (NodeType.BB.value, EdgeRel.CFG.value, NodeType.BB.value)
         edge_store = new_g[rel_key]
-        edge_store.edge_index = g.edge_index.clone()
 
-        # edge_type : 스키마 id 로 채움 (필수)
+        cfg_edges = []
+        child_edges = []
+        for src, dst in g.edge_index.t().tolist():
+            if src in bb_map and dst in bb_map:
+                cfg_edges.append([bb_map[src], bb_map[dst]])
+            elif src in bb_map and dst in tok_map:
+                child_edges.append([bb_map[src], tok_map[dst]])
+
+        if cfg_edges:
+            edge_store.edge_index = torch.tensor(cfg_edges, dtype=torch.long).t().contiguous()
+        else:
+            edge_store.edge_index = torch.empty((2, 0), dtype=torch.long)
+
         edge_store.edge_type = torch.full(
-            (g.edge_index.size(1),),
+            (edge_store.edge_index.size(1),),
             EDGE_REL_ID[EdgeRel.CFG.value],
             dtype=torch.long,
         )
 
-        # raw_edge_kind : 원본 edge_type(분기 종류 등)을 보존하고 싶다면 추가
-        if hasattr(g, "edge_type"):
-            edge_store.raw_edge_kind = g.edge_type.clone()
+
+        if child_edges:
+            rel_key_tok = (NodeType.BB.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)
+            tok_edge_store = new_g[rel_key_tok]
+            tok_edge_store.edge_index = (
+                torch.tensor(child_edges, dtype=torch.long).t().contiguous()
+            )
+            tok_edge_store.edge_type = torch.full(
+                (tok_edge_store.edge_index.size(1),),
+                EDGE_REL_ID[EdgeRel.CHILD.value],
+                dtype=torch.long,
+            )
 
         # ────────────────────────────────────────────────────────────
-        # 3) 그래프-레벨 메타
+        # 4) 그래프-레벨 메타
         # ────────────────────────────────────────────────────────────
-        if hasattr(g, "entry_id"):
-            new_g.entry_bb = g.entry_id.clone()
+        if hasattr(g, "entry_id") and int(g.entry_id[0]) in bb_map:
+            new_g.entry_bb = torch.tensor([bb_map[int(g.entry_id[0])]], dtype=torch.long)
 
         return new_g

--- a/src/graphs/normalizers/fcg_norm.py
+++ b/src/graphs/normalizers/fcg_norm.py
@@ -41,33 +41,45 @@ class FCGNormalizer(NormalizerBase):
 
         new_g = HeteroData()
 
+        kinds = getattr(g, "kind_str", None)
+        texts = getattr(g, "text", None)
+
+        fn_idx = [i for i, k in enumerate(kinds) if k != "token"] if kinds else list(range(g.num_nodes))
+        tok_idx = [i for i, k in enumerate(kinds) if k == "token"] if kinds else []
+
+        fn_map = {old: i for i, old in enumerate(fn_idx)}
+        tok_map = {old: i for i, old in enumerate(tok_idx)}
+
         # ──────────────────────────────────────────────────────────
         # 1) 노드 – 'function'
         # ──────────────────────────────────────────────────────────
         fn_store = new_g[NodeType.FUNCTION.value]
 
-        # 노드 개수 기록
-        fn_store.num_nodes = g.num_nodes
-
-        # (1-a) Dense feature
         if hasattr(g, "x") and g.x is not None:
-            fn_store.feat = g.x.clone()
+            fn_store.feat = g.x[fn_idx].clone()
 
-        # (1-b) addr / name 메타
         if hasattr(g, "addr"):
-            fn_store.addr = list(g.addr)
+            fn_store.addr = [g.addr[i] for i in fn_idx]
         if hasattr(g, "name"):
-            fn_store.name = list(g.name)
+            fn_store.name = [g.name[i] for i in fn_idx]
 
-        # (1-c) is_external  (없으면 False 패딩)
         if hasattr(g, "is_external"):
-            fn_store.is_external = g.is_external.clone()
+            fn_store.is_external = g.is_external[fn_idx].clone()
         else:
-            fn_store.is_external = torch.zeros(g.num_nodes, dtype=torch.bool)
-        fn_store.num_nodes = g.num_nodes
+            fn_store.is_external = torch.zeros(len(fn_idx), dtype=torch.bool)
+        fn_store.num_nodes = len(fn_idx)
 
         # ──────────────────────────────────────────────────────────
-        # 2) 엣지 – ('function','calls','function')
+        # 2) 토큰 노드 (선택)
+        # ──────────────────────────────────────────────────────────
+        if tok_idx:
+            tok_store = new_g[NodeType.TOKEN.value]
+            if texts:
+                tok_store.text = [texts[i] for i in tok_idx]
+            tok_store.num_nodes = len(tok_idx)
+
+        # ──────────────────────────────────────────────────────────
+        # 3) 엣지 – ('function','calls','function') + ('function','child','token')
         # ──────────────────────────────────────────────────────────
         rel_key = (
             NodeType.FUNCTION.value,
@@ -75,23 +87,42 @@ class FCGNormalizer(NormalizerBase):
             NodeType.FUNCTION.value,
         )
         edge_store = new_g[rel_key]
-        edge_store.edge_index = g.edge_index.clone()
 
-        # 스키마 ID 로 채운 edge_type
+        call_edges = []
+        child_edges = []
+        for src, dst in g.edge_index.t().tolist():
+            if src in fn_map and dst in fn_map:
+                call_edges.append([fn_map[src], fn_map[dst]])
+            elif src in fn_map and dst in tok_map:
+                child_edges.append([fn_map[src], tok_map[dst]])
+
+        if call_edges:
+            edge_store.edge_index = torch.tensor(call_edges, dtype=torch.long).t().contiguous()
+        else:
+            edge_store.edge_index = torch.empty((2, 0), dtype=torch.long)
+
         edge_store.edge_type = torch.full(
-            (g.edge_index.size(1),),
+            (edge_store.edge_index.size(1),),
             EDGE_REL_ID[EdgeRel.CALLS.value],
             dtype=torch.long,
         )
 
-        # 로더가 부여한 호출 종류(lib/direct 등) 보존
-        if hasattr(g, "edge_type"):
-            edge_store.raw_call_kind = g.edge_type.clone()
+        if child_edges:
+            rel_key_tok = (NodeType.FUNCTION.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)
+            tok_edge_store = new_g[rel_key_tok]
+            tok_edge_store.edge_index = (
+                torch.tensor(child_edges, dtype=torch.long).t().contiguous()
+            )
+            tok_edge_store.edge_type = torch.full(
+                (tok_edge_store.edge_index.size(1),),
+                EDGE_REL_ID[EdgeRel.CHILD.value],
+                dtype=torch.long,
+            )
 
         # ──────────────────────────────────────────────────────────
-        # 3) 그래프-레벨 메타
+        # 4) 그래프-레벨 메타
         # ──────────────────────────────────────────────────────────
-        if hasattr(g, "entry_id"):
-            new_g.entry_func = g.entry_id.clone()
+        if hasattr(g, "entry_id") and int(g.entry_id[0]) in fn_map:
+            new_g.entry_func = torch.tensor([fn_map[int(g.entry_id[0])]], dtype=torch.long)
 
         return new_g

--- a/src/graphs/normalizers/schema.py
+++ b/src/graphs/normalizers/schema.py
@@ -81,7 +81,7 @@ EDGE_TYPES: Final[Tuple[Tuple[str, str, str], ...]] = (
 #    - 정규화 시 해당 키만 남기거나, 누락 시 zero-vector 채움
 # --------------------------------------------------------------------------- #
 NODE_ATTRS: Final[Dict[NodeType, Sequence[str]]] = {
-    NodeType.TOKEN:    ("tok_id", "pos", "feat", "num_nodes"),
+    NodeType.TOKEN:    ("tok_id", "pos", "feat", "text", "num_nodes"),
     NodeType.BB:       ("feat", "addr", "inst_cnt", "num_nodes"),
     NodeType.FUNCTION: ("feat", "addr", "name", "is_external", "num_nodes"),
     NodeType.SYSCALL:  ("feat", "name", "num_nodes"),

--- a/src/graphs/normalizers/syscall_norm.py
+++ b/src/graphs/normalizers/syscall_norm.py
@@ -44,30 +44,37 @@ class SysCallNormalizer(NormalizerBase):
 
         new_g = HeteroData()
 
+        token_texts = getattr(g, "token_text", None)
+        n_tokens = len(token_texts) if token_texts else 0
+        n_syscalls = g.num_nodes - n_tokens
+
+        syscall_map = {i: i for i in range(n_syscalls)}
+        token_map = {n_syscalls + i: i for i in range(n_tokens)}
+
         # ──────────────────────────────────────────────────────────
         # 1) 노드 – 'syscall'
         # ──────────────────────────────────────────────────────────
         sc_store = new_g[NodeType.SYSCALL.value]
-        n_nodes = g.num_nodes
 
-        # 노드 개수 기록
-        sc_store.num_nodes = g.num_nodes
-
-        # (1-a) feat
         if hasattr(g, "x") and g.x is not None:
-            # 로더가 Dense 특성을 제공한 경우 그대로 사용
-            sc_store.feat = g.x.clone()
+            sc_store.feat = g.x[:n_syscalls].clone()
         else:
-            # Dense 특성이 없으면 sc_id(정수) → [N,1] Tensor 로 보관
-            sc_store.feat = g.sc_id.view(-1, 1).to(torch.float32)
+            sc_store.feat = g.sc_id[:n_syscalls].view(-1, 1).to(torch.float32)
 
-        # (1-b) name 리스트
         if hasattr(g, "sc_name"):
             sc_store.name = list(g.sc_name)
-        sc_store.num_nodes = n_nodes
+        sc_store.num_nodes = n_syscalls
 
         # ──────────────────────────────────────────────────────────
-        # 2) 엣지 – ('syscall','seq','syscall')
+        # 2) 토큰 노드 (선택)
+        # ──────────────────────────────────────────────────────────
+        if n_tokens > 0:
+            tok_store = new_g[NodeType.TOKEN.value]
+            tok_store.text = list(token_texts)
+            tok_store.num_nodes = n_tokens
+
+        # ──────────────────────────────────────────────────────────
+        # 3) 엣지 – seq + child(token)
         # ──────────────────────────────────────────────────────────
         rel_key = (
             NodeType.SYSCALL.value,
@@ -75,17 +82,40 @@ class SysCallNormalizer(NormalizerBase):
             NodeType.SYSCALL.value,
         )
         edge_store = new_g[rel_key]
-        edge_store.edge_index = g.edge_index.clone()
 
-        # edge_type (스키마 ID)
+        seq_edges = []
+        child_edges = []
+        for src, dst in g.edge_index.t().tolist():
+            if src < n_syscalls and dst < n_syscalls:
+                seq_edges.append([syscall_map[src], syscall_map[dst]])
+            elif src < n_syscalls and dst >= n_syscalls:
+                child_edges.append([syscall_map[src], token_map[dst]])
+
+        if seq_edges:
+            edge_store.edge_index = torch.tensor(seq_edges, dtype=torch.long).t().contiguous()
+        else:
+            edge_store.edge_index = torch.empty((2, 0), dtype=torch.long)
+
         edge_store.edge_type = torch.full(
-            (g.edge_index.size(1),),
+            (edge_store.edge_index.size(1),),
             EDGE_REL_ID[EdgeRel.SEQ.value],
             dtype=torch.long,
         )
 
+        if child_edges:
+            rel_key_tok = (NodeType.SYSCALL.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)
+            tok_edge_store = new_g[rel_key_tok]
+            tok_edge_store.edge_index = (
+                torch.tensor(child_edges, dtype=torch.long).t().contiguous()
+            )
+            tok_edge_store.edge_type = torch.full(
+                (tok_edge_store.edge_index.size(1),),
+                EDGE_REL_ID[EdgeRel.CHILD.value],
+                dtype=torch.long,
+            )
+
         # ──────────────────────────────────────────────────────────
-        # 3) 그래프-레벨 메타 데이터
+        # 4) 그래프-레벨 메타 데이터
         # ──────────────────────────────────────────────────────────
         if hasattr(g, "start_time"):
             new_g.start_time = float(g.start_time)


### PR DESCRIPTION
## Summary
- support token nodes in CFG, FCG and syscall normalizers
- allow token text attribute in schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c954690c4832e93ebc93cd897c871