### PR TITLE
Improve tokenization error handling

### DIFF
--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -289,10 +289,14 @@ def embed_corpus(
             if texts is None:
                 skipped += 1
                 continue
-            try:
-                from transformers import AutoTokenizer
+            from transformers import AutoTokenizer
 
+            try:
                 tok = AutoTokenizer.from_pretrained(encoder.config._name_or_path)
+            except Exception as exc:  # pragma: no cover - tokenizer optional
+                raise RuntimeError("Tokenizer required for text embeddings") from exc
+
+            try:
                 enc = tok(
                     list(texts),
                     padding=True,
@@ -300,10 +304,11 @@ def embed_corpus(
                     max_length=encoder.max_length,
                     return_tensors="pt",
                 )
-                input_ids = enc["input_ids"]
-                attn_mask = enc["attention_mask"]
-            except Exception as exc:  # pragma: no cover - tokenizer optional
-                raise RuntimeError("Tokenizer required for text embeddings") from exc
+            except Exception as exc:
+                raise RuntimeError(f"Tokenization failed for {out_name}: {exc}") from exc
+
+            input_ids = enc["input_ids"]
+            attn_mask = enc["attention_mask"]
 
         embeddings: list[torch.Tensor] = []
         for start in range(0, input_ids.size(0), batch_size):

--- a/tests/test_embed_stage.py
+++ b/tests/test_embed_stage.py
@@ -45,3 +45,31 @@ def test_embed_corpus_no_tokens(tmp_path):
     encoder = DummyEncoder()
     with pytest.raises(RuntimeError, match="No graphs"):
         embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+
+
+def test_embed_corpus_bad_text(tmp_path, monkeypatch):
+    hetero_dir = tmp_path / "hetero"
+    hetero_dir.mkdir()
+    g = HeteroData()
+    g["token"].text = ["bad"]
+    g["token"].num_nodes = 1
+    torch.save(g, hetero_dir / "bad.pt")
+
+    out_dir = tmp_path / "embeds"
+
+    class DummyTok:
+        def __call__(self, *args, **kwargs):
+            raise ValueError("boom")
+
+    class DummyAutoTok:
+        @staticmethod
+        def from_pretrained(name):
+            return DummyTok()
+
+    import src.models.llm_embed as llm_embed
+
+    monkeypatch.setattr(llm_embed, "AutoTokenizer", DummyAutoTok)
+
+    encoder = DummyEncoder()
+    with pytest.raises(RuntimeError, match="Tokenization failed for bad"):
+        embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)


### PR DESCRIPTION
## Summary
- narrow `except` around tokenizer loading vs. tokenization errors
- raise `RuntimeError` with file name on tokenization issues
- test invalid text handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9a803c20832e831c08262424e5a0