### PR TITLE
Handle empty corpus in embed_corpus

### DIFF
--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -268,7 +268,11 @@ def embed_corpus(
     except StopIteration:  # encoder with no parameters
         device = torch.device("cpu")
 
-    for fp in hetero_dir.glob("*.pt"):
+    files = list(hetero_dir.glob("*.pt"))
+    if not files:
+        raise RuntimeError(f"No hetero graphs found in {hetero_dir}")
+
+    for fp in files:
         out_name = fp.stem
         out_path = out_dir / f"{out_name}.ftr"
         if out_path.exists() and not overwrite:

--- a/tests/test_embed_stage.py
+++ b/tests/test_embed_stage.py
@@ -45,3 +45,13 @@ def test_embed_corpus_no_tokens(tmp_path):
     encoder = DummyEncoder()
     with pytest.raises(RuntimeError, match="No graphs"):
         embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+
+
+def test_embed_corpus_no_graphs(tmp_path):
+    hetero_dir = tmp_path / "hetero"
+    hetero_dir.mkdir()
+
+    out_dir = tmp_path / "embeds"
+    encoder = DummyEncoder()
+    with pytest.raises(RuntimeError, match="No hetero graphs"):
+        embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)


### PR DESCRIPTION
## Summary
- verify at least one hetero graph exists before embedding
- test `embed_corpus` with no graphs present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c9a810c08832e890b422d833e80ed