### PR TITLE
Improve embed_corpus text handling

### DIFF
--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -289,12 +289,19 @@ def embed_corpus(
             if texts is None:
                 skipped += 1
                 continue
+            if isinstance(texts, str):
+                texts = [texts]
+            else:
+                texts = [str(t) for t in texts if t is not None]
+            if not texts:
+                skipped += 1
+                continue
             try:
                 from transformers import AutoTokenizer
 
                 tok = AutoTokenizer.from_pretrained(encoder.config._name_or_path)
                 enc = tok(
-                    list(texts),
+                    texts,
                     padding=True,
                     truncation=True,
                     max_length=encoder.max_length,

--- a/tests/test_embed_stage.py
+++ b/tests/test_embed_stage.py
@@ -13,6 +13,9 @@ class DummyEncoder(torch.nn.Module):
     def __init__(self, hidden_size=2):
         super().__init__()
         self.hidden_size = hidden_size
+        self.config = type("cfg", (), {"_name_or_path": "dummy"})()
+        self.max_length = 64
+
     def forward(self, input_ids, attention_mask=None):
         return input_ids.float()
 
@@ -45,3 +48,51 @@ def test_embed_corpus_no_tokens(tmp_path):
     encoder = DummyEncoder()
     with pytest.raises(RuntimeError, match="No graphs"):
         embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+
+
+def test_embed_corpus_text_inputs(tmp_path, monkeypatch):
+    captured = []
+
+    class DummyTokenizer:
+        def __call__(self, texts, **kw):
+            captured.append(list(texts))
+            n = len(captured[-1])
+            return {
+                "input_ids": torch.arange(n * 2, dtype=torch.long).reshape(n, 2),
+                "attention_mask": torch.ones(n, 2, dtype=torch.long),
+            }
+
+    monkeypatch.setattr(
+        "src.models.llm_embed.AutoTokenizer.from_pretrained",
+        lambda *a, **kw: DummyTokenizer(),
+    )
+
+    encoder = DummyEncoder()
+
+    # single string case
+    hetero_dir = tmp_path / "single"
+    hetero_dir.mkdir()
+    g = HeteroData()
+    g["token"].text = "hello"
+    g["token"].num_nodes = 1
+    torch.save(g, hetero_dir / "a.pt")
+
+    out_dir = tmp_path / "embeds1"
+    embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+    assert captured[0] == ["hello"]
+    feat = load_tensor("a", out_dir)
+    assert feat.shape == (1, 2)
+
+    # mixed types case
+    hetero_dir = tmp_path / "mixed"
+    hetero_dir.mkdir()
+    g = HeteroData()
+    g["token"].text = ["a", None, 1]
+    g["token"].num_nodes = 3
+    torch.save(g, hetero_dir / "b.pt")
+
+    out_dir = tmp_path / "embeds2"
+    embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+    assert captured[1] == ["a", "1"]
+    feat = load_tensor("b", out_dir)
+    assert feat.shape == (2, 2)


### PR DESCRIPTION
## Summary
- handle `texts` robustly in `embed_corpus`
- test single string and mixed-type input cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9a81d47c832eac059d5d1f7f81f0