### PR TITLE
Handle flexible text inputs

### DIFF
--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -289,6 +289,18 @@ def embed_corpus(
             if texts is None:
                 skipped += 1
                 continue
+            if isinstance(texts, str):
+                texts = [texts]
+            else:
+                try:
+                    texts = list(texts)
+                except TypeError:
+                    texts = [texts]
+            texts = [str(t) for t in texts if t is not None]
+            if not texts:
+                skipped += 1
+                continue
+
             from transformers import AutoTokenizer
 
             try:
@@ -298,7 +310,7 @@ def embed_corpus(
 
             try:
                 enc = tok(
-                    list(texts),
+                    texts,
                     padding=True,
                     truncation=True,
                     max_length=encoder.max_length,

--- a/tests/test_embed_stage.py
+++ b/tests/test_embed_stage.py
@@ -73,3 +73,44 @@ def test_embed_corpus_bad_text(tmp_path, monkeypatch):
     encoder = DummyEncoder()
     with pytest.raises(RuntimeError, match="Tokenization failed for bad"):
         embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+
+
+def test_embed_corpus_text_coercion(tmp_path, monkeypatch):
+    hetero_dir = tmp_path / "hetero"
+    hetero_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["token"].text = "hello"
+    g1["token"].num_nodes = 1
+    torch.save(g1, hetero_dir / "one.pt")
+
+    g2 = HeteroData()
+    g2["token"].text = ["a", None, 123]
+    g2["token"].num_nodes = 3
+    torch.save(g2, hetero_dir / "two.pt")
+
+    out_dir = tmp_path / "embeds"
+
+    class DummyTok:
+        def __call__(self, texts, *args, **kwargs):
+            ids = torch.tensor([[len(t)] for t in texts], dtype=torch.long)
+            mask = torch.ones_like(ids)
+            return {"input_ids": ids, "attention_mask": mask}
+
+    class DummyAutoTok:
+        @staticmethod
+        def from_pretrained(name):
+            return DummyTok()
+
+    import src.models.llm_embed as llm_embed
+
+    monkeypatch.setattr(llm_embed, "AutoTokenizer", DummyAutoTok)
+
+    encoder = DummyEncoder()
+    embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+
+    feat1 = load_tensor("one", out_dir)
+    feat2 = load_tensor("two", out_dir)
+
+    assert feat1.tolist() == [[5]]
+    assert feat2.tolist() == [[1], [3]]


### PR DESCRIPTION
## Summary
- sanitize text inputs in `embed_corpus`
- test list and string text inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9bf419ac832eb3735560618e97c9