### PR TITLE
Implement metadata encoding & vocab

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -56,12 +56,21 @@ LOGGER = get_logger(__name__)
 # --------------------------------------------------------------------------- #
 # Dataset stub (thin wrapper around saved PyG Data objects)
 # --------------------------------------------------------------------------- #
+
 class HeteroGraphDiskDataset(InMemoryDataset):
-    """Lazy‑loads torch_geometric ``Data``/``HeteroData`` pickles from <root>."""
+    """Lazy‑loads torch_geometric ``Data``/``HeteroData`` pickles from ``root``."""
+
+    #: Shared vocabulary path used when encoding string metadata.
+    VOCAB_PATH = Path("models/token_vocab.json")
 
     def __init__(self, root: str | Path, sha_list: Sequence[str] | None = None):
         self.sha_list = set(sha_list) if sha_list else None
         super().__init__(root)
+        if self.VOCAB_PATH.is_file():
+            with open(self.VOCAB_PATH, "r", encoding="utf-8") as f:
+                self.vocab = json.load(f)
+        else:
+            self.vocab = {}
         self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
         # Ensure every stored graph has an ``.x`` attribute for each node type.
@@ -100,6 +109,61 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         source_paths: list[Path] = []
         max_dim: dict[tuple[str, str], int] = defaultdict(int)
 
+        # ------------------------------------------------------------------
+        # Build or load token vocabulary
+        # ------------------------------------------------------------------
+        if self.VOCAB_PATH.is_file():
+            vocab = json.loads(self.VOCAB_PATH.read_text())
+        else:
+            counter: dict[str, int] = defaultdict(int)
+
+            def _scan_strings(g: Data | HeteroData):
+                if isinstance(g, HeteroData):
+                    stores = [g[nt] for nt in g.node_types]
+                else:
+                    stores = [g]
+                for st in stores:
+                    for _, val in st.items():
+                        if isinstance(val, str):
+                            counter[val] += 1
+                        elif isinstance(val, Sequence) and val and all(
+                            isinstance(x, str) for x in val
+                        ):
+                            for t in val:
+                                counter[t] += 1
+
+            for p in paths:
+                g = torch.load(p, weights_only=False)
+                _scan_strings(g)
+
+            vocab = {"<PAD>": 0}
+            for tok, _ in sorted(counter.items(), key=lambda x: -x[1]):
+                if tok not in vocab:
+                    vocab[tok] = len(vocab)
+            ensure_dir(self.VOCAB_PATH.parent)
+            self.VOCAB_PATH.write_text(json.dumps(vocab))
+
+        self.vocab = vocab
+
+        def _encode_metadata(g: Data | HeteroData):
+            if isinstance(g, HeteroData):
+                stores = {nt: g[nt] for nt in g.node_types}
+            else:
+                stores = {"": g}
+            for st in stores.values():
+                meta = getattr(st, "meta", {})
+                for attr, val in list(st.items()):
+                    if isinstance(val, str):
+                        meta[attr] = val
+                        st[attr + "_id"] = torch.tensor([vocab.get(val, 0)], dtype=torch.long)
+                        delattr(st, attr)
+                    elif isinstance(val, Sequence) and val and all(isinstance(x, str) for x in val):
+                        meta[attr] = list(val)
+                        st[attr + "_id"] = torch.tensor([vocab.get(x, 0) for x in val], dtype=torch.long)
+                        delattr(st, attr)
+                st.meta = meta
+            return g
+
         # --- load graphs & collect maximum feature dimensions ---
         for p in paths:
             sha = p.stem
@@ -111,7 +175,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 store = data[NodeType.TOKEN.value]
                 if "emb" in store and "feat" not in store:
                     store.feat = store.pop("emb")
-            data_list.append(data)
+            data_list.append(_encode_metadata(data))
             source_paths.append(p)
 
             # record the maximum "feature" dimension per (node_type, attr)
@@ -308,7 +372,9 @@ def main():
     # ``train_ds._data`` represents the collated dataset containing the union of
     # node types across all graphs, which ensures the encoder is aware of every
     # possible node type.
-    params, target_node = _load_model_hparams(args.config, train_ds._data)
+    params, target_node = _load_model_hparams(
+        args.config, train_ds._data, vocab_size=len(train_ds.vocab)
+    )
     model = SelfGraphCL(**params)
 
     if device.type == "cuda" and torch.cuda.device_count() > 1:
@@ -443,7 +509,9 @@ def main():
 # --------------------------------------------------------------------------- #
 
 
-def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> tuple[dict, str | None]:
+def _load_model_hparams(
+    cfg_path: Path, graph: HeteroData | Data, *, vocab_size: int = 0
+) -> tuple[dict, str | None]:
     """Return ``SelfGraphCL`` kwargs loaded from ``cfg_path``.
 
     Expected YAML ``model`` keys are a subset of
@@ -481,9 +549,11 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> tuple[dict,
             encoder_args[k] = model_cfg.pop(k)
 
     metadata = graph.metadata() if isinstance(graph, HeteroData) else ([], [])
+    attr_dim = int(model_cfg.get("attr_dim", 32))
     if isinstance(graph, HeteroData):
         node_types, edge_types = map(list, metadata)
         in_dims: dict[str, int] = {}
+        attr_names: dict[str, list[str]] = {}
         for nt in graph.node_types:
             store = graph[nt]
             if hasattr(store, "x"):
@@ -493,7 +563,9 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> tuple[dict,
                 store.x = feat  # ensure downstream access
             else:
                 raise AttributeError(f"Node type '{nt}' lacks '.x' or '.feat'")
-            in_dims[nt] = feat.size(-1)
+            meta_keys = [k[:-3] for k in store.keys() if k.endswith("_id")]
+            attr_names[nt] = meta_keys
+            in_dims[nt] = feat.size(-1) + len(meta_keys) * attr_dim
         api_nt = NodeType.API.value
         if api_nt not in node_types:
             node_types.append(api_nt)
@@ -513,7 +585,14 @@ def _load_model_hparams(cfg_path: Path, graph: HeteroData | Data) -> tuple[dict,
         in_dims = {"": feat.size(-1)}  # type: ignore[attr-defined]
 
     target_node = encoder_args.get("target_node")
-    encoder = RGCNEncoder(metadata=metadata, in_dims=in_dims, **encoder_args)
+    encoder = RGCNEncoder(
+        metadata=metadata,
+        in_dims=in_dims,
+        attr_names=attr_names if isinstance(graph, HeteroData) else None,
+        vocab_size=vocab_size,
+        attr_dim=attr_dim,
+        **encoder_args,
+    )
 
     params = {
         "encoder": encoder,

--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -52,6 +52,9 @@ class RGCNEncoder(nn.Module):
         *,
         metadata,
         in_dims: Dict[str, int],
+        attr_names: Dict[str, list[str]] | None = None,
+        vocab_size: int = 0,
+        attr_dim: int = 32,
         hidden_dim: int = 128,
         num_layers: int = 2,
         out_dim: int = 256,
@@ -71,6 +74,11 @@ class RGCNEncoder(nn.Module):
         # 1. Per‑type input projections
         # -----------------------------------------------------------------
         self.input_proj = nn.ModuleDict()
+        self.attr_names = attr_names or {nt: [] for nt in node_types}
+        self.attr_dim = attr_dim
+        self.meta_embed = (
+            nn.Embedding(vocab_size, attr_dim) if vocab_size > 0 else None
+        )
         for nt in node_types:
             proj = nn.Linear(in_dims[nt], hidden_dim)
             nn.init.xavier_uniform_(proj.weight)
@@ -124,8 +132,14 @@ class RGCNEncoder(nn.Module):
         proto = data[data.node_types[0]].x
         x = proto.new_zeros(homo.num_nodes, self.out_proj.in_features)
         for nt in data.node_types:
+            feats = [data[nt].x]
+            for name in self.attr_names.get(nt, []):
+                attr = getattr(data[nt], f"{name}_id", None)
+                if attr is not None and self.meta_embed is not None:
+                    feats.append(self.meta_embed(attr))
+            node_feat = torch.cat(feats, dim=-1) if len(feats) > 1 else feats[0]
             mask = homo.node_type == self.ntype_map[nt]
-            x[mask] = self.input_proj[nt](data[nt].x)
+            x[mask] = self.input_proj[nt](node_feat)
 
         # 3) RGCN layers on the homogeneous representation
         edge_index = homo.edge_index

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -1,0 +1,31 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+from torch_geometric.loader import DataLoader
+
+from src.cli.pretrain_selfgcl import HeteroGraphDiskDataset
+
+
+def test_hetero_disk_dataset_meta(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    g = HeteroData()
+    g["token"].x = torch.randn(2, 1)
+    g["token"].text = ["hello", "world"]
+    g["token"].num_nodes = 2
+    torch.save(g, graph_dir / "a.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    loader = DataLoader(ds, batch_size=1)
+    batch = next(iter(loader))
+    store = batch[0]["token"] if isinstance(batch, list) else batch["token"]
+    assert store.meta["text"] == ["hello", "world"]
+    assert hasattr(store, "text_id")
+    assert torch.all(store.text_id.eq(torch.tensor([1, 2], dtype=torch.long)))


### PR DESCRIPTION
## Summary
- encode string node attributes in pretrain data loader
- build token vocab reused by selfgcl dataset
- support *_id embeddings in RGCNEncoder
- test metadata preservation during loading

## Testing
- `pytest tests/test_selfgcl_dataset.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685cad8e9798832e924265671ef33bcd