### PR TITLE
Suppress parse time logs

### DIFF
--- a/src/graphs/loaders/base.py
+++ b/src/graphs/loaders/base.py
@@ -35,6 +35,8 @@ import numpy as np
 import torch
 from torch_geometric.data import Data, HeteroData
 
+from contextlib import nullcontext
+
 from ..utils import ensure_dir, get_logger, timer
 
 # 타입 별칭 (Python ≥3.10)
@@ -110,11 +112,16 @@ class GraphLoaderBase(abc.ABC):
                 return pickle.load(f)
 
         # (2) 새로 파싱
-        with timer(
-            f"{self.LOADER_NAME} parse",
-            logger=None,
-            use_tqdm=False,
-        ):
+        parse_ctx = (
+            timer(
+                f"{self.LOADER_NAME} parse",
+                logger=self.log,
+                use_tqdm=False,
+            )
+            if self.log.isEnabledFor(logging.DEBUG)
+            else nullcontext()
+        )
+        with parse_ctx:
             g = self._parse(src, **kwargs)
 
         # (3) post-process


### PR DESCRIPTION
## Summary
- hide parse timing output during dataset preprocessing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd0bddfa4832ebc7ed40f8b482485