### PR TITLE
Handle missing kind in ASTLoader

### DIFF
--- a/src/graphs/loaders/ast_loader.py
+++ b/src/graphs/loaders/ast_loader.py
@@ -66,6 +66,14 @@ class ASTLoader(GraphLoaderBase):
 
         # -------- B) 공통 AST 처리(기존 코드) ---------------------- #
         nodes: Sequence[dict] = js["nodes"]
+
+        # Check for missing 'kind'
+        src_path = str(src) if isinstance(src, (str, Path)) else "<bytes>"
+        for n in nodes:
+            if "kind" not in n:
+                self.log.warning("node missing 'kind' in %s: %s", src_path, n)
+                n["kind"] = "unknown"
+
         id2idx: Dict[int, int] = {n["id"]: i for i, n in enumerate(nodes)}
         node_kinds: List[str] = [n["kind"] for n in nodes]
 

--- a/tests/test_ast_loader.py
+++ b/tests/test_ast_loader.py
@@ -2,6 +2,9 @@ import pytest
 pytest.importorskip("torch")
 
 from src.graphs.loaders.ast_loader import ASTLoader
+import json
+import logging
+
 
 
 def test_convert_pejson_extracts_tokens():
@@ -17,4 +20,15 @@ def test_convert_pejson_extracts_tokens():
     for n in token_nodes:
         root_edges = [e for e in ast["edges"] if e[1] == n["id"]]
         assert root_edges and root_edges[0][0] == 0
+
+
+def test_parse_missing_kind_assigns_unknown(tmp_path, caplog):
+    sample = {"nodes": [{"id": 0, "kind": "file"}, {"id": 1}], "edges": [[0, 1]]}
+    path = tmp_path / "ast.json"
+    path.write_text(json.dumps(sample))
+    loader = ASTLoader()
+    caplog.set_level(logging.WARNING)
+    data = loader._parse(path)
+    assert any("node missing 'kind'" in rec.message for rec in caplog.records)
+    assert "unknown" in data.kind_str
 


### PR DESCRIPTION
## Summary
- log a warning if AST nodes are missing a `kind`
- default missing `kind` values to `unknown`
- test behaviour when a node lacks `kind`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd3dbd504832e9886c9bc46b8d804