### PR TITLE
Fix num_nodes warnings in normalizers

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -104,11 +104,12 @@ class HeteroGraphBuilder:
         """
         for view_name, g in self._views.items():
             for ntype in g.node_types:
-                num = g[ntype].num_nodes
-                if num is None:
+                store = g[ntype]
+                if "num_nodes" not in store:
                     raise ValueError(
                         f"view '{view_name}' node type '{ntype}' lacks num_nodes"
                     )
+                num = store.num_nodes
                 start = self._global_counters[ntype]
                 self._global_counters[ntype] += num
                 for lid in range(num):

--- a/src/graphs/normalizers/ast_norm.py
+++ b/src/graphs/normalizers/ast_norm.py
@@ -42,8 +42,10 @@ class ASTNormalizer(NormalizerBase):
         new_g = HeteroData()
 
         # ── 1) 노드 영역 ────────────────────────────────────────────
-        n = g.num_nodes
+        n = g.kind_id.size(0) if hasattr(g, "kind_id") else g.num_nodes
         tok_store = new_g[NodeType.TOKEN.value]
+        tok_store.num_nodes = n  # set first to avoid PyG warnings
+
         tok_store.tok_id = g.kind_id.clone()
 
         # 위치(pos) : 0 … N-1
@@ -52,12 +54,6 @@ class ASTNormalizer(NormalizerBase):
         # 노드 임베딩(x) → 'feat'
         if hasattr(g, "x") and g.x is not None:
             tok_store.feat = g.x.clone()
-
-        # num_nodes 명시적으로 지정해 경고 제거
-        tok_store.num_nodes = n
-
-        # num_nodes 명시적으로 기록
-        new_g[NodeType.TOKEN.value].num_nodes = n
 
         # ── 2) edge 영역 ────────────────────────────────────────────
         rel_key = (NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)

--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -55,27 +55,27 @@ class CFGNormalizer(NormalizerBase):
         # ────────────────────────────────────────────────────────────
         bb_store = new_g[NodeType.BB.value]
 
+        n_nodes = len(bb_idx)
+        bb_store.num_nodes = n_nodes  # set early
+
         if hasattr(g, "x") and g.x is not None:
             bb_store.feat = g.x[bb_idx].clone()
 
         if hasattr(g, "addr"):
             bb_store.addr = [g.addr[i] for i in bb_idx]
-
-        n_nodes = len(bb_idx)
         if hasattr(g, "inst_cnt"):
             bb_store.inst_cnt = torch.as_tensor(g.inst_cnt)[bb_idx]
         else:
             bb_store.inst_cnt = torch.zeros(n_nodes, dtype=torch.long)
-        bb_store.num_nodes = n_nodes
 
         # ────────────────────────────────────────────────────────────
         # 2) 토큰 노드 (선택)
         # ────────────────────────────────────────────────────────────
         if tok_idx:
             tok_store = new_g[NodeType.TOKEN.value]
+            tok_store.num_nodes = len(tok_idx)
             if texts:
                 tok_store.text = [texts[i] for i in tok_idx]
-            tok_store.num_nodes = len(tok_idx)
 
         # ────────────────────────────────────────────────────────────
         # 3) 엣지 – ('bb', 'cfg', 'bb') + ('bb','child','token')

--- a/src/graphs/normalizers/fcg_norm.py
+++ b/src/graphs/normalizers/fcg_norm.py
@@ -55,6 +55,8 @@ class FCGNormalizer(NormalizerBase):
         # ──────────────────────────────────────────────────────────
         fn_store = new_g[NodeType.FUNCTION.value]
 
+        fn_store.num_nodes = len(fn_idx)  # set early
+
         if hasattr(g, "x") and g.x is not None:
             fn_store.feat = g.x[fn_idx].clone()
 
@@ -67,16 +69,15 @@ class FCGNormalizer(NormalizerBase):
             fn_store.is_external = g.is_external[fn_idx].clone()
         else:
             fn_store.is_external = torch.zeros(len(fn_idx), dtype=torch.bool)
-        fn_store.num_nodes = len(fn_idx)
 
         # ──────────────────────────────────────────────────────────
         # 2) 토큰 노드 (선택)
         # ──────────────────────────────────────────────────────────
         if tok_idx:
             tok_store = new_g[NodeType.TOKEN.value]
+            tok_store.num_nodes = len(tok_idx)
             if texts:
                 tok_store.text = [texts[i] for i in tok_idx]
-            tok_store.num_nodes = len(tok_idx)
 
         # ──────────────────────────────────────────────────────────
         # 3) 엣지 – ('function','calls','function') + ('function','child','token')

--- a/src/graphs/normalizers/syscall_norm.py
+++ b/src/graphs/normalizers/syscall_norm.py
@@ -56,6 +56,8 @@ class SysCallNormalizer(NormalizerBase):
         # ──────────────────────────────────────────────────────────
         sc_store = new_g[NodeType.SYSCALL.value]
 
+        sc_store.num_nodes = n_syscalls  # set early
+
         if hasattr(g, "x") and g.x is not None:
             sc_store.feat = g.x[:n_syscalls].clone()
         else:
@@ -63,15 +65,14 @@ class SysCallNormalizer(NormalizerBase):
 
         if hasattr(g, "sc_name"):
             sc_store.name = list(g.sc_name)
-        sc_store.num_nodes = n_syscalls
 
         # ──────────────────────────────────────────────────────────
         # 2) 토큰 노드 (선택)
         # ──────────────────────────────────────────────────────────
         if n_tokens > 0:
             tok_store = new_g[NodeType.TOKEN.value]
-            tok_store.text = list(token_texts)
             tok_store.num_nodes = n_tokens
+            tok_store.text = list(token_texts)
 
         # ──────────────────────────────────────────────────────────
         # 3) 엣지 – seq + child(token)


### PR DESCRIPTION
## Summary
- set `num_nodes` before other node attributes in normalizers
- avoid PyG inference warnings in builder
- compute AST node count without triggering warnings
- tests: `test_hetero_builder` passes without warnings

## Testing
- `pytest tests/test_hetero_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd8c66778832eb775172f8d94dfae