### PR TITLE
Handle numeric list metadata for SelfGraphCL dataset

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -161,6 +161,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         meta[attr] = list(val)
                         st[attr + "_id"] = torch.tensor([vocab.get(x, 0) for x in val], dtype=torch.long)
                         delattr(st, attr)
+                    elif isinstance(val, Sequence) and val and all(isinstance(x, (int, float, bool)) for x in val):
+                        st[attr] = torch.tensor(list(val), dtype=torch.float if any(isinstance(x, float) for x in val) else torch.long)
                 st.meta = meta
             return g
 


### PR DESCRIPTION
## Summary
- fix `HeteroGraphDiskDataset` processing to convert numeric sequences to tensors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfa222ff8832e90b2709fc638f180