### PR TITLE
Fix hetero builder handling of empty attributes

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -155,9 +155,18 @@ class HeteroGraphBuilder:
                             cols.append(torch.zeros(shape, dtype=ref_store[k].dtype))
                         else:  # list[str] 같은 python obj
                             cols.extend([None] * s.num_nodes)
-                merged_store[k] = (
-                    torch.cat(cols) if isinstance(cols[0], torch.Tensor) else list(cols)
-                )
+                if not cols:
+                    ref_val = ref_store[k]
+                    if isinstance(ref_val, torch.Tensor):
+                        shape = list(ref_val.shape)
+                        shape[0] = 0
+                        merged_store[k] = torch.zeros(shape, dtype=ref_val.dtype)
+                    else:
+                        merged_store[k] = []
+                else:
+                    merged_store[k] = (
+                        torch.cat(cols) if isinstance(cols[0], torch.Tensor) else list(cols)
+                    )
 
     # -----------------------------------------------------------
     def _merge_edge_stores(self, out: HeteroData) -> None:


### PR DESCRIPTION
## Summary
- avoid indexing empty attribute lists in `_merge_node_stores`
- gracefully create empty tensors/lists when no data is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cff5e9e5c832e8a451413caab02af