### PR TITLE
Fix meta handling in SelfGCL dataset

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -72,7 +72,12 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 self.vocab = json.load(f)
         else:
             self.vocab = {}
-        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
+        loaded = torch.load(self.processed_paths[0], weights_only=False)
+        if isinstance(loaded, (list, tuple)) and len(loaded) == 3:
+            self.data, self.slices, self.graph_meta = loaded
+        else:  # Backwards compatibility
+            self.data, self.slices = loaded
+            self.graph_meta = None
 
         # Ensure every stored graph has an ``.x`` attribute for each node type.
         # Some legacy datasets only provide ``.feat`` which breaks newer
@@ -90,6 +95,16 @@ class HeteroGraphDiskDataset(InMemoryDataset):
 
     def get(self, idx):  # type: ignore[override]
         data = super().get(idx)
+        if self.graph_meta is not None:
+            meta = self.graph_meta[idx]
+            if isinstance(data, HeteroData):
+                for nt in data.node_types:
+                    if nt in meta:
+                        data[nt].meta = meta[nt]
+            else:
+                if "" in meta:
+                    data.meta = meta[""]
+
         if isinstance(data, HeteroData):
             for nt in data.node_types:
                 store = data[nt]
@@ -119,6 +134,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         data_list = []
         source_paths: list[Path] = []
         max_dim: dict[tuple[str, str], int] = defaultdict(int)
+        meta_list: list[dict[str, str]] = []
 
         # ------------------------------------------------------------------
         # Build or load token vocabulary
@@ -202,7 +218,22 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 store = data[NodeType.TOKEN.value]
                 if "emb" in store and "feat" not in store:
                     store.feat = store.pop("emb")
-            data_list.append(_encode_metadata(data))
+            data = _encode_metadata(data)
+
+            graph_meta: dict[str, str] = {}
+            if isinstance(data, HeteroData):
+                for ntype in data.node_types:
+                    store = data[ntype]
+                    graph_meta[ntype] = getattr(store, "meta", "")
+                    if "meta" in store:
+                        del store["meta"]
+            else:
+                graph_meta[""] = getattr(data, "meta", "")
+                if hasattr(data, "meta"):
+                    delattr(data, "meta")
+
+            meta_list.append(graph_meta)
+            data_list.append(data)
             source_paths.append(p)
 
             # record the maximum "feature" dimension per (node_type, attr)
@@ -263,7 +294,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 f"Collation failed due to missing attribute '{missing_attr}'. "
                 "Some node features may be missing."
             ) from exc
-        torch.save((data, slices), self.processed_paths[0])
+        torch.save((data, slices, meta_list), self.processed_paths[0])
+        self.graph_meta = meta_list
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -1,4 +1,8 @@
 import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
@@ -26,6 +30,32 @@ def test_hetero_disk_dataset_meta(tmp_path, monkeypatch):
     loader = DataLoader(ds, batch_size=1)
     batch = next(iter(loader))
     store = batch[0]["token"] if isinstance(batch, list) else batch["token"]
-    assert store.meta["text"] == ["hello", "world"]
+    assert store.meta["text"] == [["hello", "world"]]
     assert hasattr(store, "text_id")
     assert torch.all(store.text_id.eq(torch.tensor([1, 2], dtype=torch.long)))
+
+
+def test_hetero_disk_dataset_meta_batch(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    g1 = HeteroData()
+    g1["token"].x = torch.randn(1, 1)
+    g1["token"].text = ["foo"]
+    g1["token"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["token"].x = torch.randn(2, 1)
+    g2["token"].text = ["bar", "baz"]
+    g2["token"].num_nodes = 2
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    loader = DataLoader(ds, batch_size=2)
+    batch = next(iter(loader))
+    store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
+    assert store.meta["text"] == [["foo"], ["bar", "baz"]]
+


### PR DESCRIPTION
## Summary
- keep metadata separate in `HeteroGraphDiskDataset`
- reattach metadata on `get`
- save/load metadata list
- test batching with multiple graphs containing metadata

## Testing
- `pytest -q tests/test_selfgcl_dataset.py::test_hetero_disk_dataset_meta tests/test_selfgcl_dataset.py::test_hetero_disk_dataset_meta_batch`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'augment')*

------
https://chatgpt.com/codex/tasks/task_e_685d0b0b1c48832e92568a52e7cc5c4f