### PR TITLE
Handle complex sequence metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ python -m cli.pretrain_selfgcl data/hetero \
     --output models/gnn/encoder.pt \
     --plot-path results/train_plot.png
 
+그래프 파일에 비숫자형 리스트 속성이 있을 경우 자동으로 메타에 저장됩니다.
+
 # GNN 학습
 
 python -m cli.finetune_supcon \

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -175,10 +175,18 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         self.vocab = vocab
 
         def _encode_metadata(g: Data | HeteroData):
+            """Convert string and sequence attributes to tensors or metadata.
+
+            Every sequence attribute becomes either a tensor (numeric) or is
+            serialized to ``meta``. The returned graph contains no raw Python
+            lists.
+            """
+
             if isinstance(g, HeteroData):
                 stores = {nt: g[nt] for nt in g.node_types}
             else:
                 stores = {"": g}
+
             for st in stores.values():
                 meta = getattr(st, "meta", {})
                 for attr, val in list(st.items()):
@@ -188,22 +196,19 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                             [vocab.get(val, 0)], dtype=torch.long
                         )
                         delattr(st, attr)
-                    elif (
-                        isinstance(val, Sequence)
-                        and val
-                        and all(isinstance(x, str) for x in val)
-                    ):
-                        meta[attr] = list(val)
-                        st[attr + "_id"] = torch.tensor(
-                            [vocab.get(x, 0) for x in val], dtype=torch.long
-                        )
-                        delattr(st, attr)
-                    elif (
-                        isinstance(val, Sequence)
-                        and val
-                        and all(isinstance(x, (int, float)) for x in val)
-                    ):
-                        st[attr] = torch.as_tensor(val)
+                    elif isinstance(val, Sequence):
+                        if val and all(isinstance(x, str) for x in val):
+                            meta[attr] = list(val)
+                            st[attr + "_id"] = torch.tensor(
+                                [vocab.get(x, 0) for x in val],
+                                dtype=torch.long,
+                            )
+                            delattr(st, attr)
+                        elif val and all(isinstance(x, (int, float)) for x in val):
+                            st[attr] = torch.as_tensor(val)
+                        else:
+                            meta[attr] = json.dumps(list(val))
+                            delattr(st, attr)
                 st.meta = json.dumps(meta)
             return g
 

--- a/tests/test_encode_metadata.py
+++ b/tests/test_encode_metadata.py
@@ -1,0 +1,41 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+pytest = __import__('pytest')
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import Data
+from src.cli.pretrain_selfgcl import HeteroGraphDiskDataset
+
+
+def test_encode_metadata_various_lists(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    g = Data(x=torch.randn(2, 1))
+    g.num_nodes = 2
+    g.num_list = [1, 2, 3]
+    g.empty_list = []
+    g.str_list = ["a", "b"]
+    g.dict_list = [{"k": 1}, {"k": 2}]
+    g.mixed_list = [1, "a"]
+    g.text = "foo"
+    torch.save(g, graph_dir / "a.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    data = ds[0]
+    meta = data.meta
+    assert torch.equal(data.num_list, torch.tensor([1, 2, 3]))
+    assert hasattr(data, "str_list_id")
+    assert "empty_list" not in data.__dict__
+    assert meta["text"] == "foo"
+    assert meta["empty_list"] == json.dumps([])
+    assert meta["dict_list"] == json.dumps([{"k": 1}, {"k": 2}])
+    assert meta["mixed_list"] == json.dumps([1, "a"])


### PR DESCRIPTION
## Summary
- handle all sequence types when preprocessing graphs for SelfGraphCL
- add regression test for complex list attributes
- document automatic metadata handling for non-numeric lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0f358eec832e8860d9ac2ac8d2da