### PR TITLE
Add tensor/ndarray handling in metadata encoder

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -31,6 +31,7 @@ import os
 from pathlib import Path
 from typing import Sequence
 from collections import defaultdict
+import numpy as np
 
 import torch
 from torch.utils.data import DataLoader
@@ -196,6 +197,12 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                             [vocab.get(val, 0)], dtype=torch.long
                         )
                         delattr(st, attr)
+                    elif isinstance(val, torch.Tensor):
+                        st[attr] = val.clone()
+                        continue
+                    elif isinstance(val, np.ndarray):
+                        st[attr] = torch.as_tensor(val)
+                        continue
                     elif isinstance(val, Sequence):
                         if val and all(isinstance(x, str) for x in val):
                             meta[attr] = list(val)

--- a/tests/test_encode_metadata.py
+++ b/tests/test_encode_metadata.py
@@ -9,6 +9,7 @@ pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
 import torch
+import numpy as np
 from torch_geometric.data import Data
 from src.cli.pretrain_selfgcl import HeteroGraphDiskDataset
 
@@ -23,6 +24,8 @@ def test_encode_metadata_various_lists(tmp_path, monkeypatch):
     g.str_list = ["a", "b"]
     g.dict_list = [{"k": 1}, {"k": 2}]
     g.mixed_list = [1, "a"]
+    g.tensor_attr = torch.tensor([4, 5])
+    g.numpy_attr = np.array([6, 7])
     g.text = "foo"
     torch.save(g, graph_dir / "a.pt")
 
@@ -35,6 +38,8 @@ def test_encode_metadata_various_lists(tmp_path, monkeypatch):
     assert torch.equal(data.num_list, torch.tensor([1, 2, 3]))
     assert hasattr(data, "str_list_id")
     assert "empty_list" not in data.__dict__
+    assert torch.equal(data.tensor_attr, torch.tensor([4, 5]))
+    assert torch.equal(data.numpy_attr, torch.tensor([6, 7]))
     assert meta["text"] == "foo"
     assert meta["empty_list"] == json.dumps([])
     assert meta["dict_list"] == json.dumps([{"k": 1}, {"k": 2}])


### PR DESCRIPTION
## Summary
- preserve `torch.Tensor` and `numpy.ndarray` attributes when encoding metadata
- ensure numpy is imported for dataset processing
- test that tensor and ndarray metadata remain tensors

## Testing
- `pytest -q tests/test_encode_metadata.py` *(fails: ModuleNotFoundError: torch_geometric)*

------
https://chatgpt.com/codex/tasks/task_e_685d12c908d8832e8a62a42c92376140