### PR TITLE
Handle complex metadata encoding

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -214,7 +214,10 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         elif val and all(isinstance(x, (int, float)) for x in val):
                             st[attr] = torch.as_tensor(val)
                         else:
-                            meta[attr] = json.dumps(list(val))
+                            try:
+                                meta[attr] = json.dumps(list(val))
+                            except TypeError:
+                                meta[attr] = repr(list(val))
                             delattr(st, attr)
                 st.meta = json.dumps(meta)
             return g

--- a/tests/test_encode_metadata.py
+++ b/tests/test_encode_metadata.py
@@ -44,3 +44,20 @@ def test_encode_metadata_various_lists(tmp_path, monkeypatch):
     assert meta["empty_list"] == json.dumps([])
     assert meta["dict_list"] == json.dumps([{"k": 1}, {"k": 2}])
     assert meta["mixed_list"] == json.dumps([1, "a"])
+
+
+def test_encode_metadata_complex_object(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    g = Data(x=torch.randn(1, 1))
+    g.num_nodes = 1
+    g.complex_list = [complex(1, 2)]
+    torch.save(g, graph_dir / "a.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    data = ds[0]
+    meta = data.meta
+    assert meta["complex_list"] == repr([complex(1, 2)])


### PR DESCRIPTION
## Summary
- make metadata encoding resilient when json serialization fails
- store string representation for lists with non-JSON-serializable items
- test metadata encoding with a complex object

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d138102c0832ebc8b664ca23c743b