### PR TITLE
Handle tensors in metadata encoding

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -26,8 +26,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import logging
-import os
 from pathlib import Path
 from typing import Sequence
 from collections import defaultdict
@@ -41,7 +39,6 @@ from torch_geometric.loader import DataLoader as PyGLoader
 
 # Project internal imports ----------------------------------------------------
 from common.utils import set_random_seed, get_logger, ensure_dir
-from graphs.utils import tqdm_wrap
 from graphs.normalizers.schema import NodeType, EdgeRel
 from augment.ops.inject_call import InjectAPICall
 from augment import auto_aug  # noqa: F401 (registers policies)
@@ -190,6 +187,11 @@ class HeteroGraphDiskDataset(InMemoryDataset):
 
             for st in stores.values():
                 meta = getattr(st, "meta", {})
+                if isinstance(meta, str):
+                    try:
+                        meta = json.loads(meta)
+                    except json.JSONDecodeError:
+                        meta = {}
                 for attr, val in list(st.items()):
                     if isinstance(val, str):
                         meta[attr] = val
@@ -203,7 +205,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                     elif isinstance(val, np.ndarray):
                         st[attr] = torch.as_tensor(val)
                         continue
-                    elif isinstance(val, Sequence):
+                    elif isinstance(val, (list, tuple)):
                         if val and all(isinstance(x, str) for x in val):
                             meta[attr] = list(val)
                             st[attr + "_id"] = torch.tensor(

--- a/tests/test_encode_metadata.py
+++ b/tests/test_encode_metadata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-pytest = __import__('pytest')
+pytest = __import__("pytest")
 pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
@@ -40,6 +40,8 @@ def test_encode_metadata_various_lists(tmp_path, monkeypatch):
     assert "empty_list" not in data.__dict__
     assert torch.equal(data.tensor_attr, torch.tensor([4, 5]))
     assert torch.equal(data.numpy_attr, torch.tensor([6, 7]))
+    assert "tensor_attr" not in meta
+    assert "numpy_attr" not in meta
     assert meta["text"] == "foo"
     assert meta["empty_list"] == json.dumps([])
     assert meta["dict_list"] == json.dumps([{"k": 1}, {"k": 2}])
@@ -61,3 +63,24 @@ def test_encode_metadata_complex_object(tmp_path, monkeypatch):
     data = ds[0]
     meta = data.meta
     assert meta["complex_list"] == repr([complex(1, 2)])
+
+
+def test_encode_metadata_tensor_numpy(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    g = Data(x=torch.randn(1, 1))
+    g.num_nodes = 1
+    g.tensor_attr = torch.tensor([1, 2, 3])
+    g.numpy_attr = np.array([4, 5, 6])
+    torch.save(g, graph_dir / "a.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    data = ds[0]
+    meta = data.meta
+    assert torch.equal(data.tensor_attr, torch.tensor([1, 2, 3]))
+    assert torch.equal(data.numpy_attr, torch.tensor([4, 5, 6]))
+    assert "tensor_attr" not in meta
+    assert "numpy_attr" not in meta


### PR DESCRIPTION
## Summary
- handle `torch.Tensor` and `np.ndarray` early in `_encode_metadata`
- decode existing metadata strings before encoding
- only serialize Python lists and tuples
- ensure tensors aren't serialized in metadata
- add regression tests

## Testing
- `pytest -k encode_metadata -q`

------
https://chatgpt.com/codex/tasks/task_e_685d15112e20832eabf31026d7330bbb