### PR TITLE
Add direction-specific AttentionGate edges

### DIFF
--- a/src/models/gnn/layers/attention_gate.py
+++ b/src/models/gnn/layers/attention_gate.py
@@ -25,8 +25,9 @@ node_gate : bool, default True
 edge_gate : bool, default True
     Whether to learn edge-wise gates.
 edge_share : bool, default True
-    Share the same linear layer for both (src,dst) and (dst,src) pairs.
-    Set False if you want directed edge weights.
+    Share a single linear layer for both ``(src,dst)`` and ``(dst,src)`` pairs.
+    Set ``False`` to learn direction-specific weights with two separate
+    projections.
 """
 
 from __future__ import annotations
@@ -60,9 +61,16 @@ class AttentionGate(nn.Module):
 
         if edge_gate:
             edge_in = in_dim * 2
-            self.edge_fc = nn.Linear(edge_in, 1, bias=True)
-            nn.init.xavier_uniform_(self.edge_fc.weight)
-            nn.init.zeros_(self.edge_fc.bias)
+            if edge_share:
+                self.edge_fc = nn.Linear(edge_in, 1, bias=True)
+                nn.init.xavier_uniform_(self.edge_fc.weight)
+                nn.init.zeros_(self.edge_fc.bias)
+            else:
+                self.edge_fc_src2dst = nn.Linear(edge_in, 1, bias=True)
+                self.edge_fc_dst2src = nn.Linear(edge_in, 1, bias=True)
+                for m in (self.edge_fc_src2dst, self.edge_fc_dst2src):
+                    nn.init.xavier_uniform_(m.weight)
+                    nn.init.zeros_(m.bias)
 
     # ------------------------------------------------------------------ #
     def forward(
@@ -78,9 +86,13 @@ class AttentionGate(nn.Module):
         -------
         x_out : Tensor, shape (N, F)
             Gated node features.
-        edge_index : Tensor, unchanged.
-        edge_alpha : Tensor | None, shape (E,)
-            Edge weights in (0,1) if `edge_gate=True`.
+        edge_index : Tensor
+            Unchanged if ``edge_share=True``; otherwise concatenated with its
+            reversed counterpart resulting in shape ``(2, 2E)``.
+        edge_alpha : Tensor | None, shape (E,) or (2E,)
+            Edge weights in ``(0, 1)`` if ``edge_gate=True``. When
+            ``edge_share=False`` the returned vector contains forward and
+            reverse weights consecutively.
         """
         # ------------------- node gate ------------------- #
         if self.node_gate:
@@ -94,13 +106,24 @@ class AttentionGate(nn.Module):
         edge_alpha: Optional[Tensor] = None
         if self.edge_gate:
             src, dst = edge_index
-            concat_feat = torch.cat([x[src], x[dst]], dim=-1)  # (E, 2F)
-            edge_alpha = torch.sigmoid(self.edge_fc(concat_feat)).squeeze(-1)  # (E,)
+            feat_fwd = torch.cat([x[src], x[dst]], dim=-1)  # (E, 2F)
 
-            if self.edge_share is False:
-                # Optionally learn direction-specific weights by
-                # concatenating reversed edges (not typical for undirected)
-                pass
+            if self.edge_share:
+                edge_alpha = torch.sigmoid(self.edge_fc(feat_fwd)).squeeze(-1)  # (E,)
+            else:
+                # forward (src -> dst)
+                alpha_fwd = torch.sigmoid(
+                    self.edge_fc_src2dst(feat_fwd)
+                ).squeeze(-1)  # (E,)
+
+                # reverse (dst -> src)
+                feat_rev = torch.cat([x[dst], x[src]], dim=-1)  # (E, 2F)
+                alpha_rev = torch.sigmoid(
+                    self.edge_fc_dst2src(feat_rev)
+                ).squeeze(-1)  # (E,)
+
+                edge_index = torch.cat([edge_index, edge_index.flip(0)], dim=1)  # (2, 2E)
+                edge_alpha = torch.cat([alpha_fwd, alpha_rev], dim=0)  # (2E,)
         # ------------------------------------------------- #
 
         if return_alpha:

--- a/tests/test_attention_gate.py
+++ b/tests/test_attention_gate.py
@@ -1,0 +1,33 @@
+import pytest
+
+pytest.importorskip("torch")
+
+import torch
+from src.models.gnn.layers import AttentionGate
+
+
+def _make_graph():
+    x = torch.randn(3, 4)
+    edge_index = torch.tensor([[0, 1], [1, 2]], dtype=torch.long)
+    return x, edge_index
+
+
+def test_attention_gate_shared_edges():
+    x, edge_index = _make_graph()
+    gate = AttentionGate(in_dim=4, edge_share=True)
+    x_out, ei_out, alpha = gate(x, edge_index)
+    assert x_out.shape == x.shape
+    assert torch.equal(ei_out, edge_index)
+    assert alpha.shape == (edge_index.size(1),)
+
+
+def test_attention_gate_direction_specific():
+    x, edge_index = _make_graph()
+    gate = AttentionGate(in_dim=4, edge_share=False)
+    x_out, ei_out, alpha = gate(x, edge_index)
+    E = edge_index.size(1)
+    assert x_out.shape == x.shape
+    assert ei_out.shape == (2, 2 * E)
+    assert torch.equal(ei_out[:, :E], edge_index)
+    assert torch.equal(ei_out[:, E:], edge_index.flip(0))
+    assert alpha.shape == (2 * E,)


### PR DESCRIPTION
## Summary
- support learning edge-direction-specific weights in `AttentionGate`
- document the new behavior and update forward
- test edge gating with and without shared weights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d457daabc832ea26036b9cbfd1c3e