### PR TITLE
Add clean rebuild option for hetero graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ python -m cli.preprocessing --input-dir data/raw/malware --out . labels --label 
 python -m cli.preprocessing --input-dir data/raw --out . --overwrite json
 # --json으로 json파일 형식을 읽는것을 명시. view를 생성한다.
 
-python -m cli.preprocessing --input-dir data/raw --out . graphs --normalise --rebuild --with-feats
-# hetero graph 생성
+# hetero graph 생성 (기존 *.pt를 삭제하려면 --clean)
+python -m cli.preprocessing --input-dir data/raw --out . graphs --normalise --rebuild --clean --with-feats
 
 python -m cli.preprocessing --input-dir data/hetero --out . splits --fallback random --strategy random --json-out split_fold.json
 # 학습, 평가, 테스트 데이터 분할

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -246,8 +246,9 @@ def run_graphs(args: argparse.Namespace) -> None:
 
     logger = _get_logger(args.log_level)
     logger.info(
-        "[GRAPHS] rebuild=%s  normalise=%s  with_feats=%s  feat_policy=%s",
+        "[GRAPHS] rebuild=%s  clean=%s  normalise=%s  with_feats=%s  feat_policy=%s",
         args.rebuild,
+        args.clean,
         args.normalise,
         args.with_feats,
         args.feat_policy,
@@ -260,6 +261,7 @@ def run_graphs(args: argparse.Namespace) -> None:
             hetero_dir=hetero_dir,
             normalise=args.normalise,
             rebuild=args.rebuild,
+            clean=args.clean,
             workers=args.workers,
             with_feats=args.with_feats,
             feat_policy=OverLengthPolicy[args.feat_policy],
@@ -341,6 +343,7 @@ def run_all(args: argparse.Namespace) -> None:
         "views": ["ast", "cfg", "fcg", "syscall"],
         "normalise": False,
         "rebuild": False,
+        "clean": False,
         "with_feats": False,
         "feat_policy": "TRIM",
         "strategy": "time",
@@ -413,6 +416,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
     p = sub.add_parser("graphs", help="Merge views into hetero graphs")
     p.add_argument("--normalise", action="store_true")
     p.add_argument("--rebuild", action="store_true")
+    p.add_argument("--clean", action="store_true", help="Remove existing *.pt when rebuilding")
     p.add_argument("--with-feats", action="store_true", help="Pad missing node features")
     p.add_argument(
         "--feat-policy",
@@ -449,6 +453,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: C901
                    help="Views to extract and convert")
     p.add_argument("--normalise", action="store_true", help="Normalise features")
     p.add_argument("--rebuild", action="store_true", help="Rebuild existing graphs")
+    p.add_argument("--clean", action="store_true", help="Remove existing *.pt when rebuilding")
     p.add_argument("--with-feats", action="store_true", help="Pad missing node features")
     p.add_argument(
         "--feat-policy",

--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -348,6 +348,7 @@ def build_hetero_dataset(
     views: Tuple[str, ...] = ("ast", "cfg", "fcg", "syscall"),
     normalise: bool = True,
     rebuild: bool = False,
+    clean: bool = False,
     workers: int | None = 0,
     seed: int = 42,
     log_level: int = logging.INFO,
@@ -365,10 +366,14 @@ def build_hetero_dataset(
     views       : tuple  사용할 뷰 이름들
     normalise   : bool   view loader 뒤 schema normaliser 적용 여부
     rebuild     : bool   이미 존재하는 .pt 도 강제로 갱신할지
+    clean       : bool   rebuild 시 이미 존재하는 *.pt 파일 삭제 여부
     workers     : int    0/1 ⇒ 직렬, 그 이상은 mp.Pool
     seed        : int    mp fork-safety RNG 시드
     """
     ensure_dir(hetero_dir)
+    if clean and rebuild:
+        for p in hetero_dir.glob("*.pt"):
+            p.unlink(missing_ok=True)
     set_random_seed(seed)
     log = get_logger("builder.dataset", log_level)
 


### PR DESCRIPTION
## Summary
- clean hetero graph directory when rebuilding via new option
- expose `--clean` flag in preprocessing CLI
- document clean rebuild in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4bfbe2f4832ebdbff4eaa7b8227b