### PR TITLE
Import NODE_ATTRS and filter metadata

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -39,7 +39,7 @@ from torch_geometric.loader import DataLoader as PyGLoader
 
 # Project internal imports ----------------------------------------------------
 from common.utils import set_random_seed, get_logger, ensure_dir
-from graphs.normalizers.schema import NodeType, EdgeRel
+from graphs.normalizers.schema import NodeType, EdgeRel, NODE_ATTRS
 from augment.ops.inject_call import InjectAPICall
 from augment import auto_aug  # noqa: F401 (registers policies)
 from augment.basic import get_default_graphcl_transforms
@@ -177,7 +177,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
 
             Every sequence attribute becomes either a tensor (numeric) or is
             serialized to ``meta``. The returned graph contains no raw Python
-            lists.
+            lists.  Attributes not defined in :data:`NODE_ATTRS` are moved to
+            ``meta`` regardless of type.
             """
 
             if isinstance(g, HeteroData):
@@ -185,7 +186,10 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             else:
                 stores = {"": g}
 
-            for st in stores.values():
+            for ntype, st in stores.items():
+                allowed = (
+                    set(NODE_ATTRS.get(NodeType(ntype), ())) if ntype else None
+                )
                 meta = getattr(st, "meta", {})
                 if isinstance(meta, str):
                     try:
@@ -193,6 +197,13 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                     except json.JSONDecodeError:
                         meta = {}
                 for attr, val in list(st.items()):
+                    if allowed is not None and attr not in allowed:
+                        try:
+                            meta[attr] = json.dumps(val)
+                        except TypeError:
+                            meta[attr] = repr(val)
+                        delattr(st, attr)
+                        continue
                     if isinstance(val, str):
                         meta[attr] = val
                         st[attr + "_id"] = torch.tensor(


### PR DESCRIPTION
## Summary
- expose NODE_ATTRS for the SelfGraphCL pretraining CLI
- move attributes not defined in NODE_ATTRS to the graph `meta`

## Testing
- `pytest tests/test_selfgcl_dataset.py tests/test_encode_metadata.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4fb56ca4832e95aae39587eb0363