### PR TITLE
Add addr metadata check in HeteroGraphDiskDataset tests

### DIFF
--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -59,3 +59,36 @@ def test_hetero_disk_dataset_meta_batch(tmp_path, monkeypatch):
     store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
     assert store.meta["text"] == [["foo"], ["bar", "baz"]]
 
+
+def test_hetero_disk_dataset_token_addr(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["token"].x = torch.randn(1, 1)
+    g1["token"].addr = [1234]
+    g1["token"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["token"].x = torch.randn(2, 1)
+    g2["token"].num_nodes = 2
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+
+    store0 = ds[0]["token"]
+    store1 = ds[1]["token"]
+    assert not hasattr(store0, "addr")
+    assert store0.meta["addr"] == "[1234]"
+    assert not hasattr(store1, "addr")
+    assert "addr" not in store1.meta
+
+    loader = DataLoader(ds, batch_size=2)
+    batch = next(iter(loader))
+    store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
+    assert not hasattr(store, "addr")
+    assert store.meta["addr"] == ["[1234]", None]


### PR DESCRIPTION
## Summary
- add test ensuring token `addr` field is removed from node stores
- confirm `addr` metadata survives and dataset batching works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5c3c6ed0832ea45acc3ea39ef14a