### PR TITLE
Add test to check addr attr moved to meta in HeteroGraphDiskDataset

### DIFF
--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -92,3 +92,29 @@ def test_hetero_disk_dataset_token_addr(tmp_path, monkeypatch):
     store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
     assert not hasattr(store, "addr")
     assert store.meta["addr"] == ["[1234]", None]
+
+
+def test_extra_attr_moved_to_meta(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["token"].x = torch.randn(1, 1)
+    g1["token"].addr = [4321]
+    g1["token"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["token"].x = torch.randn(2, 1)
+    g2["token"].num_nodes = 2
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    loader = DataLoader(ds, batch_size=2)
+    batch = next(iter(loader))
+    store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
+    assert not hasattr(store, "addr")
+    assert store.meta["addr"] == ["[4321]", None]


### PR DESCRIPTION
## Summary
- add `test_extra_attr_moved_to_meta` to ensure extra node attributes are moved into `meta`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685d5da7b538832e8f7bef969a9140b9