### PR TITLE
Add addr attribute to token/syscall nodes

### DIFF
--- a/src/graphs/normalizers/schema.py
+++ b/src/graphs/normalizers/schema.py
@@ -81,10 +81,10 @@ EDGE_TYPES: Final[Tuple[Tuple[str, str, str], ...]] = (
 #    - 정규화 시 해당 키만 남기거나, 누락 시 zero-vector 채움
 # --------------------------------------------------------------------------- #
 NODE_ATTRS: Final[Dict[NodeType, Sequence[str]]] = {
-    NodeType.TOKEN:    ("tok_id", "pos", "feat", "text", "num_nodes"),
+    NodeType.TOKEN:    ("tok_id", "pos", "feat", "addr", "text", "num_nodes"),
     NodeType.BB:       ("feat", "addr", "inst_cnt", "num_nodes"),
     NodeType.FUNCTION: ("feat", "addr", "name", "is_external", "num_nodes"),
-    NodeType.SYSCALL:  ("feat", "name", "num_nodes"),
+    NodeType.SYSCALL:  ("feat", "addr", "name", "num_nodes"),
     NodeType.IMPORT:   ("dll", "ordinal", "num_nodes"),
     NodeType.SECTION:  ("name", "size", "num_nodes"),
     NodeType.STRING:   ("slen", "num_nodes"),

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -72,6 +72,7 @@ def test_hetero_disk_dataset_token_addr(tmp_path, monkeypatch):
 
     g2 = HeteroData()
     g2["token"].x = torch.randn(2, 1)
+    g2["token"].addr = [4321, 8765]
     g2["token"].num_nodes = 2
     torch.save(g2, graph_dir / "b.pt")
 
@@ -82,16 +83,13 @@ def test_hetero_disk_dataset_token_addr(tmp_path, monkeypatch):
 
     store0 = ds[0]["token"]
     store1 = ds[1]["token"]
-    assert not hasattr(store0, "addr")
-    assert store0.meta["addr"] == "[1234]"
-    assert not hasattr(store1, "addr")
-    assert "addr" not in store1.meta
+    assert torch.all(store0.addr.eq(torch.tensor([1234])))
+    assert torch.all(store1.addr.eq(torch.tensor([4321, 8765])))
 
     loader = DataLoader(ds, batch_size=2)
     batch = next(iter(loader))
     store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
-    assert not hasattr(store, "addr")
-    assert store.meta["addr"] == ["[1234]", None]
+    assert torch.all(store.addr.eq(torch.tensor([1234, 4321, 8765])))
 
 
 def test_extra_attr_moved_to_meta(tmp_path, monkeypatch):
@@ -100,7 +98,7 @@ def test_extra_attr_moved_to_meta(tmp_path, monkeypatch):
 
     g1 = HeteroData()
     g1["token"].x = torch.randn(1, 1)
-    g1["token"].addr = [4321]
+    g1["token"].foo = [4321]
     g1["token"].num_nodes = 1
     torch.save(g1, graph_dir / "a.pt")
 
@@ -116,5 +114,37 @@ def test_extra_attr_moved_to_meta(tmp_path, monkeypatch):
     loader = DataLoader(ds, batch_size=2)
     batch = next(iter(loader))
     store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
-    assert not hasattr(store, "addr")
-    assert store.meta["addr"] == ["[4321]", None]
+    assert not hasattr(store, "foo")
+    assert store.meta["foo"] == ["[4321]", None]
+
+
+def test_hetero_disk_dataset_syscall_addr(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["syscall"].x = torch.randn(1, 1)
+    g1["syscall"].addr = [1111]
+    g1["syscall"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["syscall"].x = torch.randn(2, 1)
+    g2["syscall"].addr = [2222, 3333]
+    g2["syscall"].num_nodes = 2
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+
+    sc0 = ds[0]["syscall"]
+    sc1 = ds[1]["syscall"]
+    assert torch.all(sc0.addr.eq(torch.tensor([1111])))
+    assert torch.all(sc1.addr.eq(torch.tensor([2222, 3333])))
+
+    loader = DataLoader(ds, batch_size=2)
+    batch = next(iter(loader))
+    store = batch["syscall"] if not isinstance(batch, list) else batch[0]["syscall"]
+    assert torch.all(store.addr.eq(torch.tensor([1111, 2222, 3333])))


### PR DESCRIPTION
## Summary
- allow `addr` for token and syscall nodes in the schema
- expect these addresses to be kept when loading graphs
- adjust dataset tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d60855528832e95ad229e80734469