### PR TITLE
Improve dataset collation with missing attributes

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -133,6 +133,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         source_paths: list[Path] = []
         max_dim: dict[tuple[str, str], int] = defaultdict(int)
         meta_list: list[dict[str, str]] = []
+        attr_union: dict[str, set[str]] = defaultdict(set)
+        attr_example: dict[tuple[str, str], object] = {}
 
         # ------------------------------------------------------------------
         # Build or load token vocabulary
@@ -264,20 +266,75 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             data_list.append(data)
             source_paths.append(p)
 
-            # record the maximum "feature" dimension per (node_type, attr)
+            # record attribute union and example per node type
             if isinstance(data, HeteroData):
                 for ntype in data.node_types:
-                    for attr, val in data[ntype].items():
+                    store = data[ntype]
+                    attr_union[ntype].update(store.keys())
+                    for attr, val in store.items():
+                        key = (ntype, attr)
+                        if key not in attr_example:
+                            attr_example[key] = val
                         if isinstance(val, torch.Tensor) and val.dim() == 2:
-                            key = (ntype, attr)
                             max_dim[key] = max(max_dim[key], val.size(1))
             else:
+                attr_union[""].update(data.keys())
                 for attr, val in data.items():
+                    key = ("", attr)
+                    if key not in attr_example:
+                        attr_example[key] = val
                     if isinstance(val, torch.Tensor) and val.dim() == 2:
-                        key = ("", attr)
                         max_dim[key] = max(max_dim[key], val.size(1))
 
         LOGGER.info("Loaded %d graphs from %s", len(data_list), self.root)
+
+        # --- fill missing attributes with defaults ---
+        for g, path in zip(data_list, source_paths):
+            if isinstance(g, HeteroData):
+                for ntype in g.node_types:
+                    store = g[ntype]
+                    num_nodes = store.num_nodes
+                    for attr in attr_union[ntype]:
+                        if attr in store:
+                            continue
+                        tmpl = attr_example.get((ntype, attr))
+                        if isinstance(tmpl, torch.Tensor):
+                            if tmpl.dim() == 2:
+                                dim = max_dim.get((ntype, attr), tmpl.size(1))
+                                store[attr] = torch.zeros((num_nodes, dim), dtype=tmpl.dtype)
+                            else:
+                                store[attr] = torch.zeros((num_nodes,), dtype=tmpl.dtype)
+                        elif isinstance(tmpl, Sequence):
+                            store[attr] = []
+                        else:
+                            store[attr] = torch.zeros((num_nodes,), dtype=torch.long)
+                        LOGGER.warning(
+                            "Filled missing attribute '%s' for node type '%s' in graph %s",
+                            attr,
+                            ntype,
+                            path,
+                        )
+            else:
+                num_nodes = g.num_nodes
+                for attr in attr_union[""]:
+                    if attr in g:
+                        continue
+                    tmpl = attr_example.get(("", attr))
+                    if isinstance(tmpl, torch.Tensor):
+                        if tmpl.dim() == 2:
+                            dim = max_dim.get(("", attr), tmpl.size(1))
+                            g[attr] = torch.zeros((num_nodes, dim), dtype=tmpl.dtype)
+                        else:
+                            g[attr] = torch.zeros((num_nodes,), dtype=tmpl.dtype)
+                    elif isinstance(tmpl, Sequence):
+                        g[attr] = []
+                    else:
+                        g[attr] = torch.zeros((num_nodes,), dtype=torch.long)
+                    LOGGER.warning(
+                        "Filled missing attribute '%s' in graph %s",
+                        attr,
+                        path,
+                    )
 
         # --- pad each tensor attribute to the maximum dimension ---
         for g in data_list:

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -148,3 +148,31 @@ def test_hetero_disk_dataset_syscall_addr(tmp_path, monkeypatch):
     batch = next(iter(loader))
     store = batch["syscall"] if not isinstance(batch, list) else batch[0]["syscall"]
     assert torch.all(store.addr.eq(torch.tensor([1111, 2222, 3333])))
+
+
+def test_fill_missing_attributes(tmp_path, monkeypatch, caplog):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["token"].x = torch.randn(1, 1)
+    g1["token"].addr = [1]
+    g1["token"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["token"].x = torch.randn(2, 1)
+    g2["token"].num_nodes = 2
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    with caplog.at_level("WARNING"):
+        ds = HeteroGraphDiskDataset(graph_dir)
+    assert any("Filled missing attribute" in rec.message for rec in caplog.records)
+
+    loader = DataLoader(ds, batch_size=2)
+    batch = next(iter(loader))
+    store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
+    assert torch.all(store.addr.eq(torch.tensor([1, 0, 0], dtype=torch.long)))


### PR DESCRIPTION
## Summary
- expand `HeteroGraphDiskDataset.process()` to gather attributes across graphs
- automatically fill missing node attributes with default tensors
- warn when attributes are synthesized
- test handling of graphs missing optional attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d64a55734832eaf2fa02310df65c4