### PR TITLE
Handle hex address strings

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -207,11 +207,23 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         delattr(st, attr)
                         continue
                     if isinstance(val, str):
-                        meta[attr] = val
-                        st[attr + "_id"] = torch.tensor(
-                            [vocab.get(val, 0)], dtype=torch.long
-                        )
-                        delattr(st, attr)
+                        if attr == "addr" and val.lower().startswith("0x"):
+                            try:
+                                st[attr] = torch.tensor([
+                                    int(val, 16)
+                                ], dtype=torch.long)
+                            except ValueError:
+                                meta[attr] = val
+                                st[attr + "_id"] = torch.tensor(
+                                    [vocab.get(val, 0)], dtype=torch.long
+                                )
+                                delattr(st, attr)
+                        else:
+                            meta[attr] = val
+                            st[attr + "_id"] = torch.tensor(
+                                [vocab.get(val, 0)], dtype=torch.long
+                            )
+                            delattr(st, attr)
                     elif isinstance(val, torch.Tensor):
                         st[attr] = val.clone()
                         continue

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -176,3 +176,35 @@ def test_fill_missing_attributes(tmp_path, monkeypatch, caplog):
     batch = next(iter(loader))
     store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
     assert torch.all(store.addr.eq(torch.tensor([1, 0, 0], dtype=torch.long)))
+
+
+def test_hex_addr_conversion(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["token"].x = torch.randn(1, 1)
+    g1["token"].addr = "0x10"
+    g1["token"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["token"].x = torch.randn(1, 1)
+    g2["token"].addr = "0x20"
+    g2["token"].num_nodes = 1
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+
+    st0 = ds[0]["token"]
+    st1 = ds[1]["token"]
+    assert torch.all(st0.addr.eq(torch.tensor([16], dtype=torch.long)))
+    assert torch.all(st1.addr.eq(torch.tensor([32], dtype=torch.long)))
+
+    loader = DataLoader(ds, batch_size=2)
+    batch = next(iter(loader))
+    store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
+    assert torch.all(store.addr.eq(torch.tensor([16, 32], dtype=torch.long)))


### PR DESCRIPTION
## Summary
- convert string addresses like "0x10" to integers in `_encode_metadata`
- test that hex address strings are handled correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d69fc8b74832e98c86314117f504c