### PR TITLE
Handle out-of-range edges in NodeDrop

### DIFF
--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -16,6 +16,8 @@ import math
 import numbers
 from typing import Any, Dict, Mapping, Tuple
 
+import logging
+
 import numpy as np
 import torch
 from torch_geometric.data import Data, HeteroData
@@ -130,8 +132,9 @@ class NodeDrop(SimpleAug, AugmentBase):
     def _drop_nodes_data(self, data: Data, keep_p: float) -> torch.Tensor:
         """homogeneous Data용 노드 삭제 + 에지 갱신."""
         target_idx = 0 if self.target_node is not None else None
+        device = _get_store_device(data)
         mask, mapping = self._make_mask_mapping(
-            data.num_nodes, keep_p, data.device, target_idx
+            data.num_nodes, keep_p, device, target_idx
         )
         # 노드 특성 필터링
         self._apply_node_mask(data, mask)
@@ -192,12 +195,32 @@ class NodeDrop(SimpleAug, AugmentBase):
         """edge_index 재구성 및 edge-level 속성 동기화."""
         edge_index = store.edge_index
         src, dst = edge_index[0], edge_index[1]
+        num_e = src.size(0)
+
+        # ── 노드 범위를 벗어난 엣지 필터링 ──────────────────────────────
+        valid = (
+            (src >= 0)
+            & (src < src_map.size(0))
+            & (dst >= 0)
+            & (dst < dst_map.size(0))
+        )
+        if (~valid).any():
+            logging.warning(
+                "NodeDrop filtered %d out-of-range edges", int((~valid).sum())
+            )
+        src = src[valid]
+        dst = dst[valid]
+
         keep = (src_map[src] != -1) & (dst_map[dst] != -1)
 
         # edge_index 재인덱싱
         new_ei = torch.stack(
             [src_map[src[keep]], dst_map[dst[keep]]], dim=0
         )
+
+        # 원본 에지에 대한 최종 마스크 (edge attributes filtering)
+        final_mask = torch.zeros(num_e, dtype=torch.bool, device=edge_index.device)
+        final_mask[valid] = keep
 
         # ── 삭제 후 남은 엣지가 없으면 self-loop 생성 ─────────────────────
         if new_ei.numel() == 0:
@@ -209,9 +232,8 @@ class NodeDrop(SimpleAug, AugmentBase):
         store.edge_index = new_ei
 
         # edge-level 특성 동기화
-        num_e = keep.size(0)
         for key, val in list(store.items()):
             if key == "edge_index":
                 continue
             if torch.is_tensor(val) and val.size(0) == num_e:
-                store[key] = val[keep]
+                store[key] = val[final_mask]

--- a/tests/test_node_drop.py
+++ b/tests/test_node_drop.py
@@ -6,7 +6,7 @@ pytest.importorskip("numpy")
 
 import torch
 import numpy as np
-from torch_geometric.data import Data
+from torch_geometric.data import Data, HeteroData
 
 from src.augment.ops.drop_node import NodeDrop
 
@@ -33,3 +33,35 @@ def test_node_drop_updates_num_nodes():
 
     assert result.num_nodes == expected
     assert result.num_nodes == result.x.size(0)
+
+
+def test_node_drop_filters_invalid_edges_data():
+    g = Data(
+        x=torch.randn(3, 1),
+        edge_index=torch.tensor([[0, 1, 2], [1, 4, -1]]),
+        edge_attr=torch.tensor([10, 20, 30]),
+        num_nodes=3,
+    )
+
+    aug = NodeDrop(keep_prob=1.0)
+    out = aug(g)
+
+    assert out.edge_index.size(1) == 1
+    assert torch.equal(out.edge_index, torch.tensor([[0], [1]]))
+    assert torch.equal(out.edge_attr, torch.tensor([10]))
+
+
+def test_node_drop_filters_invalid_edges_hetero():
+    g = HeteroData()
+    g["a"].x = torch.randn(2, 1)
+    g["a"].num_nodes = 2
+    g["b"].x = torch.randn(1, 1)
+    g["b"].num_nodes = 1
+    g[("a", "to", "b")].edge_index = torch.tensor([[0, 1], [0, 5]])
+    g[("b", "to", "a")].edge_index = torch.tensor([[0], [-1]])
+
+    aug = NodeDrop(keep_prob=1.0)
+    out = aug(g)
+
+    assert torch.equal(out[("a", "to", "b")].edge_index, torch.tensor([[0], [0]]))
+    assert out[("b", "to", "a")].edge_index.numel() == 0


### PR DESCRIPTION
## Summary
- filter invalid edges before reindexing in `NodeDrop`
- warn when edges are dropped
- support PyG versions without `Data.device`
- test filtering of out-of-range edges for `Data` and `HeteroData`

## Testing
- `pytest tests/test_node_drop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6e02af3c832e818da7c748611ea8