### PR TITLE
Fix NodeDrop invalid edge handling

### DIFF
--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -198,19 +198,20 @@ class NodeDrop(SimpleAug, AugmentBase):
         num_e = src.size(0)
 
         # ── 노드 범위를 벗어난 엣지 필터링 ──────────────────────────────
-        valid = (
+        valid_edge = (
             (src >= 0)
             & (src < src_map.size(0))
             & (dst >= 0)
             & (dst < dst_map.size(0))
         )
-        if (~valid).any():
+        if (~valid_edge).any():
             logging.warning(
-                "NodeDrop filtered %d out-of-range edges", int((~valid).sum())
+                "NodeDrop filtered %d out-of-range edges", int((~valid_edge).sum())
             )
-        src = src[valid]
-        dst = dst[valid]
+        src = src[valid_edge]
+        dst = dst[valid_edge]
 
+        # ── 삭제 노드와 연결된 엣지 필터링 ────────────────────────────
         keep = (src_map[src] != -1) & (dst_map[dst] != -1)
 
         # edge_index 재인덱싱
@@ -219,8 +220,7 @@ class NodeDrop(SimpleAug, AugmentBase):
         )
 
         # 원본 에지에 대한 최종 마스크 (edge attributes filtering)
-        final_mask = torch.zeros(num_e, dtype=torch.bool, device=edge_index.device)
-        final_mask[valid] = keep
+        final_mask = keep
 
         # ── 삭제 후 남은 엣지가 없으면 self-loop 생성 ─────────────────────
         if new_ei.numel() == 0:
@@ -236,4 +236,4 @@ class NodeDrop(SimpleAug, AugmentBase):
             if key == "edge_index":
                 continue
             if torch.is_tensor(val) and val.size(0) == num_e:
-                store[key] = val[final_mask]
+                store[key] = val[valid_edge][final_mask]

--- a/tests/test_node_drop.py
+++ b/tests/test_node_drop.py
@@ -65,3 +65,18 @@ def test_node_drop_filters_invalid_edges_hetero():
 
     assert torch.equal(out[("a", "to", "b")].edge_index, torch.tensor([[0], [0]]))
     assert out[("b", "to", "a")].edge_index.numel() == 0
+
+
+def test_node_drop_ignores_invalid_references():
+    g = Data(
+        x=torch.randn(2, 1),
+        edge_index=torch.tensor([[0, 2], [1, 0]]),
+        edge_attr=torch.tensor([5, 7]),
+        num_nodes=2,
+    )
+
+    aug = NodeDrop(keep_prob=1.0)
+    out = aug(g)
+
+    assert torch.equal(out.edge_index, torch.tensor([[0], [1]]))
+    assert torch.equal(out.edge_attr, torch.tensor([5]))


### PR DESCRIPTION
## Summary
- handle out-of-range edges in NodeDrop before computing keep mask
- support filtering of invalid edges when syncing edge attributes
- add regression test for invalid edge references

## Testing
- `pytest tests/test_node_drop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685d71b151f4832eb18ccfddd5e20ab4