### PR TITLE
Add test to ensure NodeDrop handles out-of-range edges

### DIFF
--- a/tests/test_node_drop.py
+++ b/tests/test_node_drop.py
@@ -80,3 +80,19 @@ def test_node_drop_ignores_invalid_references():
 
     assert torch.equal(out.edge_index, torch.tensor([[0], [1]]))
     assert torch.equal(out.edge_attr, torch.tensor([5]))
+
+
+def test_node_drop_handles_out_of_range_indices():
+    g = Data(
+        x=torch.randn(4, 1),
+        edge_index=torch.tensor([[0, 4, 2], [1, 3, 3]]),
+        edge_attr=torch.tensor([11, 22, 33]),
+        num_nodes=4,
+    )
+
+    aug = NodeDrop(keep_prob=1.0)
+    out = aug(g)
+
+    assert torch.equal(out.edge_index, torch.tensor([[0, 2], [1, 3]]))
+    assert torch.equal(out.edge_attr, torch.tensor([11, 33]))
+    assert out.edge_index.max().item() < 4


### PR DESCRIPTION
## Summary
- add a unit test verifying that NodeDrop removes edges that reference
  indices outside of `num_nodes`

## Testing
- `pytest tests/test_node_drop.py::test_node_drop_handles_out_of_range_indices -q`

------
https://chatgpt.com/codex/tasks/task_e_685d74ea107c832e94747f67962f37c5