### PR TITLE
Ensure num_nodes metadata before adding hetero views

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -230,6 +230,32 @@ from ..normalizers.base import get_normalizer  # optional schema normaliser
 from ..utils import tqdm_wrap, ensure_dir, set_random_seed
 
 
+def _ensure_num_nodes_any(g: Data | HeteroData) -> Data | HeteroData:
+    """Infer ``num_nodes`` for ``Data`` or ``HeteroData`` objects."""
+    if isinstance(g, HeteroData):
+        for _, store in g.node_items():
+            n = store.num_nodes
+            if n is None:
+                if len(store) > 0:
+                    n = len(store)
+                elif "edge_index" in store:
+                    n = int(store["edge_index"].max()) + 1
+                else:
+                    n = 0
+            store.num_nodes = int(n)
+    else:  # Data
+        n = getattr(g, "num_nodes", None)
+        if n is None:
+            if hasattr(g, "x"):
+                n = g.x.size(0)
+            elif hasattr(g, "edge_index"):
+                n = int(g.edge_index.max()) + 1
+            else:
+                n = 0
+        g.num_nodes = int(n)
+    return g
+
+
 def ensure_num_nodes(hetero: HeteroData) -> None:
     """Infer and set ``num_nodes`` for every node store in ``hetero``.
 
@@ -328,6 +354,7 @@ def _process_one(
         g = get_loader(v).load(fp_json)
         if normalise:
             g = get_normalizer(v).normalize(g)
+        g = _ensure_num_nodes_any(g)
         builder.add_view(g, v)
 
     if not builder._views:

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -127,3 +127,21 @@ def test_merge_list_attribute_length():
 
     hetero = builder.build()
     assert len(hetero["n"].label) == g1["n"].num_nodes + g2["n"].num_nodes
+
+
+def test_no_warnings_on_build():
+    import warnings
+    import logging
+
+    g = Data(edge_index=torch.tensor([[0, 1], [1, 2]]))
+
+    logging.getLogger().setLevel(logging.WARNING)
+    builder = HeteroGraphBuilder()
+    from src.graphs.builders.hetero_builder import _ensure_num_nodes_any
+
+    g = _ensure_num_nodes_any(g)
+    builder.add_view(g, "cfg")
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        _ = builder.build()
+    assert not record


### PR DESCRIPTION
## Summary
- add helper to infer `num_nodes` for Data/HeteroData
- run helper in dataset building before `add_view`
- verify no warnings are raised when building graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d79035df4832ea84f9613f1898ae2