### PR TITLE
Fill missing __init__ docstrings

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,7 @@
-"""TODO"""
+"""Top-level package for *robust-malware-graph*.
+
+This namespace gathers the various subpackages used throughout the
+project such as :mod:`extract`, :mod:`graphs` and :mod:`models`.
+"""
+
+__all__ = []

--- a/src/collect/__init__.py
+++ b/src/collect/__init__.py
@@ -1,1 +1,3 @@
-"""TODO"""
+"""Data collection helpers for building raw malware datasets."""
+
+__all__ = []

--- a/src/continual/callbacks/__init__.py
+++ b/src/continual/callbacks/__init__.py
@@ -1,5 +1,5 @@
-"""TODO"""
-"""
+"""Callback utilities for continual-learning experiments.
+
 src.continual.callbacks
 =======================
 

--- a/src/extract/__init__.py
+++ b/src/extract/__init__.py
@@ -1,1 +1,25 @@
-"""TODO"""
+"""Binary view extraction utilities.
+
+This package exposes common extractor classes and helper functions for
+building data pipelines that convert raw binaries into graph views.
+"""
+
+from .base import ExtractorBase
+from .extractors import (
+    ASTExtractor,
+    CFGExtractor,
+    FCGExtractor,
+    ImportExtractor,
+    SysCallExtractor,
+)
+from .pipelines import run_pipeline
+
+__all__ = [
+    "ExtractorBase",
+    "ASTExtractor",
+    "CFGExtractor",
+    "FCGExtractor",
+    "ImportExtractor",
+    "SysCallExtractor",
+    "run_pipeline",
+]

--- a/src/extract/extractors/__init__.py
+++ b/src/extract/extractors/__init__.py
@@ -1,1 +1,24 @@
-"""TODO"""
+"""Collection of concrete extractor classes.
+
+Each extractor converts a binary into a particular view such as an AST
+or CFG.  Utility helpers for registering and looking up extractors are
+re-exported from :mod:`view_registry`.
+"""
+
+from .ast_extractor import ASTExtractor
+from .cfg_extractor import CFGExtractor
+from .fcg_extractor import FCGExtractor
+from .import_extractor import ImportExtractor
+from .syscall_extractor import SysCallExtractor
+from .view_registry import get_extractor, register_view, list_views
+
+__all__ = [
+    "ASTExtractor",
+    "CFGExtractor",
+    "FCGExtractor",
+    "ImportExtractor",
+    "SysCallExtractor",
+    "get_extractor",
+    "register_view",
+    "list_views",
+]


### PR DESCRIPTION
## Summary
- write brief package descriptions in several `__init__.py` modules
- export common extractor classes and helpers via `__all__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d78f29688832e82e9818d5ae88fe0