### PR TITLE
Update rmg-cli entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 Homepage = "https://example.com"
 
 [project.scripts]
-rmg-cli = "cli:main"
+rmg-cli = "robust_malware_graph.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/robust_malware_graph/cli/__init__.py
+++ b/src/robust_malware_graph/cli/__init__.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for ``robust_malware_graph.cli``."""
+
+from cli import *  # re-export commands defined in ``src/cli``


### PR DESCRIPTION
## Summary
- expose `rmg-cli` entrypoint from `robust_malware_graph.cli:main`
- add compatibility module `robust_malware_graph.cli`

## Testing
- `pip install -e .`
- `rmg-cli --help`

------
https://chatgpt.com/codex/tasks/task_e_685d78ed351c832e985931b984766bf6