### PR TITLE
Add dataset attribute validation to SelfGCL CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ python -m cli.pretrain_selfgcl data/hetero \
     --output models/gnn/encoder.pt \
     --plot-path results/train_plot.png
 
+그래프 간 노드 속성 집합을 먼저 검증하며, 불일치 시 경고가 출력됩니다.
+`--reprocess` 플래그를 주면 processed 데이터셋을 자동으로 다시 생성합니다.
+
 그래프 파일에 비숫자형 리스트 속성이 있을 경우 자동으로 메타에 저장됩니다.
 
 # GNN 학습

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -395,6 +395,33 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         self.graph_meta = meta_list
 
 
+def validate_dataset(dataset: HeteroGraphDiskDataset) -> bool:
+    """Return ``True`` if all graphs share the same attribute set."""
+    paths = sorted(Path(dataset.root).glob("*.pt"))
+    ref: dict[str, set[str]] | None = None
+    ok = True
+    for p in paths:
+        g = torch.load(p, weights_only=False)
+        attrs: dict[str, set[str]] = {}
+        if isinstance(g, HeteroData):
+            for nt in g.node_types:
+                a = set(g[nt].keys())
+                a.discard("meta")
+                attrs[nt] = a
+        else:
+            a = set(g.keys())
+            a.discard("meta")
+            attrs[""] = a
+        if ref is None:
+            ref = attrs
+        elif attrs != ref:
+            LOGGER.warning("Attribute set mismatch in %s", p)
+            ok = False
+    if not ok:
+        LOGGER.warning("Dataset has inconsistent attributes. Run with --reprocess to rebuild.")
+    return ok
+
+
 # --------------------------------------------------------------------------- #
 # Training utilities
 # --------------------------------------------------------------------------- #
@@ -485,6 +512,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--save-every", type=int, default=10, help="Checkpoint interval (epochs)"
     )
+    p.add_argument(
+        "--reprocess",
+        action="store_true",
+        help="Rebuild processed dataset when attribute mismatch is detected",
+    )
     return p.parse_args()
 
 
@@ -514,6 +546,17 @@ def main():
     train_shas = split_json["train"]
 
     train_ds = HeteroGraphDiskDataset(args.graph_dir, sha_list=train_shas)
+
+    if not validate_dataset(train_ds):
+        if args.reprocess:
+            LOGGER.info("Reprocessing dataset …")
+            train_ds.process()
+            train_ds = HeteroGraphDiskDataset(args.graph_dir, sha_list=train_shas)
+        else:
+            LOGGER.warning(
+                "Attribute mismatch detected. Re-run with --reprocess to rebuild"
+            )
+
     train_loader = PyGLoader(
         train_ds,
         batch_size=args.batch_size,


### PR DESCRIPTION
## Summary
- add dataset validation helper in `pretrain_selfgcl`
- warn on attribute mismatch and optionally reprocess dataset with `--reprocess`
- document new validation behaviour and flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7a86fc70832e9443b5ffaac7ad5e