### PR TITLE
Handle missing addr attributes

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -29,6 +29,7 @@ import json
 from pathlib import Path
 from typing import Sequence
 from collections import defaultdict
+import logging
 import numpy as np
 
 import torch
@@ -135,6 +136,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         meta_list: list[dict[str, str]] = []
         attr_union: dict[str, set[str]] = defaultdict(set)
         attr_example: dict[tuple[str, str], object] = {}
+        meta_keys: dict[str, set[str]] = defaultdict(set)
 
         # ------------------------------------------------------------------
         # Build or load token vocabulary
@@ -266,7 +268,14 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             if isinstance(data, HeteroData):
                 for ntype in data.node_types:
                     store = data[ntype]
-                    graph_meta[ntype] = getattr(store, "meta", "")
+                    mval = getattr(store, "meta", "")
+                    if mval:
+                        try:
+                            m_dict = json.loads(mval) if isinstance(mval, str) else mval
+                            meta_keys[ntype].update(m_dict.keys())
+                        except json.JSONDecodeError:
+                            pass
+                    graph_meta[ntype] = mval
                     if "meta" in store:
                         del store["meta"]
             else:
@@ -300,6 +309,22 @@ class HeteroGraphDiskDataset(InMemoryDataset):
 
         LOGGER.info("Loaded %d graphs from %s", len(data_list), self.root)
 
+        # --- fill missing metadata keys ---
+        for meta in meta_list:
+            for ntype, keys in meta_keys.items():
+                mval = meta.get(ntype, "{}")
+                try:
+                    m_dict = json.loads(mval) if isinstance(mval, str) else mval
+                except json.JSONDecodeError:
+                    m_dict = {}
+                changed = False
+                for k in keys:
+                    if k not in m_dict:
+                        m_dict[k] = None
+                        changed = True
+                if changed or not isinstance(mval, str):
+                    meta[ntype] = json.dumps(m_dict)
+
         # --- fill missing attributes with defaults ---
         for g, path in zip(data_list, source_paths):
             if isinstance(g, HeteroData):
@@ -320,12 +345,19 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                             store[attr] = []
                         else:
                             store[attr] = torch.zeros((num_nodes,), dtype=torch.long)
-                        LOGGER.warning(
-                            "Filled missing attribute '%s' for node type '%s' in graph %s",
-                            attr,
-                            ntype,
-                            path,
+                        msg = (
+                            "Filled missing attribute '%s' for node type '%s' in graph %s"
                         )
+                        LOGGER.warning(msg, attr, ntype, path)
+                        logging.getLogger().warning(msg, attr, ntype, path)
+                    allowed = set(NODE_ATTRS.get(NodeType(ntype), ()))
+                    if "addr" in allowed and "addr" not in store:
+                        store["addr"] = torch.zeros((num_nodes,), dtype=torch.long)
+                        msg = (
+                            "Added missing attribute 'addr' for node type '%s' in graph %s"
+                        )
+                        LOGGER.warning(msg, ntype, path)
+                        logging.getLogger().warning(msg, ntype, path)
             else:
                 num_nodes = g.num_nodes
                 for attr in attr_union[""]:

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -208,3 +208,28 @@ def test_hex_addr_conversion(tmp_path, monkeypatch):
     batch = next(iter(loader))
     store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
     assert torch.all(store.addr.eq(torch.tensor([16, 32], dtype=torch.long)))
+
+
+def test_schema_addr_default(tmp_path, monkeypatch):
+    """Ensure 'addr' is added when defined in schema but missing in data."""
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["token"].x = torch.randn(1, 1)
+    g1["token"].num_nodes = 1
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["token"].x = torch.randn(2, 1)
+    g2["token"].num_nodes = 2
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    loader = DataLoader(ds, batch_size=2)
+    batch = next(iter(loader))
+    store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
+    assert torch.all(store.addr.eq(torch.zeros(3, dtype=torch.long)))


### PR DESCRIPTION
## Summary
- ensure missing metadata keys are filled so `meta` collation works
- insert zero-valued `addr` if node type schema expects it
- emit warnings via root logger for easier capture
- test coverage for `addr` schema default

## Testing
- `pytest tests/test_selfgcl_dataset.py::test_fill_missing_attributes tests/test_selfgcl_dataset.py::test_extra_attr_moved_to_meta tests/test_selfgcl_dataset.py::test_schema_addr_default -q`
- `pytest tests/test_selfgcl_dataset.py::test_schema_addr_default -q`


------
https://chatgpt.com/codex/tasks/task_e_685d7f59ea74832eb18dea199467b386