### PR TITLE
Fix RGCNEncoder checkpoint load

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -195,9 +195,17 @@ class RGCNEncoder(nn.Module):
 
         edge_types = [(node_types[0], f"r{i}", node_types[0]) for i in range(num_rel)]
 
+        vocab_size = 0
+        attr_dim = 32
+        if "meta_embed.weight" in state:
+            vocab_size = state["meta_embed.weight"].size(0)
+            attr_dim = state["meta_embed.weight"].size(1)
+
         enc = cls(
             metadata=(node_types, edge_types),
             in_dims=in_dims,
+            vocab_size=vocab_size,
+            attr_dim=attr_dim,
             hidden_dim=hidden_dim,
             num_layers=num_layers,
             out_dim=out_dim,

--- a/tests/test_encoder_load.py
+++ b/tests/test_encoder_load.py
@@ -1,0 +1,48 @@
+import sys
+import types
+import pytest
+
+pytest.importorskip("torch")
+
+import torch
+
+# Stub minimal torch_geometric modules to allow importing the encoder
+stub_tg = types.ModuleType("torch_geometric")
+stub_nn = types.ModuleType("torch_geometric.nn")
+
+class DummyRGCNConv(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, num_relations, num_bases):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.empty(num_relations, in_channels, out_channels)
+        )
+
+    def forward(self, x, edge_index, edge_type):  # pragma: no cover
+        return x
+
+def global_mean_pool(x, batch):
+    return x
+
+stub_nn.RGCNConv = DummyRGCNConv
+stub_nn.global_mean_pool = global_mean_pool
+stub_tg.nn = stub_nn
+sys.modules.setdefault("torch_geometric", stub_tg)
+sys.modules.setdefault("torch_geometric.nn", stub_nn)
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def test_from_state_dict_with_meta_embed():
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        vocab_size=3,
+        attr_dim=2,
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=8,
+    )
+    state = enc.state_dict()
+    loaded = RGCNEncoder._from_state_dict(state)
+    assert loaded.meta_embed is not None
+    assert loaded.meta_embed.weight.shape == enc.meta_embed.weight.shape


### PR DESCRIPTION
## Summary
- support meta_embed.weight when rebuilding RGCNEncoder from a state dict
- add regression test for this behaviour

## Testing
- `pytest tests/test_encoder_load.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn', 'angr', 'omegaconf')*

------
https://chatgpt.com/codex/tasks/task_e_685d8f6ca4e0832e9daf2b2a4871d5f6