### PR TITLE
Fix encoder attr names loading

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -35,7 +35,7 @@ import torch
 import torch.multiprocessing as mp
 from torch import nn, optim
 from torch.utils.data import DataLoader
-from torch_geometric.data import InMemoryDataset, Batch
+from torch_geometric.data import InMemoryDataset, Batch, HeteroData
 import torch_geometric.transforms as T
 import matplotlib.pyplot as plt
 
@@ -260,8 +260,23 @@ def main() -> None:
         import wandb
         wandb.init(project="robust-malware-graph", name="finetune_supcon", config=vars(args))
 
+    # ---------------- DataLoaders ---------------------------------------- #
+    train_dl, val_dl = make_dataloaders(args.splits_dir, args.split, args.batch_size)
+
+    attr_names = {}
+    g0, _, _ = train_dl.dataset[0]
+    if isinstance(g0, HeteroData):
+        for nt in g0.node_types:
+            names = [k[:-3] for k in g0[nt].keys() if k.endswith("_id")]
+            if names:
+                attr_names[nt] = names
+
     # ---------------- Model ---------------------------------------------- #
-    encoder = RGCNEncoder.load_from_checkpoint(args.encoder_checkpoint, map_location=device)
+    encoder = RGCNEncoder.load_from_checkpoint(
+        args.encoder_checkpoint,
+        attr_names=attr_names,
+        map_location=device,
+    )
     if args.lora:
         from peft import inject_adapter
         encoder = inject_adapter(encoder, r=8, alpha=32)
@@ -269,9 +284,6 @@ def main() -> None:
 
     model = nn.Module(); model.encoder = encoder; model.head = head
     model.to(device)
-
-    # ---------------- DataLoaders ---------------------------------------- #
-    train_dl, val_dl = make_dataloaders(args.splits_dir, args.split, args.batch_size)
 
     # ---------------- Optim / Sched -------------------------------------- #
     optimizer = optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)

--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -171,7 +171,9 @@ class RGCNEncoder(nn.Module):
 
     # ------------------------------------------------------------------
     @classmethod
-    def _from_state_dict(cls, state: Dict[str, Tensor]) -> "RGCNEncoder":
+    def _from_state_dict(
+        cls, state: Dict[str, Tensor], attr_names: Dict[str, list[str]] | None = None
+    ) -> "RGCNEncoder":
         """Instantiate encoder from ``state`` without external metadata."""
         node_types = []
         in_dims: Dict[str, int] = {}
@@ -201,9 +203,13 @@ class RGCNEncoder(nn.Module):
             vocab_size = state["meta_embed.weight"].size(0)
             attr_dim = state["meta_embed.weight"].size(1)
 
+        if attr_names is None:
+            attr_names = {nt: [] for nt in node_types}
+
         enc = cls(
             metadata=(node_types, edge_types),
             in_dims=in_dims,
+            attr_names=attr_names,
             vocab_size=vocab_size,
             attr_dim=attr_dim,
             hidden_dim=hidden_dim,
@@ -215,7 +221,9 @@ class RGCNEncoder(nn.Module):
 
     # ------------------------------------------------------------------
     @classmethod
-    def load_from_checkpoint(cls, path, *, map_location=None) -> "RGCNEncoder":
+    def load_from_checkpoint(
+        cls, path, *, attr_names: Dict[str, list[str]] | None = None, map_location=None
+    ) -> "RGCNEncoder":
         """Load encoder from ``torch.save`` checkpoint."""
         obj = torch.load(path, map_location=map_location, weights_only=False)
 
@@ -229,4 +237,4 @@ class RGCNEncoder(nn.Module):
         else:
             raise ValueError(f"Unrecognized checkpoint format: {path}")
 
-        return cls._from_state_dict(state)
+        return cls._from_state_dict(state, attr_names=attr_names)

--- a/tests/test_encoder_load.py
+++ b/tests/test_encoder_load.py
@@ -46,3 +46,33 @@ def test_from_state_dict_with_meta_embed():
     loaded = RGCNEncoder._from_state_dict(state)
     assert loaded.meta_embed is not None
     assert loaded.meta_embed.weight.shape == enc.meta_embed.weight.shape
+
+
+def test_load_checkpoint_with_attr_names(tmp_path):
+    pytest.importorskip("torch_geometric")
+    from torch_geometric.data import HeteroData
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 6},
+        attr_names={"n": ["foo"]},
+        vocab_size=5,
+        attr_dim=2,
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=8,
+    )
+    ckpt = {"model": enc.state_dict()}
+    path = tmp_path / "enc.pt"
+    torch.save(ckpt, path)
+
+    g = HeteroData()
+    g["n"].x = torch.randn(1, 4)
+    g["n"].foo_id = torch.tensor([1])
+    g["n"].num_nodes = 1
+
+    attr_names = {nt: [k[:-3] for k in g[nt].keys() if k.endswith("_id")]
+                  for nt in g.node_types}
+
+    loaded = RGCNEncoder.load_from_checkpoint(path, attr_names=attr_names)
+    loaded(g)


### PR DESCRIPTION
## Summary
- forward attr_names through `RGCNEncoder.load_from_checkpoint`
- preserve attr_names when instantiating from a checkpoint
- infer attr_names from dataset samples in `finetune_supcon` CLI
- add regression test for meta attribute checkpoint

## Testing
- `pytest -k encoder_load -q`

------
https://chatgpt.com/codex/tasks/task_e_685d92b74864832ebfccb7e851cf7a14