### PR TITLE
Include attr_names in encoder checkpoints

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -728,10 +728,12 @@ def main():
 
     # Save final encoder weights (without projection head)
     if hasattr(model, "module"):
-        encoder_state = model.module.encoder.state_dict()
+        enc = model.module.encoder
     else:
-        encoder_state = model.encoder.state_dict()
-    torch.save(encoder_state, args.output)
+        enc = model.encoder
+
+    encoder_state = enc.state_dict()
+    torch.save({"model": encoder_state, "attr_names": enc.attr_names}, args.output)
     LOGGER.info(
         "Pre‑training completed ✔  BestLoss %.4f  Saved → %s", best_loss, args.output
     )

--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -172,7 +172,10 @@ class RGCNEncoder(nn.Module):
     # ------------------------------------------------------------------
     @classmethod
     def _from_state_dict(
-        cls, state: Dict[str, Tensor], attr_names: Dict[str, list[str]] | None = None
+        cls,
+        state: Dict[str, Tensor],
+        *,
+        attr_names: Dict[str, list[str]] | None = None,
     ) -> "RGCNEncoder":
         """Instantiate encoder from ``state`` without external metadata."""
         node_types = []
@@ -226,15 +229,21 @@ class RGCNEncoder(nn.Module):
     ) -> "RGCNEncoder":
         """Load encoder from ``torch.save`` checkpoint."""
         obj = torch.load(path, map_location=map_location, weights_only=False)
+        ckpt_attr_names = None
 
         if isinstance(obj, cls):
             return obj
 
         if isinstance(obj, dict) and "model" in obj:
             state = obj["model"]
+            ckpt_attr_names = obj.get("attr_names")
         elif isinstance(obj, dict):
             state = obj
+            ckpt_attr_names = obj.get("attr_names")
         else:
             raise ValueError(f"Unrecognized checkpoint format: {path}")
+
+        if attr_names is None:
+            attr_names = ckpt_attr_names
 
         return cls._from_state_dict(state, attr_names=attr_names)

--- a/tests/test_encoder_load.py
+++ b/tests/test_encoder_load.py
@@ -48,7 +48,7 @@ def test_from_state_dict_with_meta_embed():
     assert loaded.meta_embed.weight.shape == enc.meta_embed.weight.shape
 
 
-def test_load_checkpoint_with_attr_names(tmp_path):
+def test_load_checkpoint_with_external_attr_names(tmp_path):
     pytest.importorskip("torch_geometric")
     from torch_geometric.data import HeteroData
 
@@ -76,3 +76,31 @@ def test_load_checkpoint_with_attr_names(tmp_path):
 
     loaded = RGCNEncoder.load_from_checkpoint(path, attr_names=attr_names)
     loaded(g)
+
+
+def test_load_checkpoint_with_saved_attr_names(tmp_path):
+    pytest.importorskip("torch_geometric")
+    from torch_geometric.data import HeteroData
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 6},
+        attr_names={"n": ["foo"]},
+        vocab_size=5,
+        attr_dim=2,
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=8,
+    )
+    ckpt = {"model": enc.state_dict(), "attr_names": enc.attr_names}
+    path = tmp_path / "enc.pt"
+    torch.save(ckpt, path)
+
+    g = HeteroData()
+    g["n"].x = torch.randn(1, 4)
+    g["n"].foo_id = torch.tensor([1])
+    g["n"].num_nodes = 1
+
+    loaded = RGCNEncoder.load_from_checkpoint(path)
+    loaded(g)
+


### PR DESCRIPTION
## Summary
- save encoder `attr_names` metadata in SelfGCL pretraining output
- expose `attr_names` param in encoder `_from_state_dict`
- load encoder metadata from checkpoints when available
- test checkpoint loading with saved metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9de8f0a4832e9fc3f9e71cbdeddc