### PR TITLE
Fix attr name mismatch in SupCon fine-tune

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -263,20 +263,23 @@ def main() -> None:
     # ---------------- DataLoaders ---------------------------------------- #
     train_dl, val_dl = make_dataloaders(args.splits_dir, args.split, args.batch_size)
 
-    attr_names = {}
-    g0, _, _ = train_dl.dataset[0]
-    if isinstance(g0, HeteroData):
-        for nt in g0.node_types:
-            names = [k[:-3] for k in g0[nt].keys() if k.endswith("_id")]
-            if names:
-                attr_names[nt] = names
-
     # ---------------- Model ---------------------------------------------- #
     encoder = RGCNEncoder.load_from_checkpoint(
         args.encoder_checkpoint,
-        attr_names=attr_names,
         map_location=device,
     )
+
+    # Optional: check whether dataset provides required metadata attributes
+    g0, _, _ = train_dl.dataset[0]
+    if isinstance(g0, HeteroData):
+        for nt, expected in encoder.attr_names.items():
+            present = {k[:-3] for k in g0[nt].keys() if k.endswith("_id")}
+            if not expected <= present:
+                LOGGER.warning(
+                    "Node type '%s' missing metadata fields %s required by checkpoint",
+                    nt,
+                    sorted(set(expected) - present),
+                )
     if args.lora:
         from peft import inject_adapter
         encoder = inject_adapter(encoder, r=8, alpha=32)


### PR DESCRIPTION
## Summary
- avoid overriding encoder attr metadata with dataset inspection
- warn when dataset is missing required metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dffcd9a98832e81d44297cadb1135