### PR TITLE
Add meta-id padding in GraphDataset

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -147,7 +147,11 @@ class GraphDataset(Dataset):
     # collate
     # ────────────────────────────────────────────────────────────────
     @staticmethod
-    def collate_fn(batch: List[Tuple[GraphT, int | None, str]]) -> Dict:
+    def collate_fn(
+        batch: List[Tuple[GraphT, int | None, str]],
+        *,
+        attr_names: Dict[str, List[str]] | None = None,
+    ) -> Dict:
         """Collate a list of graphs with possible feature size mismatch.
 
         ``torch_geometric.data.Batch.from_data_list`` requires matching
@@ -163,6 +167,8 @@ class GraphDataset(Dataset):
 
         # ensure num_nodes metadata is present for all graphs
         graphs = [GraphDataset._ensure_num_nodes(g) for g in graphs]
+        if attr_names:
+            graphs = [GraphDataset._ensure_meta_ids(g, attr_names) for g in graphs]
 
         # ensure every graph has an 'x' tensor to avoid collation errors
         fixed_graphs: List[GraphT] = []
@@ -341,9 +347,9 @@ class GraphDataset(Dataset):
                 if "x" in store and store.num_nodes is not None:
                     _handle(store, "x", store.num_nodes, node_type)
         elif isinstance(g, Data):
-            if not hasattr(g, "x") and hasattr(g, "feat"):
+            if getattr(g, "x", None) is None and hasattr(g, "feat"):
                 g.x = g.feat
-            if hasattr(g, "x") and getattr(g, "num_nodes", None) is not None:
+            if getattr(g, "x", None) is not None and getattr(g, "num_nodes", None) is not None:
                 _handle(g, "x", g.num_nodes, "Data")
         return g
 
@@ -369,4 +375,27 @@ class GraphDataset(Dataset):
                 else:
                     n = 0
             g.num_nodes = int(n)
+        return g
+
+    # --------------------------------------------------------------
+    @staticmethod
+    def _ensure_meta_ids(g: GraphT, attr_names: Dict[str, List[str]]) -> GraphT:
+        """Ensure metadata id tensors exist for required attributes."""
+        if isinstance(g, HeteroData):
+            for nt, names in attr_names.items():
+                if nt not in g.node_types:
+                    continue
+                store = g[nt]
+                n = store.num_nodes or 0
+                for name in names:
+                    key = f"{name}_id"
+                    if not hasattr(store, key):
+                        setattr(store, key, torch.zeros(n, dtype=torch.long))
+        elif isinstance(g, Data):
+            names = attr_names.get("", [])
+            n = g.num_nodes or 0
+            for name in names:
+                key = f"{name}_id"
+                if not hasattr(g, key):
+                    setattr(g, key, torch.zeros(n, dtype=torch.long))
         return g

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -154,3 +154,70 @@ def test_collate_handles_mixed_num_nodes_keys(tmp_path):
     batch = next(iter(loader))
 
     assert batch["graph"].num_nodes == 5
+
+
+def test_collate_fills_missing_metadata(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g1 = HeteroData()
+    g1["n"].x = torch.randn(1, 1)
+    g1["n"].num_nodes = 1
+    g1["n"].foo_id = torch.tensor([1])
+
+    g2 = HeteroData()
+    g2["n"].x = torch.randn(2, 1)
+    g2["n"].num_nodes = 2
+    g2["n"].bar_id = torch.tensor([2, 3])
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    labels = tmp_path / "train" / "labels.csv"
+    labels.write_text("sha256,label\na,0\nb,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    from torch.utils.data import DataLoader
+    from functools import partial
+
+    attr_names = {"n": ["foo", "bar"]}
+    loader = DataLoader(
+        ds,
+        batch_size=2,
+        collate_fn=partial(GraphDataset.collate_fn, attr_names=attr_names),
+    )
+    batch = next(iter(loader))
+
+    assert torch.equal(batch["graph"]["n"].foo_id, torch.tensor([1, 0, 0]))
+    assert torch.equal(batch["graph"]["n"].bar_id, torch.tensor([0, 2, 3]))
+
+
+def test_collate_fills_missing_metadata_data(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    from torch_geometric.data import Data
+
+    g1 = Data(x=torch.randn(1, 1), foo_id=torch.tensor([1]), num_nodes=1)
+    g2 = Data(x=torch.randn(2, 1), num_nodes=2)
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    labels = tmp_path / "train" / "labels.csv"
+    labels.write_text("sha256,label\na,0\nb,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    from torch.utils.data import DataLoader
+    from functools import partial
+
+    attr_names = {"": ["foo"]}
+    loader = DataLoader(
+        ds,
+        batch_size=2,
+        collate_fn=partial(GraphDataset.collate_fn, attr_names=attr_names),
+    )
+
+    batch = next(iter(loader))
+
+    assert torch.equal(batch["graph"].foo_id, torch.tensor([1, 0, 0]))


### PR DESCRIPTION
## Summary
- add `_ensure_meta_ids` helper to insert zero tensors for missing metadata
- support optional `attr_names` argument in `GraphDataset.collate_fn`
- handle Data objects lacking `x` more robustly
- test collation of missing metadata

## Testing
- `pytest tests/test_graph_dataset.py tests/test_encode_metadata.py::test_encode_metadata_various_lists -q`

------
https://chatgpt.com/codex/tasks/task_e_685e03661aa0832ea1b1aaf67ff91f29