### PR TITLE
Add strict metadata check to finetune_supcon

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ python -m cli.pretrain_selfgcl data/hetero \
     --plot-path results/train_plot.png
 
 그래프 간 노드 속성 집합을 먼저 검증하며, 불일치 시 경고가 출력됩니다.
+`--strict-meta` 플래그를 주면 누락 시 오류가 발생합니다.
 `--reprocess` 플래그를 주면 processed 데이터셋을 자동으로 다시 생성합니다.
 
 그래프 파일에 비숫자형 리스트 속성이 있을 경우 자동으로 메타에 저장됩니다.
@@ -112,6 +113,7 @@ python -m cli.finetune_supcon \
        --split "2023Q4" \
        --epochs 100 --batch-size 128 \
        --lr 1e-4 --patience 3 \
+       --strict-meta \
        --plot-path results/finetune_supcon/train.png
 
 # RES-GCL 분류기 학습

--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -81,6 +81,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--plot-path", type=Path,
                    help="Where to save training curve PNG; defaults to logdir/train.png")
     p.add_argument("--wandb", action="store_true", help="Enable WandB logging")
+    p.add_argument("--strict-meta", action="store_true",
+                   help="Error out if required metadata fields are missing")
 
     # Hydra inspection ------------------------------------------------------ #
     p.add_argument("--cfg", choices=["hydra"], help="Dump merged config and exit")
@@ -275,11 +277,14 @@ def main() -> None:
         for nt, expected in encoder.attr_names.items():
             present = {k[:-3] for k in g0[nt].keys() if k.endswith("_id")}
             if not expected <= present:
-                LOGGER.warning(
-                    "Node type '%s' missing metadata fields %s required by checkpoint",
-                    nt,
-                    sorted(set(expected) - present),
+                missing = sorted(set(expected) - present)
+                msg = (
+                    "Node type '%s' missing metadata fields %s required by checkpoint"
+                    % (nt, missing)
                 )
+                if args.strict_meta:
+                    raise RuntimeError(msg)
+                LOGGER.warning(msg)
     if args.lora:
         from peft import inject_adapter
         encoder = inject_adapter(encoder, r=8, alpha=32)


### PR DESCRIPTION
## Summary
- extend finetune_supcon CLI with `--strict-meta`
- raise `RuntimeError` when required metadata fields are missing if strict mode is enabled
- document strict mode in README usage example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e062e6720832eb562f99cf6b9e7ab