### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ python -m cli.preprocessing --input-dir data/raw --out . graphs --normalise --re
 python -m cli.preprocessing --input-dir data/hetero --out . splits --fallback random --strategy random --json-out split_fold.json
 # 학습, 평가, 테스트 데이터 분할
 
-python -m cli.preprocessing --out . embeds --model-name microsoft/codebert-base --batch-size 64 --device cuda
+python -m cli.preprocessing --input-dir data/hetero --out . embeds --model-name microsoft/codebert-base --batch-size 64 --device cuda
 # graphs 단계에서 생성한 hetero 그래프가 필요합니다.
 
 python -m cli.pretrain_selfgcl data/hetero \


### PR DESCRIPTION
## Summary
- add missing `--input-dir` flag for embedding stage example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e1c9578e0832e88176a94862a4fee