### PR TITLE
Fix metadata fields check in finetune CLI

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -322,7 +322,7 @@ def main() -> None:
     if isinstance(g0, HeteroData):
         for nt, expected in encoder.attr_names.items():
             present = {k[:-3] for k in g0[nt].keys() if k.endswith("_id")}
-            if not expected <= present:
+            if not set(expected) <= present:
                 LOGGER.warning(
                     "Node type '%s' missing metadata fields %s required by checkpoint",
                     nt,


### PR DESCRIPTION
## Summary
- avoid comparing list with set when verifying dataset metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e56ee17e0832e9e3d7e24cf2d0645