### PR TITLE
Fix SupCon finetune metadata handling

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -97,8 +97,21 @@ def build_parser() -> argparse.ArgumentParser:
 # Data Utilities
 # --------------------------------------------------------------------------- #
 
-def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[DataLoader, DataLoader]:
+def make_dataloaders(
+    splits_dir: Path,
+    split: str,
+    batch_size: int,
+    *,
+    attr_names: dict[str, list[str]] | None = None,
+) -> Tuple[DataLoader, DataLoader]:
     """Load GraphDataset splits and wrap in PyG ``DataLoader`` objects.
+
+    Parameters
+    ----------
+    attr_names:
+        Optional mapping of node types to metadata attribute names.  When
+        provided, missing ``<name>_id`` tensors will be zero-padded by
+        :func:`GraphDataset.collate_fn` so they match the encoder checkpoint.
 
     ``pin_memory`` only makes sense when data is loaded on the CPU.  Graphs are
     now kept on the CPU and moved to the target device inside the training
@@ -134,7 +147,7 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         batch_size=batch_size,
         shuffle=True,
         num_workers=num_workers,
-        collate_fn=GraphDataset.collate_fn,
+        collate_fn=lambda batch: GraphDataset.collate_fn(batch, attr_names=attr_names),
         pin_memory=not use_cuda,
     )
     val_dl = DataLoader(
@@ -142,7 +155,7 @@ def make_dataloaders(splits_dir: Path, split: str, batch_size: int) -> Tuple[Dat
         batch_size=batch_size,
         shuffle=False,
         num_workers=num_workers,
-        collate_fn=GraphDataset.collate_fn,
+        collate_fn=lambda batch: GraphDataset.collate_fn(batch, attr_names=attr_names),
         pin_memory=not use_cuda,
     )
     return train_dl, val_dl
@@ -267,13 +280,18 @@ def main() -> None:
         import wandb
         wandb.init(project="robust-malware-graph", name="finetune_supcon", config=vars(args))
 
-    # ---------------- DataLoaders ---------------------------------------- #
-    train_dl, val_dl = make_dataloaders(args.splits_dir, args.split, args.batch_size)
-
     # ---------------- Model ---------------------------------------------- #
     encoder = RGCNEncoder.load_from_checkpoint(
         args.encoder_checkpoint,
         map_location=device,
+    )
+
+    # ---------------- DataLoaders ---------------------------------------- #
+    train_dl, val_dl = make_dataloaders(
+        args.splits_dir,
+        args.split,
+        args.batch_size,
+        attr_names=encoder.attr_names,
     )
 
     if args.force_reinit:


### PR DESCRIPTION
## Summary
- ensure missing metadata is padded using encoder attr_names
- build dataloaders after loading encoder so attr_names are known

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e57bfe1a4832ea676f2e0d9ce02b0