### PR TITLE
Add attribute sanitization in GraphDataset

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -170,6 +170,8 @@ class GraphDataset(Dataset):
         if attr_names:
             graphs = [GraphDataset._ensure_meta_ids(g, attr_names) for g in graphs]
 
+        graphs = [GraphDataset._sanitize_attrs(g) for g in graphs]
+
         # ensure every graph has an 'x' tensor to avoid collation errors
         fixed_graphs: List[GraphT] = []
         for g in graphs:
@@ -398,4 +400,40 @@ class GraphDataset(Dataset):
                 key = f"{name}_id"
                 if not hasattr(g, key):
                     setattr(g, key, torch.zeros(n, dtype=torch.long))
+        return g
+
+    # --------------------------------------------------------------
+    @staticmethod
+    def _sanitize_attrs(g: GraphT) -> GraphT:
+        """Convert numeric lists to tensors and stash others under ``meta``."""
+
+        def process_store(store: Data | HeteroData) -> None:
+            meta = getattr(store, "meta", None)
+            if not isinstance(meta, dict):
+                meta = {} if meta is None else {"value": meta}
+
+            for attr, val in list(store.items()):
+                if attr == "meta":
+                    continue
+                if isinstance(val, list):
+                    if all(isinstance(x, (int, float, bool)) for x in val) or not val:
+                        store[attr] = torch.tensor(val)
+                    else:
+                        meta[attr] = val
+                        del store[attr]
+                elif isinstance(val, str):
+                    meta[attr] = val
+                    del store[attr]
+
+            if meta:
+                store.meta = meta
+
+        if isinstance(g, HeteroData):
+            for _, store in g.node_items():
+                process_store(store)
+            for _, store in g.edge_items():
+                process_store(store)
+        else:
+            process_store(g)
+
         return g

--- a/tests/test_graph_dataset_sanitize.py
+++ b/tests/test_graph_dataset_sanitize.py
@@ -1,0 +1,42 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData, Batch
+from torch.utils.data import DataLoader
+
+from src.graphs.dataset.graph_dataset import GraphDataset
+
+
+def test_collate_sanitizes_list_attrs(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g1 = HeteroData()
+    g1["n"].x = torch.randn(1, 1)
+    g1["n"].foo = [1, 2]
+    g1["n"].bar = ["a", "b"]
+    g1["n"].name = "sample1"
+    g1["n"].num_nodes = 1
+
+    g2 = HeteroData()
+    g2["n"].x = torch.randn(1, 1)
+    g2["n"].foo = [3]
+    g2["n"].bar = ["c"]
+    g2["n"].name = "sample2"
+    g2["n"].num_nodes = 1
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    loader = DataLoader(ds, batch_size=2, collate_fn=GraphDataset.collate_fn)
+    batch = next(iter(loader))
+
+    assert isinstance(batch["graph"], Batch)
+    assert torch.is_tensor(batch["graph"]["n"].foo)
+    assert hasattr(batch["graph"]["n"], "meta")
+    assert "bar" in batch["graph"]["n"].meta
+    assert "name" in batch["graph"]["n"].meta


### PR DESCRIPTION
## Summary
- sanitize non-tensor attributes in `GraphDataset` to ensure batchability
- call `_sanitize_attrs` during collation
- test that list attributes are converted or stored in `meta`

## Testing
- `pytest tests/test_graph_dataset_sanitize.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5a9d007c832e810e864e9cffc44e