### PR TITLE
Filter mismatched checkpoint params

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -42,7 +42,7 @@ import torch_geometric.transforms as T
 import matplotlib.pyplot as plt
 
 # Local project imports ----------------------------------------------------- #
-from src.common.utils import set_random_seed, get_logger, ensure_dir
+from src.common.utils import set_random_seed, get_logger, ensure_dir, filter_state_dict
 from graphs.dataset.graph_dataset import GraphDataset
 from src.models.gnn.encoder import RGCNEncoder
 from src.models.contrast.sup_con import SupContrastHead
@@ -332,7 +332,8 @@ def main() -> None:
             target_node=encoder.target_node,
         )
         state = encoder.state_dict()
-        new_enc.load_state_dict(state, strict=False)
+        filtered = filter_state_dict(new_enc, state, logger=LOGGER)
+        new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
 
     # Optional: check whether dataset provides required metadata attributes

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -239,6 +239,53 @@ def flatten_dict(d: Mapping[str, Any], parent_key: str = "", sep: str = ".") -> 
 
 
 # ---------------------------------------------------------------------------
+# State dict helpers
+# ---------------------------------------------------------------------------
+
+def filter_state_dict(
+    model: "torch.nn.Module",
+    state: Mapping[str, "torch.Tensor"],
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> Dict[str, "torch.Tensor"]:
+    """Return subset of ``state`` compatible with ``model``.
+
+    Parameters
+    ----------
+    model:
+        Target model whose ``state_dict`` provides reference shapes.
+    state:
+        Checkpoint state dictionary to be filtered.
+    logger:
+        Optional logger to emit warnings for ignored keys.
+    """
+
+    if torch is None:
+        raise RuntimeError("filter_state_dict requires PyTorch")
+
+    logger = logger or get_logger(__name__)
+    model_state = model.state_dict()
+    filtered: Dict[str, torch.Tensor] = {}
+
+    for k, v in state.items():
+        target = model_state.get(k)
+        if target is None:
+            logger.warning("Ignoring checkpoint parameter '%s' not found in model", k)
+            continue
+        if target.shape != v.shape:
+            logger.warning(
+                "Ignoring checkpoint parameter '%s' with shape %s (expected %s)",
+                k,
+                tuple(v.shape),
+                tuple(target.shape),
+            )
+            continue
+        filtered[k] = v
+
+    return filtered
+
+
+# ---------------------------------------------------------------------------
 # Miscellaneous helpers
 # ---------------------------------------------------------------------------
 
@@ -257,6 +304,7 @@ __all__ = [
     "get_device",
     "get_logger",
     "human_bytes",
+    "filter_state_dict",
     "set_random_seed",
     "sha256sum",
     "timer",

--- a/tests/test_force_reinit.py
+++ b/tests/test_force_reinit.py
@@ -1,0 +1,40 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from src.models.gnn.encoder import RGCNEncoder
+from src.common.utils import filter_state_dict
+
+
+def test_force_reinit_filters_mismatched(tmp_path):
+    # encoder trained with feature dim 4
+    enc_old = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=8,
+    )
+    ckpt = {"model": enc_old.state_dict()}
+    path = tmp_path / "enc.pt"
+    torch.save(ckpt, path)
+
+    # new dataset requires feature dim 6
+    new_enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 6},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=8,
+    )
+    orig_weight = new_enc.input_proj["n"].weight.clone()
+
+    state = ckpt["model"]
+    filtered = filter_state_dict(new_enc, state)
+    new_enc.load_state_dict(filtered, strict=False)
+
+    # mismatched weight should remain unchanged
+    assert torch.allclose(new_enc.input_proj["n"].weight, orig_weight)
+


### PR DESCRIPTION
## Summary
- add `filter_state_dict` helper to ignore incompatible parameters when loading checkpoints
- use it in `finetune_supcon.py` during `--force-reinit`
- regression test for mismatched shapes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb7aedebc832eb835974c33186cc6