### PR TITLE
Improve num_nodes inference

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -230,29 +230,51 @@ from ..normalizers.base import get_normalizer  # optional schema normaliser
 from ..utils import tqdm_wrap, ensure_dir, set_random_seed
 
 
+def _guess_num_nodes(store: Data | HeteroData) -> int:
+    """Heuristically derive ``num_nodes`` for a node store.
+
+    When ``num_nodes`` is ``None`` we inspect common attributes such as
+    ``x``, ``feat``, ``addr`` and ``inst_cnt``.  If those are missing we fall
+    back to ``edge_index`` and return ``0`` when no hint is available.
+    """
+
+    n = getattr(store, "num_nodes", None)
+    if n is not None:
+        return int(n)
+
+    for attr in ("x", "feat"):
+        val = getattr(store, attr, None)
+        if isinstance(val, torch.Tensor):
+            return int(val.size(0))
+
+    for attr in ("addr", "inst_cnt"):
+        val = getattr(store, attr, None)
+        if val is not None:
+            try:
+                return len(val)
+            except TypeError:
+                if isinstance(val, torch.Tensor):
+                    return int(val.size(0))
+
+    ei = getattr(store, "edge_index", None)
+    if isinstance(ei, torch.Tensor) and ei.numel() > 0:
+        return int(ei.max()) + 1
+
+    return 0
+
+
 def _ensure_num_nodes_any(g: Data | HeteroData) -> Data | HeteroData:
-    """Infer ``num_nodes`` for ``Data`` or ``HeteroData`` objects."""
+    """Infer ``num_nodes`` for ``Data`` or ``HeteroData`` objects.
+
+    Values are derived using :func:`_guess_num_nodes` so that saved graphs
+    missing this metadata remain usable.
+    """
+
     if isinstance(g, HeteroData):
         for _, store in g.node_items():
-            n = store.num_nodes
-            if n is None:
-                if len(store) > 0:
-                    n = len(store)
-                elif "edge_index" in store:
-                    n = int(store["edge_index"].max()) + 1
-                else:
-                    n = 0
-            store.num_nodes = int(n)
+            store.num_nodes = _guess_num_nodes(store)
     else:  # Data
-        n = getattr(g, "num_nodes", None)
-        if n is None:
-            if hasattr(g, "x"):
-                n = g.x.size(0)
-            elif hasattr(g, "edge_index"):
-                n = int(g.edge_index.max()) + 1
-            else:
-                n = 0
-        g.num_nodes = int(n)
+        g.num_nodes = _guess_num_nodes(g)
     return g
 
 
@@ -262,18 +284,12 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
     Parameters
     ----------
     hetero : HeteroData
-        Graph whose node stores may lack ``num_nodes`` metadata.
+        Graph whose node stores may lack ``num_nodes`` metadata.  The value is
+        guessed from attributes such as ``x``, ``feat``, ``addr`` or
+        ``inst_cnt`` with ``edge_index`` used as a fallback.
     """
     for _, store in hetero.node_items():
-        n = store.num_nodes
-        if n is None:
-            if len(store) > 0:
-                n = len(store)
-            elif "edge_index" in store:
-                n = int(store["edge_index"].max()) + 1
-            else:
-                n = 0
-        store.num_nodes = int(n)
+        store.num_nodes = _guess_num_nodes(store)
 
 
 def fill_missing_node_feats(

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -47,6 +47,7 @@ from torch_geometric.data import Batch, Data, HeteroData
 
 from ..builders.hetero_builder import (
     ensure_num_nodes as hetero_ensure_num_nodes,
+    _guess_num_nodes,
     OverLengthPolicy,
 )
 
@@ -357,26 +358,15 @@ class GraphDataset(Dataset):
 
     @staticmethod
     def _ensure_num_nodes(g: GraphT) -> GraphT:
-        """Infer ``num_nodes`` metadata when missing."""
+        """Infer ``num_nodes`` metadata when missing.
+
+        Length is guessed from attributes such as ``x``/``feat``/``addr`` or
+        ``inst_cnt`` with ``edge_index`` as a last resort.
+        """
         if isinstance(g, HeteroData):
-            # Delegate to shared utility used by builders
             hetero_ensure_num_nodes(g)
-            # Ensure "num_nodes" exists in every node store's mapping
-            for _, store in g.node_items():
-                n = store.num_nodes
-                if n is None:
-                    n = 0
-                store.num_nodes = int(n)
         elif isinstance(g, Data):
-            n = g.num_nodes
-            if n is None:
-                if hasattr(g, "x"):
-                    n = g.x.size(0)
-                elif hasattr(g, "edge_index"):
-                    n = int(g.edge_index.max()) + 1
-                else:
-                    n = 0
-            g.num_nodes = int(n)
+            g.num_nodes = _guess_num_nodes(g)
         return g
 
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `_guess_num_nodes` helper for inferring `num_nodes`
- use it in `ensure_num_nodes` and dataset handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed11aa370832eaad1c8ca681deb57