### PR TITLE
Add tests for num_nodes inference

### DIFF
--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -145,3 +145,20 @@ def test_no_warnings_on_build():
         warnings.simplefilter("always")
         _ = builder.build()
     assert not record
+
+def test_infer_num_nodes_from_attrs():
+    g = HeteroData()
+    g["bb"].addr = [0x1000, 0x2000, 0x3000]
+    g["bb"].inst_cnt = torch.tensor([1, 2, 3])
+    from src.graphs.builders.hetero_builder import _ensure_num_nodes_any
+
+    g = _ensure_num_nodes_any(g)
+    assert g["bb"].num_nodes == 3
+
+
+def test_infer_num_nodes_data_addr_only():
+    g = Data(addr=[0x1000, 0x2000])
+    from src.graphs.builders.hetero_builder import _ensure_num_nodes_any
+
+    g = _ensure_num_nodes_any(g)
+    assert g.num_nodes == 2


### PR DESCRIPTION
## Summary
- add tests that `_ensure_num_nodes_any` infers `num_nodes` from common attributes
- check inference on `HeteroData` and `Data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed2f4f020832ebabcfe642a719067