### PR TITLE
Improve num_nodes inference

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -165,7 +165,9 @@ class HeteroGraphBuilder:
                         merged_store[k] = []
                 else:
                     merged_store[k] = (
-                        torch.cat(cols) if isinstance(cols[0], torch.Tensor) else list(cols)
+                        torch.cat(cols)
+                        if isinstance(cols[0], torch.Tensor)
+                        else list(cols)
                     )
 
     # -----------------------------------------------------------
@@ -231,36 +233,49 @@ from ..utils import tqdm_wrap, ensure_dir, set_random_seed
 
 
 def _guess_num_nodes(store: Data | HeteroData) -> int:
-    """Heuristically derive ``num_nodes`` for a node store.
+    """Return a best effort ``num_nodes`` guess for *store*.
 
-    When ``num_nodes`` is ``None`` we inspect common attributes such as
-    ``x``, ``feat``, ``addr`` and ``inst_cnt``.  If those are missing we fall
-    back to ``edge_index`` and return ``0`` when no hint is available.
+    The previous logic picked the first suitable attribute, which could result
+    in inconsistent metadata when attributes such as ``addr`` and
+    ``inst_cnt`` had different lengths.  This implementation collects all
+    candidate lengths and issues a warning on mismatch before returning the
+    maximum size.  ``0`` is returned when no hint is available.
     """
 
     n = getattr(store, "num_nodes", None)
     if n is not None:
         return int(n)
 
+    candidates = []
+
     for attr in ("x", "feat"):
         val = getattr(store, attr, None)
         if isinstance(val, torch.Tensor):
-            return int(val.size(0))
+            candidates.append(int(val.size(0)))
 
     for attr in ("addr", "inst_cnt"):
         val = getattr(store, attr, None)
         if val is not None:
             try:
-                return len(val)
+                candidates.append(len(val))
             except TypeError:
                 if isinstance(val, torch.Tensor):
-                    return int(val.size(0))
+                    candidates.append(int(val.size(0)))
 
     ei = getattr(store, "edge_index", None)
     if isinstance(ei, torch.Tensor) and ei.numel() > 0:
-        return int(ei.max()) + 1
+        candidates.append(int(ei.max()) + 1)
 
-    return 0
+    if not candidates:
+        return 0
+
+    unique = set(candidates)
+    if len(unique) > 1:
+        warnings.warn(
+            f"num_nodes mismatch across attributes {sorted(unique)}; using max",
+            RuntimeWarning,
+        )
+    return max(unique)
 
 
 def _ensure_num_nodes_any(g: Data | HeteroData) -> Data | HeteroData:

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -54,6 +54,7 @@ def test_fill_missing_feats_warn_trim():
     g["n"].feat = torch.randn(3, 1)
     g["n"].num_nodes = 2
     import warnings
+
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         fill_missing_node_feats(g, dim=1, policy=OverLengthPolicy.TRIM)
@@ -78,10 +79,13 @@ def test_ensure_num_nodes_no_warning():
     ensure_num_nodes(hetero)
 
     import warnings
+
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         _ = len(hetero["token"])
     assert not record
+
+
 @pytest.mark.xfail(reason="policy not implemented")
 def test_num_nodes_error_policy():
     g = HeteroData()
@@ -146,6 +150,7 @@ def test_no_warnings_on_build():
         _ = builder.build()
     assert not record
 
+
 def test_infer_num_nodes_from_attrs():
     g = HeteroData()
     g["bb"].addr = [0x1000, 0x2000, 0x3000]
@@ -162,3 +167,18 @@ def test_infer_num_nodes_data_addr_only():
 
     g = _ensure_num_nodes_any(g)
     assert g.num_nodes == 2
+
+
+def test_guess_num_nodes_length_mismatch_warns():
+    g = HeteroData()
+    g["bb"].addr = [1, 2]
+    g["bb"].inst_cnt = torch.tensor([1])
+    from src.graphs.builders.hetero_builder import _ensure_num_nodes_any
+    import warnings
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        g = _ensure_num_nodes_any(g)
+    assert rec, "expected RuntimeWarning on length mismatch"
+    assert "num_nodes mismatch" in str(rec[0].message)
+    assert g["bb"].num_nodes == 2


### PR DESCRIPTION
## Summary
- fix `_guess_num_nodes` to handle conflicting attribute lengths
- warn when mismatch occurs and pick the maximum length
- add test for mismatched lengths

## Testing
- `black -q src/graphs/builders/hetero_builder.py tests/test_hetero_builder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed68e2758832ebf09e762252a74e1