### PR TITLE
Handle encoder metadata in training

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ python -m cli.pretrain_selfgcl data/hetero \
     --output models/gnn/encoder.pt \
     --plot-path results/train_plot.png
 
+# 위 명령을 실행하면 encoder.pt와 함께 그래프 메타데이터가
+# models/gnn/encoder.meta.pkl로 저장됩니다.
+
 그래프 간 노드 속성 집합을 먼저 검증하며, 불일치 시 경고가 출력됩니다.
 `--reprocess` 플래그를 주면 processed 데이터셋을 자동으로 다시 생성합니다.
 
@@ -109,14 +112,15 @@ python -m cli.pretrain_selfgcl data/hetero \
 
 python -m cli.finetune_supcon \
        --encoder-checkpoint models/gnn/encoder.pt \
+       --meta-path models/gnn/encoder.meta.pkl \
        --split "2023Q4" \
        --epochs 100 --batch-size 128 \
        --lr 1e-4 --patience 3 \
-       --force-reinit \
        --plot-path results/finetune_supcon/train.png
-
 `--force-reinit` should be used when the fine‑tuning dataset has different
 node feature dimensions or metadata from the encoder pre‑training data.
+`--meta-path` automatically handles mismatched input layers using the
+saved meta snapshot without needing `--force-reinit`.
 
 # RES-GCL 분류기 학습
 python -m cli.train_res_gcl \

--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -69,6 +69,8 @@ def build_parser() -> argparse.ArgumentParser:
     # Model / Training ------------------------------------------------------ #
     p.add_argument("--encoder-checkpoint", type=Path, required=True,
                    help="Path to pre‑trained encoder .pt file")
+    p.add_argument("--meta-path", type=Path,
+                   help="Path to encoder meta snapshot (.meta.pkl)")
     p.add_argument(
         "--force-reinit",
         action="store_true",
@@ -286,6 +288,13 @@ def main() -> None:
         map_location=device,
     )
 
+    meta_snapshot = None
+    if args.meta_path and args.meta_path.is_file():
+        try:
+            meta_snapshot = torch.load(args.meta_path)
+        except Exception as exc:  # pragma: no cover - I/O handling
+            LOGGER.warning("Failed to load meta snapshot %s: %s", args.meta_path, exc)
+
     # ---------------- DataLoaders ---------------------------------------- #
     train_dl, val_dl = make_dataloaders(
         args.splits_dir,
@@ -293,24 +302,41 @@ def main() -> None:
         args.batch_size,
         attr_names=encoder.attr_names,
     )
+    g0, _, _ = train_dl.dataset[0]
+    if isinstance(g0, HeteroData):
+        metadata = g0.metadata()
+        attr_names = {
+            nt: [k[:-3] for k in g0[nt].keys() if k.endswith("_id")]
+            for nt in g0.node_types
+        }
+        in_dims = {
+            nt: getattr(g0[nt], "x").size(-1) + len(attr_names[nt]) * encoder.attr_dim
+            for nt in g0.node_types
+        }
+    else:
+        metadata = ([], [])
+        attr_names = {}
+        in_dims = {"": getattr(g0, "x").size(-1)}
 
-    if args.force_reinit:
-        g0, _, _ = train_dl.dataset[0]
-        if isinstance(g0, HeteroData):
-            metadata = g0.metadata()
-            attr_names = {
-                nt: [k[:-3] for k in g0[nt].keys() if k.endswith("_id")]
-                for nt in g0.node_types
-            }
-            in_dims = {
-                nt: getattr(g0[nt], "x").size(-1)
-                + len(attr_names[nt]) * encoder.attr_dim
-                for nt in g0.node_types
-            }
+    auto_reinit = False
+    if meta_snapshot is not None:
+        snap_ntypes = set(meta_snapshot.get("node_types", []))
+        snap_etypes = set(tuple(e) for e in meta_snapshot.get("edge_types", []))
+        curr_ntypes = set(metadata[0])
+        curr_etypes = set(tuple(e) for e in metadata[1])
+        if snap_ntypes != curr_ntypes or snap_etypes != curr_etypes:
+            auto_reinit = True
         else:
-            metadata = ([], [])
-            attr_names = {}
-            in_dims = {"": getattr(g0, "x").size(-1)}
+            for nt, dim in in_dims.items():
+                if meta_snapshot.get("in_dims", {}).get(nt) != dim:
+                    auto_reinit = True
+                    break
+
+    if args.force_reinit or auto_reinit:
+        if auto_reinit and not args.force_reinit:
+            LOGGER.info(
+                "Dataset metadata mismatch with %s - reinitializing input layers", args.meta_path
+            )
         hidden_dim = (
             encoder.convs[0].sublayer.out_channels
             if hasattr(encoder.convs[0], "sublayer")

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -603,7 +603,7 @@ def main():
     # ``train_ds._data`` represents the collated dataset containing the union of
     # node types across all graphs, which ensures the encoder is aware of every
     # possible node type.
-    params, target_node = _load_model_hparams(
+    params, target_node, meta_info = _load_model_hparams(
         args.config, train_ds._data, vocab_size=len(train_ds.vocab)
     )
     model = SelfGraphCL(**params)
@@ -734,6 +734,10 @@ def main():
 
     encoder_state = enc.state_dict()
     torch.save({"model": encoder_state, "attr_names": enc.attr_names}, args.output)
+    try:
+        torch.save(meta_info, Path(args.output).with_suffix(".meta.pkl"))
+    except Exception as exc:  # pragma: no cover - I/O safeguard
+        LOGGER.warning("Failed to save meta snapshot: %s", exc)
     LOGGER.info(
         "Pre‑training completed ✔  BestLoss %.4f  Saved → %s", best_loss, args.output
     )
@@ -746,7 +750,7 @@ def main():
 
 def _load_model_hparams(
     cfg_path: Path, graph: HeteroData | Data, *, vocab_size: int = 0
-) -> tuple[dict, str | None]:
+) -> tuple[dict, str | None, dict]:
     """Return ``SelfGraphCL`` kwargs loaded from ``cfg_path``.
 
     Expected YAML ``model`` keys are a subset of
@@ -835,7 +839,12 @@ def _load_model_hparams(
         "temperature": cfg.get("loss", {}).get("temperature", 0.2),
         "gather_distributed": model_cfg.pop("gather_distributed", False),
     }
-    return params, target_node
+    meta_info = {
+        "node_types": list(metadata[0]),
+        "edge_types": [tuple(e) for e in metadata[1]],
+        "in_dims": {k: int(v) for k, v in in_dims.items()},
+    }
+    return params, target_node, meta_info
 
 
 def _build_scheduler(


### PR DESCRIPTION
## Summary
- save metadata snapshot after SelfGraphCL pretraining
- allow SupCon finetuning to load `--meta-path` and auto reinit when metadata mismatches
- document new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eeae19298832e9b2d68b3e502e494