### PR TITLE
Handle feature mismatch when fine-tuning SupCon

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -318,7 +318,26 @@ def main() -> None:
         attr_names = {}
         in_dims = {"": getattr(g0, "x").size(-1)}
 
-    auto_reinit = False
+    # automatically rebuild input layers if feature dimensions mismatch
+    dim_mismatch = False
+    for nt, proj in encoder.input_proj.items():
+        ds_dim = in_dims.get(nt)
+        if ds_dim != proj.in_features:
+            LOGGER.warning(
+                "Input feature dimension mismatch for node type '%s': dataset=%s checkpoint=%s",
+                nt,
+                ds_dim,
+                proj.in_features,
+            )
+            dim_mismatch = True
+    for nt in in_dims.keys() - encoder.input_proj.keys():
+        LOGGER.warning(
+            "Node type '%s' present in dataset but missing in checkpoint",
+            nt,
+        )
+        dim_mismatch = True
+
+    auto_reinit = dim_mismatch
     if meta_snapshot is not None:
         snap_ntypes = set(meta_snapshot.get("node_types", []))
         snap_etypes = set(tuple(e) for e in meta_snapshot.get("edge_types", []))

--- a/tests/test_auto_reinit_input_dim.py
+++ b/tests/test_auto_reinit_input_dim.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path, feat_dim: int) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, feat_dim)
+    g["n"].num_nodes = 2
+    g[("n", "r0", "n")].edge_index = torch.tensor([[0, 1], [1, 0]])
+    torch.save(g, path)
+
+
+def test_main_auto_reinit_on_dim_mismatch(tmp_path, caplog):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", 6)
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt_path = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt_path)
+
+    logdir = tmp_path / "log"
+    argv = [
+        "finetune_supcon",
+        "--encoder-checkpoint",
+        str(ckpt_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--logdir",
+        str(logdir),
+    ]
+
+    mod = importlib.import_module("src.cli.finetune_supcon")
+    caplog.set_level("INFO")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert any("dimension mismatch" in rec.message for rec in caplog.records)
+    assert any("Epoch 1" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- warn and rebuild encoder if dataset features differ from checkpoint
- add regression test covering automatic reinitialisation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eef8f5e74832ebd8daffa49c6ca37