### PR TITLE
Handle empty bb nodes in InjectAPICall

### DIFF
--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -153,6 +153,8 @@ class InjectAPICall(SimpleAug, AugmentBase):
 
         # (1) target bb 노드 선택
         num_bb = data["bb"].num_nodes
+        if not num_bb:
+            return
         bb_indices = self._choose_bb_indices(num_bb, device)
 
         # (2) API 노드 추가 ------------------------------------------------------------

--- a/tests/test_inject_call.py
+++ b/tests/test_inject_call.py
@@ -1,0 +1,15 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+from torch_geometric.data import HeteroData
+
+from src.augment.ops.inject_call import InjectAPICall
+
+
+def test_inject_api_call_handles_missing_bb():
+    g = HeteroData()
+    aug = InjectAPICall()
+    out = aug(g)
+    assert isinstance(out, HeteroData)


### PR DESCRIPTION
## Summary
- avoid errors in `InjectAPICall` when the graph contains a `bb` node type with zero nodes
- add unit test ensuring the augmentation can be applied when no `bb` nodes exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860dd261cb4832e8ba189d4f2022c06