### PR TITLE
Fix num_nodes handling in HeteroGraphBuilder

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -88,6 +88,8 @@ class HeteroGraphBuilder:
         out = HeteroData()
         self._assign_global_ids()
         self._merge_node_stores(out)
+        for ntype, count in self._global_counters.items():
+            out[ntype].num_nodes = count
         self._merge_edge_stores(out)
         return out
 
@@ -133,7 +135,7 @@ class HeteroGraphBuilder:
 
             # 모든 속성 키 집계
             keys = set(itertools.chain.from_iterable(s.keys() for s in stores))
-            keys.discard("num_nodes")
+            # keys.discard("num_nodes")  # keep num_nodes for later assignment
             merged_store = out[ntype]
 
             for k in keys:


### PR DESCRIPTION
## Summary
- keep `num_nodes` attribute during node store merge
- assign accumulated node counts in `build()`

## Testing
- `pytest tests/test_hetero_builder.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68619b71ca84832e866787866e9a327f