### PR TITLE
Fill missing address with zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ python -m cli.pretrain_selfgcl data/hetero \
 `--reprocess` 플래그를 주면 processed 데이터셋을 자동으로 다시 생성합니다.
 
 그래프 파일에 비숫자형 리스트 속성이 있을 경우 자동으로 메타에 저장됩니다.
+주소 정보가 없는 노드의 `addr` 속성은 0으로 채워집니다.
 
 # GNN 학습
 

--- a/src/graphs/normalizers/ast_norm.py
+++ b/src/graphs/normalizers/ast_norm.py
@@ -47,6 +47,7 @@ class ASTNormalizer(NormalizerBase):
         tok_store.num_nodes = n  # set first to avoid PyG warnings
 
         tok_store.tok_id = g.kind_id.clone()
+        tok_store.addr = torch.zeros(n, dtype=torch.long)
 
         # 위치(pos) : 0 … N-1
         tok_store.pos = torch.arange(n, dtype=torch.long)

--- a/src/graphs/normalizers/syscall_norm.py
+++ b/src/graphs/normalizers/syscall_norm.py
@@ -57,6 +57,7 @@ class SysCallNormalizer(NormalizerBase):
         sc_store = new_g[NodeType.SYSCALL.value]
 
         sc_store.num_nodes = n_syscalls  # set early
+        sc_store.addr = torch.zeros(n_syscalls, dtype=torch.long)
 
         if hasattr(g, "x") and g.x is not None:
             sc_store.feat = g.x[:n_syscalls].clone()
@@ -73,6 +74,7 @@ class SysCallNormalizer(NormalizerBase):
             tok_store = new_g[NodeType.TOKEN.value]
             tok_store.num_nodes = n_tokens
             tok_store.text = list(token_texts)
+            tok_store.addr = torch.zeros(n_tokens, dtype=torch.long)
 
         # ──────────────────────────────────────────────────────────
         # 3) 엣지 – seq + child(token)


### PR DESCRIPTION
## Summary
- add empty addr tensor to ASTNormalizer token store
- ensure addr exists for SysCallNormalizer syscalls and tokens
- note default zero addr values in README

## Testing
- `pytest tests/test_inject_call.py tests/test_normalizer.py::test_ast_normalizer_num_nodes tests/test_normalizer.py::test_syscall_normalizer_num_nodes -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ade31bd4832eaca4f492274ec81a