### PR TITLE
Ensure `api` num_nodes inference

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -255,7 +255,7 @@ def _guess_num_nodes(store: Data | HeteroData) -> int:
         if isinstance(val, torch.Tensor):
             candidates.append(int(val.size(0)))
 
-    for attr in ("addr", "inst_cnt"):
+    for attr in ("addr", "inst_cnt", "name", "api_name"):
         val = getattr(store, attr, None)
         if val is not None:
             try:

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -221,3 +221,20 @@ def test_collate_fills_missing_metadata_data(tmp_path):
     batch = next(iter(loader))
 
     assert torch.equal(batch["graph"].foo_id, torch.tensor([1, 0, 0]))
+
+
+def test_dataset_sets_api_num_nodes(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["bb"].num_nodes = 1
+    g[("bb", "calls", "api")].edge_index = torch.tensor([[0], [0]])
+    g["api"].api_name = ["CreateFileA"]
+
+    torch.save(g, graph_dir / "s.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    loaded, _, _ = ds[0]
+
+    assert loaded["api"].num_nodes == 1

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -182,3 +182,14 @@ def test_guess_num_nodes_length_mismatch_warns():
     assert rec, "expected RuntimeWarning on length mismatch"
     assert "num_nodes mismatch" in str(rec[0].message)
     assert g["bb"].num_nodes == 2
+
+
+def test_guess_num_nodes_from_api_name():
+    g = HeteroData()
+    g["api"].api_name = ["Open", "Close", "Read"]
+
+    from src.graphs.builders.hetero_builder import _ensure_num_nodes_any
+
+    g = _ensure_num_nodes_any(g)
+
+    assert g["api"].num_nodes == 3


### PR DESCRIPTION
## Summary
- support `name` & `api_name` when guessing `num_nodes`
- unit test for API name inference
- unit test verifying dataset sets `api` num_nodes

## Testing
- `pytest -q tests/test_hetero_builder.py::test_guess_num_nodes_from_api_name tests/test_graph_dataset.py::test_dataset_sets_api_num_nodes -q`
- `pytest -q` *(fails: AttributeError: Can't get local object 'make_dataloaders.<locals>.<lambda>' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6861af4b3694832eb6e59dda5c0c142f