### PR TITLE
Fix PyG storage warning in SelfGraphCL dataset

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -73,24 +73,24 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             self.vocab = {}
         loaded = torch.load(self.processed_paths[0], weights_only=False)
         if isinstance(loaded, (list, tuple)) and len(loaded) == 3:
-            self.data, self.slices, self.graph_meta = loaded
+            self._data, self.slices, self.graph_meta = loaded
         else:  # Backwards compatibility
-            self.data, self.slices = loaded
+            self._data, self.slices = loaded
             self.graph_meta = None
 
         # Ensure every stored graph has an ``.x`` attribute for each node type.
         # Some legacy datasets only provide ``.feat`` which breaks newer
-        # modules that expect ``.x``.  We patch the collated ``self.data`` in
+        # modules that expect ``.x``.  We patch the collated ``self._data`` in
         # place so that ``self.get()`` will yield graphs with the expected
         # attribute available.
-        if isinstance(self.data, HeteroData):
-            for ntype in self.data.node_types:
-                store = self.data[ntype]
+        if isinstance(self._data, HeteroData):
+            for ntype in self._data.node_types:
+                store = self._data[ntype]
                 if not hasattr(store, "x") and hasattr(store, "feat"):
                     store.x = store.feat
         else:
-            if not hasattr(self.data, "x") and hasattr(self.data, "feat"):
-                self.data.x = self.data.feat
+            if not hasattr(self._data, "x") and hasattr(self._data, "feat"):
+                self._data.x = self._data.feat
 
     def get(self, idx):  # type: ignore[override]
         data = super().get(idx)


### PR DESCRIPTION
## Summary
- update `HeteroGraphDiskDataset` to use `self._data`
- adjust metadata patching comments and references

## Testing
- `pytest tests/test_selfgcl_dataset.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6861ba2ec574832ea906402932ed6fa3