### PR TITLE
Enable loading classifier head from checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ saved meta snapshot without needing `--force-reinit`.
 # RES-GCL 분류기 학습
 python -m cli.train_res_gcl \
        --encoder-checkpoint models/gnn/encoder.pt \
+       --head-checkpoint models/gnn/supcon_head.pt \
        --splits-dir data/splits \
        --epochs 50 --batch-size 256 \
        --lr 1e-3 \

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 import torch_geometric.transforms as T
 
 from src.common.utils import set_random_seed, ensure_dir, get_logger
+from src.models import get_model
 from graphs.dataset.graph_dataset import GraphDataset
 from src.models.gnn.encoder import RGCNEncoder
 from src.models.gnn.res_wrapper import RESGCLClassifier
@@ -32,6 +33,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--encoder-checkpoint", type=Path, required=True,
                    help="Pre-trained encoder .pt file")
+    p.add_argument("--head-checkpoint", type=Path,
+                   help="Load head weights from this .pt file")
+    p.add_argument("--head-class", type=str, default="sup_con",
+                   help="Head class name if --head-checkpoint is given")
     p.add_argument("--splits-dir", type=Path, default=Path("data/splits"),
                    help="Dataset root with train/val/test folders")
     p.add_argument("--split", type=str, default="latest",
@@ -122,7 +127,20 @@ def main(argv: list[str] | None = None) -> None:
     train_dl, val_dl = make_dataloaders(root, args.batch_size, args.num_workers)
 
     encoder = RGCNEncoder.load_from_checkpoint(args.encoder_checkpoint, map_location=device)
-    model = RESGCLClassifier(encoder=encoder, head="binary_mlp", drop_prob=args.drop_prob)
+    if args.head_checkpoint:
+        state = torch.load(args.head_checkpoint, map_location=device)
+        head_state = {
+            k[len("head."):]: v
+            for k, v in state.items()
+            if k.startswith("head.")
+        }
+        HeadCls = get_model(args.head_class)
+        head = HeadCls(in_dim=encoder.out_dim)
+        head.load_state_dict(head_state)
+    else:
+        head = "binary_mlp"
+    model = RESGCLClassifier(encoder=encoder, head=head,
+                             drop_prob=args.drop_prob)
     model.to(device)
 
     optimizer = optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)


### PR DESCRIPTION
## Summary
- allow train_res_gcl to load a head module via `--head-checkpoint`
- instantiate the specified head class from the registry
- document new argument in README example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c3946e10832ea04628992a41b2e8