### PR TITLE
Improve SupCon evaluation

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -247,15 +247,21 @@ def evaluate(model: nn.Module, loader: DataLoader, device: torch.device) -> dict
     if len(set(y.tolist())) < 2:
         return {"AUROC": float("nan"), "MacroF1": float("nan")}
 
-    X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=0.3, random_state=42)
+    X_tr, X_te, y_tr, y_te = train_test_split(
+        X, y, test_size=0.3, random_state=42, stratify=y
+    )
     clf = LogisticRegression(max_iter=1000)
     clf.fit(X_tr, y_tr)
     prob = clf.predict_proba(X_te)
     pred = clf.predict(X_te)
 
     try:
-        auroc = roc_auc_score(y_te, prob, multi_class="ovr" if prob.shape[1] > 2 else "raise")
-    except ValueError:
+        if prob.shape[1] == 2:
+            auroc = roc_auc_score(y_te, prob[:, 1])
+        else:
+            auroc = roc_auc_score(y_te, prob, multi_class="ovr")
+    except Exception as exc:  # sklearn may raise ValueError or other exceptions
+        LOGGER.warning("AUROC evaluation failed: %s", exc)
         auroc = float("nan")
     f1 = f1_score(y_te, pred, average="macro")
     return {"AUROC": float(auroc), "MacroF1": float(f1)}


### PR DESCRIPTION
## Summary
- ensure stratified data splits in finetune evaluation
- compute AUROC properly for binary and multi-class cases
- warn and return NaN if AUROC calculation fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c7b68da4832eaa82f2717678760c