### PR TITLE
Add balanced sampler option to finetune_supcon

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -36,7 +36,7 @@ from typing import Iterable, Tuple
 import torch
 import torch.multiprocessing as mp
 from torch import nn, optim
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, WeightedRandomSampler
 from torch_geometric.data import InMemoryDataset, Batch, HeteroData
 import torch_geometric.transforms as T
 import matplotlib.pyplot as plt
@@ -65,6 +65,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--split", type=str, default="latest",
                    help="Optional subfolder under --splits-dir")
     p.add_argument("--batch-size", type=int, default=256)
+    p.add_argument(
+        "--balanced",
+        action="store_true",
+        help="Use class-balanced sampling for the training loader",
+    )
 
     # Model / Training ------------------------------------------------------ #
     p.add_argument("--encoder-checkpoint", type=Path, required=True,
@@ -105,6 +110,7 @@ def make_dataloaders(
     batch_size: int,
     *,
     attr_names: dict[str, list[str]] | None = None,
+    balanced: bool = False,
 ) -> Tuple[DataLoader, DataLoader]:
     """Load GraphDataset splits and wrap in PyG ``DataLoader`` objects.
 
@@ -114,6 +120,9 @@ def make_dataloaders(
         Optional mapping of node types to metadata attribute names.  When
         provided, missing ``<name>_id`` tensors will be zero-padded by
         :func:`GraphDataset.collate_fn` so they match the encoder checkpoint.
+    balanced:
+        If ``True``, use :class:`WeightedRandomSampler` for class-balanced
+        batches in the training loader.
 
     ``pin_memory`` only makes sense when data is loaded on the CPU.  Graphs are
     now kept on the CPU and moved to the target device inside the training
@@ -144,10 +153,22 @@ def make_dataloaders(
     )
 
     num_workers = 0 if use_cuda else os.cpu_count()
+
+    sampler = None
+    shuffle = True
+    if balanced:
+        labels = [train_ds.labels[sha] for sha in train_ds.samples]
+        label_tensor = torch.tensor(labels, dtype=torch.long)
+        counts = torch.bincount(label_tensor)
+        weights = 1.0 / counts[label_tensor]
+        sampler = WeightedRandomSampler(weights.tolist(), len(weights), replacement=True)
+        shuffle = False
+
     train_dl = DataLoader(
         train_ds,
         batch_size=batch_size,
-        shuffle=True,
+        shuffle=shuffle,
+        sampler=sampler,
         num_workers=num_workers,
         collate_fn=lambda batch: GraphDataset.collate_fn(batch, attr_names=attr_names),
         pin_memory=not use_cuda,
@@ -307,6 +328,7 @@ def main() -> None:
         args.split,
         args.batch_size,
         attr_names=encoder.attr_names,
+        balanced=args.balanced,
     )
     g0, _, _ = train_dl.dataset[0]
     if isinstance(g0, HeteroData):


### PR DESCRIPTION
## Summary
- implement optional class-balanced sampling using `WeightedRandomSampler`
- expose `--balanced` CLI flag to enable sampler
- extend `make_dataloaders` to support sampler and hook up in `main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c8a88e78832e8626cff3d8093a50