### PR TITLE
Add monitoring option to finetune_supcon

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,13 @@ python -m cli.finetune_supcon \
        --meta-path models/gnn/encoder.meta.pkl \
        --split "2023Q4" \
        --epochs 100 --batch-size 128 \
-       --lr 1e-4 --patience 3 \
+       --lr 1e-4 --patience 3 --monitor both \
        --plot-path results/finetune_supcon/train.png
 `--force-reinit` should be used when the fine‑tuning dataset has different
 node feature dimensions or metadata from the encoder pre‑training data.
 `--meta-path` automatically handles mismatched input layers using the
 saved meta snapshot without needing `--force-reinit`.
+`--monitor` chooses the metric used for early stopping (`f1`, `auroc`, or `both`).
 
 # RES-GCL 분류기 학습
 python -m cli.train_res_gcl \

--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -104,6 +104,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--lr", type=float, default=1e-4)
     p.add_argument("--weight-decay", type=float, default=1e-5)
     p.add_argument("--patience", type=int, default=5, help="Early‑stop patience")
+    p.add_argument(
+        "--monitor",
+        choices=["f1", "auroc", "both"],
+        default="both",
+        help="Metric to monitor for early stopping",
+    )
 
     # Misc / Repro ---------------------------------------------------------- #
     p.add_argument("--device", type=str, default="cuda:0")
@@ -491,6 +497,12 @@ def main() -> None:
 
         improved_auc = val_metrics["AUROC"] > best_auroc + 1e-4
         improved_f1 = val_metrics["MacroF1"] > best_macro_f1 + 1e-4
+        if args.monitor == "auroc":
+            improved = improved_auc
+        elif args.monitor == "f1":
+            improved = improved_f1
+        else:
+            improved = improved_auc or improved_f1
         LOGGER.info(
             "Epoch %d | train_loss=%.4f | val_AUROC=%.4f%s | val_macroF1=%.4f%s",
             epoch,
@@ -504,7 +516,7 @@ def main() -> None:
             wandb.log({"epoch": epoch, "train_loss": train_loss, **val_metrics})
 
         # Early stop ------------------------------------------------------- #
-        if improved_auc or improved_f1:
+        if improved:
             if improved_auc:
                 best_auroc = val_metrics["AUROC"]
             if improved_f1:


### PR DESCRIPTION
## Summary
- add `--monitor` CLI arg for finetune_supcon to choose early stop metric
- improve training loop to handle monitoring selection
- document usage of `--monitor` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ccab9544832eb73cc34756e1de41