### PR TITLE
Add hint-features support to PPO trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ python -m cli.rulegen_cli feature-mine \
 python -m cli.rulegen_cli ppo-train \
           --train-features features.json \
           --val-features val_features.json \
+          --hint-features hints.json \
           --config configs/rulegen/ppo.yaml \
           --checkpoint models/rulebank/ppo_agent.pt
 # RL
 python -m cli.rulegen_cli ppo-train \
        --train-features features.json \
+       --hint-features hints.json \
        --epochs 50000 \
        --checkpoint models/rulebank/ppo_agent.pt \
        --plot-path runs/rulegen/ppo_train.png

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -205,11 +205,12 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # ------------------------------------------------------------------
     train_feats = _read_json_lines(Path(args.train_features))
     val_feats = _read_json_lines(Path(args.val_features)) if args.val_features else []
+    hint_feats = _read_json_lines(Path(args.hint_features)) if args.hint_features else None
 
     # ------------------------------------------------------------------
     # 3) Environment & agent instantiation
     # ------------------------------------------------------------------
-    env = rulegen.make_env(dataset_dir=dataset_dir, device=device)
+    env = rulegen.make_env(dataset_dir=dataset_dir, device=device, hint_features=hint_feats)
     agent = rulegen.load_agent(env=env)
     total_steps = int(cfg.get("scheduler", {}).get("total_updates", args.epochs))
     log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))
@@ -348,6 +349,7 @@ def _build_parser() -> argparse.ArgumentParser:
     pt = sub.add_parser("ppo-train", help="Train PPO rule agent")
     pt.add_argument("--train-features", required=True, help="JSONL mined features")
     pt.add_argument("--val-features", help="Validation feature file (optional)")
+    pt.add_argument("--hint-features", help="Optional JSON with rule hints")
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -43,3 +43,78 @@ def test_ppo_train_checks_dataset(tmp_path, caplog, monkeypatch):
 
     assert exc.value.code == 1
     assert "Dataset directory missing required files clean.pt and dummy.pt" in caplog.text
+
+
+def test_hint_features_passed(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(device=lambda *a, **k: None,
+                                       cuda=types.SimpleNamespace(is_available=lambda: False))
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            self.env = env
+
+        def train(self, **kw):
+            captured["train"] = kw
+            return []
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = lambda env=None: DummyAgent(env)
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner"); fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent"); ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    y_mod = types.ModuleType("rulegen.yara_builder"); y_mod.YaraBuilder = object
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder"); c_mod.CapaBuilder = object
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+    hint_fp = tmp_path / "hint.json"
+    hint_fp.write_text('[{"h": 1}]')
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args([
+        "ppo-train",
+        "--train-features",
+        str(train_fp),
+        "--dataset-dir",
+        str(ds),
+        "--hint-features",
+        str(hint_fp),
+        "--epochs",
+        "1",
+        "--cpu",
+    ])
+
+    args.func(args)
+    assert captured["hint_features"] == [{"h": 1}]


### PR DESCRIPTION
## Summary
- support `--hint-features` in `ppo-train` CLI
- pass parsed hints to `rulegen.make_env`
- document new option in README
- test CLI parsing and forwarding of hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e0d2be1c832eaa2ac372e7921e72