### PR TITLE
Support hint embeddings in PPO policy

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -85,12 +85,14 @@ class GRUPolicy(nn.Module):
         embed_dim: int = 128,
         hidden_size: int = 256,
         gru_layers: int = 1,
+        use_hint: bool = False,
     ):
         super().__init__()
         self.embed = nn.Embedding(vocab_size, embed_dim, padding_idx=0)
         self.ln = nn.LayerNorm(embed_dim)
+        self.use_hint = use_hint
         self.gru = nn.GRU(
-            input_size=embed_dim,
+            input_size=embed_dim * (2 if use_hint else 1),
             hidden_size=hidden_size,
             num_layers=gru_layers,
             batch_first=True,
@@ -105,7 +107,11 @@ class GRUPolicy(nn.Module):
                 nn.init.zeros_(m.bias)
         nn.init.orthogonal_(self.pi_head.weight, gain=0.01)
 
-    def forward(self, obs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self,
+        obs: torch.Tensor,
+        hint_ids: torch.Tensor | None = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Parameters
         ----------
@@ -121,10 +127,16 @@ class GRUPolicy(nn.Module):
             mask = mask.unsqueeze(0)
         x = self.embed(obs)  # (B,L,E)
         x = self.ln(x)
-        # mean‑pool valid tokens → (B,E)
         lengths = mask.sum(dim=1).clamp(min=1)
         pooled = (x * mask.unsqueeze(-1)).sum(dim=1) / lengths.unsqueeze(-1)
-        # GRU expects 3‑D (B,1,E)
+
+        if self.use_hint:
+            if hint_ids is None:
+                hint_vec = torch.zeros_like(pooled)
+            else:
+                hint_vec = self.embed(hint_ids).mean(dim=1)
+            pooled = torch.cat([pooled, hint_vec], dim=1)
+
         gru_out, _ = self.gru(pooled.unsqueeze(1))
         h = gru_out[:, -1]  # (B,H)
         logits = self.pi_head(h)
@@ -156,6 +168,7 @@ class PPORuleAgent:
         batch_size: int = 256,
         minibatch_size: int = 64,
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
+        use_hint: bool = False,
     ):
         self.env = env
         self.gamma = gamma
@@ -170,11 +183,13 @@ class PPORuleAgent:
         self.minibatch_size = minibatch_size
 
         self.device = torch.device(device)
+        self.use_hint = use_hint
 
         self.policy = GRUPolicy(
             vocab_size=env.action_space.n,
             embed_dim=128,
             hidden_size=256,
+            use_hint=use_hint,
         ).to(self.device)
         self.optimizer = torch.optim.Adam(self.policy.parameters(), lr=lr)
 
@@ -189,16 +204,27 @@ class PPORuleAgent:
         self.rew_buf: List[float] = []
         self.done_buf: List[bool] = []
         self.val_buf: List[float] = []
+        if self.use_hint:
+            self.hint_buf: List[np.ndarray] = []
 
     @torch.no_grad()
-    def select_action(self, obs: np.ndarray) -> Tuple[int, float, float]:
+    def select_action(
+        self,
+        obs: np.ndarray,
+        hint_obs: np.ndarray | None = None,
+    ) -> Tuple[int, float, float]:
         """
         Returns
         -------
         action, log_prob, value
         """
         obs_t = torch.from_numpy(obs).long().unsqueeze(0).to(self.device)
-        logits, value = self.policy(obs_t)
+        hint_t = (
+            torch.from_numpy(hint_obs).long().unsqueeze(0).to(self.device)
+            if hint_obs is not None
+            else None
+        )
+        logits, value = self.policy(obs_t, hint_t)
         dist = torch.distributions.Categorical(logits=logits)
         action = dist.sample()
         log_prob = dist.log_prob(action)
@@ -222,6 +248,7 @@ class PPORuleAgent:
         List of ``(step, avg_return)`` logged at each ``log_interval``.
         """
         obs, _ = self.env.reset()
+        hint = None
         global_step = 0
         episode_returns: List[float] = []
         interval_returns: List[float] = []
@@ -230,7 +257,7 @@ class PPORuleAgent:
 
         while global_step < total_timesteps:
             for _ in range(self.n_steps):
-                action, logp, value = self.select_action(obs)
+                action, logp, value = self.select_action(obs, hint)
                 next_obs, reward, done, trunc, info = self.env.step(action)
 
                 self.obs_buf.append(obs)
@@ -239,6 +266,8 @@ class PPORuleAgent:
                 self.val_buf.append(value)
                 self.rew_buf.append(reward)
                 self.done_buf.append(done or trunc)
+                if self.use_hint:
+                    self.hint_buf.append(hint if hint is not None else np.zeros_like(obs))
 
                 ep_return += reward
                 obs = next_obs
@@ -249,6 +278,7 @@ class PPORuleAgent:
                     interval_returns.append(ep_return)
                     ep_return = 0.0
                     obs, _ = self.env.reset()
+                    hint = None
 
             # ── PPO Update
             self._update()
@@ -277,6 +307,9 @@ class PPORuleAgent:
         vals = torch.tensor(self.val_buf, dtype=torch.float32, device=self.device)
         rews = torch.tensor(self.rew_buf, dtype=torch.float32, device=self.device)
         dones = torch.tensor(self.done_buf, dtype=torch.float32, device=self.device)
+        hints = None
+        if self.use_hint:
+            hints = torch.from_numpy(np.stack(self.hint_buf)).long().to(self.device)
 
         # 2) Compute GAE / returns
         advs = torch.zeros_like(rews, device=self.device)
@@ -307,8 +340,9 @@ class PPORuleAgent:
                 mb_old_logp = old_logp[mb_idx]
                 mb_returns = returns[mb_idx]
                 mb_advs = advs[mb_idx]
+                mb_hint = hints[mb_idx] if hints is not None else None
 
-                logits, values = self.policy(mb_obs)
+                logits, values = self.policy(mb_obs, mb_hint)
                 dist = torch.distributions.Categorical(logits=logits)
                 new_logp = dist.log_prob(mb_act)
                 entropy = dist.entropy().mean()

--- a/tests/test_gru_policy_hint.py
+++ b/tests/test_gru_policy_hint.py
@@ -1,0 +1,40 @@
+import sys
+import types
+import pytest
+torch = pytest.importorskip("torch")
+
+gym_stub = types.ModuleType("gymnasium")
+gym_stub.registry = {}
+gym_stub.register = lambda *a, **k: None
+sys.modules.setdefault("gymnasium", gym_stub)
+
+rl_env_stub = types.ModuleType("src.rulegen.rl_env")
+rl_env_stub.RuleGenEnv = object
+sys.modules.setdefault("src.rulegen.rl_env", rl_env_stub)
+
+from src.rulegen.rl_agent import GRUPolicy
+
+
+def test_policy_no_hint():
+    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=False)
+    obs = torch.tensor([[1, 2, 0], [3, 0, 0]], dtype=torch.long)
+    logits, value = policy(obs)
+    assert logits.shape == (2, 10)
+    assert value.shape == (2,)
+
+
+def test_policy_with_hint():
+    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True)
+    obs = torch.tensor([[1, 2, 0], [3, 4, 0]], dtype=torch.long)
+    hint = torch.tensor([[5, 6], [7, 8]], dtype=torch.long)
+    logits, value = policy(obs, hint)
+    assert logits.shape == (2, 10)
+    assert value.shape == (2,)
+
+
+def test_policy_hint_none():
+    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True)
+    obs = torch.tensor([[1, 0, 0]], dtype=torch.long)
+    logits, value = policy(obs)
+    assert logits.shape == (1, 10)
+    assert value.shape == (1,)


### PR DESCRIPTION
## Summary
- extend `GRUPolicy` to optionally accept hint token IDs
- wire hint vectors through `PPORuleAgent`
- test GRU policy hint handling

## Testing
- `pytest tests/test_gru_policy_hint.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6861e0b94e6c832e81097f03e799cf3e