### PR TITLE
Add hint features to RuleGenEnv reset

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -87,6 +87,7 @@ class RuleGenEnv(gym.Env):
         batch_size_eval: int = 128,
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         seed: int = 2024,
+        hint_features: Optional[List[str]] = None,
     ):
         """
         Parameters
@@ -98,6 +99,7 @@ class RuleGenEnv(gym.Env):
         batch_size_eval  : 보상 산출 시 배치 추론 크기
         device           : 모델/데이터 평가 디바이스
         seed             : reproducibility
+        hint_features    : 초기 관측에 포함할 토큰 문자열 시퀀스
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -122,6 +124,15 @@ class RuleGenEnv(gym.Env):
 
         self.vocab_size = len(self.token2id)
         self.max_len = max_len
+
+        # Hint features / tokens
+        self.hint_features = hint_features or []
+        self.hint_tokens: List[int] = []
+        for feat in self.hint_features:
+            for tok in self._rule_tokenize(feat):
+                tok_id = self.token2id.get(tok)
+                if tok_id is not None:
+                    self.hint_tokens.append(tok_id)
 
         # Gym spaces
         self.action_space = gym.spaces.Discrete(self.vocab_size)
@@ -155,7 +166,7 @@ class RuleGenEnv(gym.Env):
         self, *, seed: Optional[int] = None, options: Optional[dict] = None
     ) -> Tuple[np.ndarray, dict]:
         super().reset(seed=seed)
-        self._tokens: List[int] = []
+        self._tokens = list(self.hint_tokens)
         obs = self._pad_obs(self._tokens)
         info = {}
         return obs, info
@@ -236,7 +247,9 @@ class RuleGenEnv(gym.Env):
     # 관측 pad
     def _pad_obs(self, toks: Sequence[int]) -> np.ndarray:
         arr = np.full((self.max_len,), fill_value=self.token2id[self.PAD], dtype=np.int32)
-        arr[: len(toks)] = toks
+        n = min(len(toks), self.max_len)
+        if n:
+            arr[:n] = list(toks)[:n]
         return arr
 
     # token → string → rule

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -14,6 +14,7 @@ from torch_geometric.data import HeteroData
 
 from src.rulegen.rl_env import RuleGenEnv
 import src.models.gnn.res_wrapper as res_wrapper
+import models.gnn.res_wrapper as res_wrapper_pkg
 
 
 class DummyClf(torch.nn.Module):
@@ -24,6 +25,7 @@ dummy_clf = DummyClf()
 res_wrapper.RESGCLClassifier.load_pretrained = classmethod(
     lambda cls, path, map_location=None: dummy_clf
 )
+res_wrapper_pkg.RESGCLClassifier.load_pretrained = res_wrapper.RESGCLClassifier.load_pretrained
 
 
 def test_env_instantiates(tmp_path):
@@ -44,3 +46,25 @@ def test_env_instantiates(tmp_path):
     )
 
     assert env.action_space.n == len(env.token2id)
+
+
+def test_reset_with_hints(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        device="cpu",
+        hint_features=["A"],
+    )
+
+    obs, _ = env.reset()
+    assert obs[0] == env.token2id["A"]


### PR DESCRIPTION
## Summary
- support hint tokens in RuleGenEnv
- ensure observation padding works with pre-filled tokens
- test env reset with hints

## Testing
- `PYTHONPATH=src pytest tests/test_rl_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e0a5b868832e859a5f19ece73909