### PR TITLE
Add classifier_ckpt option for rulegen

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -209,7 +209,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # ------------------------------------------------------------------
     # 3) Environment & agent instantiation
     # ------------------------------------------------------------------
-    env = rulegen.make_env(dataset_dir=dataset_dir, device=device)
+    env = rulegen.make_env(
+        dataset_dir=dataset_dir,
+        device=device,
+        classifier_ckpt=args.classifier_ckpt,
+    )
     agent = rulegen.load_agent(env=env)
     total_steps = int(cfg.get("scheduler", {}).get("total_updates", args.epochs))
     log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))
@@ -350,6 +354,11 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--val-features", help="Validation feature file (optional)")
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")
+    pt.add_argument(
+        "--classifier-ckpt",
+        default="models/gnn/res_gcl.pt",
+        help="Path to pretrained graph classifier",
+    )
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
     pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import logging
 from importlib import metadata
+from pathlib import Path
 from typing import Any, Dict, Optional
 import importlib
 import sys
@@ -144,7 +145,12 @@ def __getattr__(name: str) -> Any:
 # ╔══════════════════════════════════════════════════════════════╗
 # ║                      Convenience helpers                     ║
 # ╚══════════════════════════════════════════════════════════════╝
-def make_env(rule_type: str = "yara", **kwargs: Any) -> RuleGenEnv:
+def make_env(
+    rule_type: str = "yara",
+    *,
+    classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
+    **kwargs: Any,
+) -> RuleGenEnv:
     """
     PPO 학습·추론용 환경 생성 헬퍼.
 
@@ -152,7 +158,7 @@ def make_env(rule_type: str = "yara", **kwargs: Any) -> RuleGenEnv:
     -------
     >>> env = rulegen.make_env(rule_type="capa", max_len=128)
     """
-    env = RuleGenEnv(rule_type=rule_type, **kwargs)
+    env = RuleGenEnv(rule_type=rule_type, classifier_ckpt=classifier_ckpt, **kwargs)
     _LOG.info("Created RuleGenEnv(rule_type=%s)", rule_type)
     return env
 

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -85,6 +85,7 @@ class RuleGenEnv(gym.Env):
         dataset_dir: Union[str, Path] = "data/splits",
         max_len: int = 180,
         batch_size_eval: int = 128,
+        classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         seed: int = 2024,
     ):
@@ -96,6 +97,7 @@ class RuleGenEnv(gym.Env):
         dataset_dir      : time‑split train/val/test parquet 경로
         max_len          : 룰 최대 토큰 길이 (spec ≤ 512 제한 대비 여유)
         batch_size_eval  : 보상 산출 시 배치 추론 크기
+        classifier_ckpt  : 학습된 그래프 분류기 체크포인트 경로
         device           : 모델/데이터 평가 디바이스
         seed             : reproducibility
         """
@@ -136,7 +138,7 @@ class RuleGenEnv(gym.Env):
         self._load_datasets(dataset_dir)
         self.device = torch.device(device)
         self.classifier: RESGCLClassifier = RESGCLClassifier.load_pretrained(
-            Path("models/gnn/res_gcl.pt"), map_location=self.device
+            Path(classifier_ckpt), map_location=self.device
         )
         self.batch_size_eval = batch_size_eval
 

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -31,6 +31,7 @@ def test_ppo_train_checks_dataset(tmp_path, caplog, monkeypatch):
         val_features=None,
         config=None,
         dataset_dir=tmp_path,
+        classifier_ckpt=str(tmp_path / "model.pt"),
         epochs=1,
         checkpoint=None,
         plot_path=None,

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -32,6 +32,9 @@ def test_env_instantiates(tmp_path):
     torch.save(clean, tmp_path / "clean.pt")
     torch.save(dummy, tmp_path / "dummy.pt")
 
+    ckpt = tmp_path / "clf.pt"
+    ckpt.write_bytes(b"dummy")
+
     vocab_file = tmp_path / "vocab.json"
     json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
 
@@ -40,6 +43,7 @@ def test_env_instantiates(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=8,
+        classifier_ckpt=ckpt,
         device="cpu",
     )
 


### PR DESCRIPTION
## Summary
- allow passing a classifier checkpoint to `RuleGenEnv`
- expose the option via `rulegen.make_env` and the CLI
- adapt tests to pass a temporary checkpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e0f635b4832e9996a8ba50374f56