### PR TITLE
Fix padding for metadata in RES-GCL training

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -59,7 +59,13 @@ def build_parser() -> argparse.ArgumentParser:
 # Data
 # --------------------------------------------------------------------------- #
 
-def make_dataloaders(root: Path, batch_size: int, num_workers: int) -> tuple[DataLoader, DataLoader]:
+def make_dataloaders(
+    root: Path,
+    batch_size: int,
+    num_workers: int,
+    *,
+    attr_names: dict[str, list[str]] | None = None,
+) -> tuple[DataLoader, DataLoader]:
     transform = T.Compose([
         T.NormalizeFeatures(),
     ])
@@ -72,7 +78,7 @@ def make_dataloaders(root: Path, batch_size: int, num_workers: int) -> tuple[Dat
         batch_size=batch_size,
         shuffle=True,
         num_workers=workers,
-        collate_fn=GraphDataset.collate_fn,
+        collate_fn=lambda batch: GraphDataset.collate_fn(batch, attr_names=attr_names),
         pin_memory=use_cuda,
     )
     val_dl = DataLoader(
@@ -80,7 +86,7 @@ def make_dataloaders(root: Path, batch_size: int, num_workers: int) -> tuple[Dat
         batch_size=batch_size,
         shuffle=False,
         num_workers=workers,
-        collate_fn=GraphDataset.collate_fn,
+        collate_fn=lambda batch: GraphDataset.collate_fn(batch, attr_names=attr_names),
         pin_memory=use_cuda,
     )
     return train_dl, val_dl
@@ -123,10 +129,19 @@ def main(argv: list[str] | None = None) -> None:
     set_random_seed(args.seed)
     device = torch.device(args.device)
 
-    root = args.splits_dir / args.split if (args.splits_dir / args.split).is_dir() else args.splits_dir
-    train_dl, val_dl = make_dataloaders(root, args.batch_size, args.num_workers)
+    root = (
+        args.splits_dir / args.split
+        if (args.splits_dir / args.split).is_dir()
+        else args.splits_dir
+    )
 
-    encoder = RGCNEncoder.load_from_checkpoint(args.encoder_checkpoint, map_location=device)
+    encoder = RGCNEncoder.load_from_checkpoint(
+        args.encoder_checkpoint, map_location=device
+    )
+
+    train_dl, val_dl = make_dataloaders(
+        root, args.batch_size, args.num_workers, attr_names=encoder.attr_names
+    )
     if args.head_checkpoint:
         state = torch.load(args.head_checkpoint, map_location=device)
         head_state = {


### PR DESCRIPTION
## Summary
- allow `make_dataloaders` to take `attr_names` for zero‐padding
- pass encoder `attr_names` when building loaders so missing metadata IDs are padded
- load encoder before loaders in `train_res_gcl` CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e5a72084832ea8d8b259b792db72