### PR TITLE
Expose env classifier checkpoint

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -210,7 +210,12 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # ------------------------------------------------------------------
     # 3) Environment & agent instantiation
     # ------------------------------------------------------------------
-    env = rulegen.make_env(dataset_dir=dataset_dir, device=device, hint_features=hint_feats)
+    env = rulegen.make_env(
+        dataset_dir=dataset_dir,
+        device=device,
+        hint_features=hint_feats,
+        classifier_ckpt=args.classifier_ckpt,
+    )
     agent = rulegen.load_agent(env=env)
     total_steps = int(cfg.get("scheduler", {}).get("total_updates", args.epochs))
     log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))
@@ -352,6 +357,11 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--hint-features", help="Optional JSON with rule hints")
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")
+    pt.add_argument(
+        "--classifier-ckpt",
+        default="models/gnn/res_gcl.pt",
+        help="Classifier checkpoint used for reward computation",
+    )
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
     pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 from importlib import metadata
 from typing import Any, Dict, Optional
+from pathlib import Path
 import importlib
 import sys
 
@@ -144,7 +145,12 @@ def __getattr__(name: str) -> Any:
 # ╔══════════════════════════════════════════════════════════════╗
 # ║                      Convenience helpers                     ║
 # ╚══════════════════════════════════════════════════════════════╝
-def make_env(rule_type: str = "yara", **kwargs: Any) -> RuleGenEnv:
+def make_env(
+    rule_type: str = "yara",
+    *,
+    classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
+    **kwargs: Any,
+) -> RuleGenEnv:
     """
     PPO 학습·추론용 환경 생성 헬퍼.
 
@@ -152,7 +158,11 @@ def make_env(rule_type: str = "yara", **kwargs: Any) -> RuleGenEnv:
     -------
     >>> env = rulegen.make_env(rule_type="capa", max_len=128)
     """
-    env = RuleGenEnv(rule_type=rule_type, **kwargs)
+    env = RuleGenEnv(
+        rule_type=rule_type,
+        classifier_ckpt=classifier_ckpt,
+        **kwargs,
+    )
     _LOG.info("Created RuleGenEnv(rule_type=%s)", rule_type)
     return env
 

--- a/src/rulegen/__init__.pyi
+++ b/src/rulegen/__init__.pyi
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional
+from pathlib import Path
 from .rl_env import RuleGenEnv
 from .rl_agent import PPORuleAgent
 from .feature_miner import FeatureMiner
@@ -9,7 +10,12 @@ __all__: list[str]
 __version__: str
 
 
-def make_env(rule_type: str = "yara", **kwargs: Any) -> RuleGenEnv: ...
+def make_env(
+    rule_type: str = "yara",
+    *,
+    classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
+    **kwargs: Any,
+) -> RuleGenEnv: ...
 
 def load_agent(
     ckpt_path: str | None = None,

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -85,6 +85,7 @@ class RuleGenEnv(gym.Env):
         dataset_dir: Union[str, Path] = "data/splits",
         max_len: int = 180,
         batch_size_eval: int = 128,
+        classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         seed: int = 2024,
         hint_features: Optional[List[str]] = None,
@@ -97,6 +98,7 @@ class RuleGenEnv(gym.Env):
         dataset_dir      : time‑split train/val/test parquet 경로
         max_len          : 룰 최대 토큰 길이 (spec ≤ 512 제한 대비 여유)
         batch_size_eval  : 보상 산출 시 배치 추론 크기
+        classifier_ckpt  : 보상 계산용 분류기 체크포인트 경로
         device           : 모델/데이터 평가 디바이스
         seed             : reproducibility
         hint_features    : 초기 관측에 포함할 토큰 문자열 시퀀스
@@ -147,7 +149,7 @@ class RuleGenEnv(gym.Env):
         self._load_datasets(dataset_dir)
         self.device = torch.device(device)
         self.classifier: RESGCLClassifier = RESGCLClassifier.load_pretrained(
-            Path("models/gnn/res_gcl.pt"), map_location=self.device
+            Path(classifier_ckpt), map_location=self.device
         )
         self.batch_size_eval = batch_size_eval
 

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -111,6 +111,8 @@ def test_hint_features_passed(tmp_path, monkeypatch):
         str(ds),
         "--hint-features",
         str(hint_fp),
+        "--classifier-ckpt",
+        str(ds / "clf.pt"),
         "--epochs",
         "1",
         "--cpu",
@@ -118,3 +120,4 @@ def test_hint_features_passed(tmp_path, monkeypatch):
 
     args.func(args)
     assert captured["hint_features"] == [{"h": 1}]
+    assert captured["classifier_ckpt"] == str(ds / "clf.pt")

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -42,6 +42,7 @@ def test_env_instantiates(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=8,
+        classifier_ckpt=tmp_path / "clf.pt",
         device="cpu",
     )
 
@@ -62,6 +63,7 @@ def test_reset_with_hints(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=4,
+        classifier_ckpt=tmp_path / "clf.pt",
         device="cpu",
         hint_features=["A"],
     )


### PR DESCRIPTION
## Summary
- parametrize RL environment with a `classifier_ckpt` option
- plumb checkpoint path through `rulegen.make_env` and CLI
- adapt CLI tests and env tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e51852f4832ea48b3f2b3c65d42f