### PR TITLE
Add meta-path auto reinit for RES-GCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ saved meta snapshot without needing `--force-reinit`.
 # RES-GCL 분류기 학습
 python -m cli.train_res_gcl \
        --encoder-checkpoint models/gnn/encoder.pt \
+       --meta-path models/gnn/encoder.meta.pkl \
        --head-checkpoint models/gnn/supcon_head.pt \
        --splits-dir data/splits \
        --epochs 50 --batch-size 256 \
        --lr 1e-3 \
        --output models/gnn/res_gcl.pt
+`--force-reinit` ignores the snapshot and always rebuilds input layers.
 
 # 분류기 head 학습
 

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -8,12 +8,18 @@ import argparse
 from pathlib import Path
 
 import torch
-from torch import optim
+from torch import nn, optim
 from torch.utils.data import DataLoader
 import torch.nn.functional as F
 import torch_geometric.transforms as T
+from torch_geometric.data import HeteroData
 
-from src.common.utils import set_random_seed, ensure_dir, get_logger
+from src.common.utils import (
+    set_random_seed,
+    ensure_dir,
+    get_logger,
+    filter_state_dict,
+)
 from src.models import get_model
 from graphs.dataset.graph_dataset import GraphDataset
 from src.models.gnn.encoder import RGCNEncoder
@@ -33,6 +39,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--encoder-checkpoint", type=Path, required=True,
                    help="Pre-trained encoder .pt file")
+    p.add_argument("--meta-path", type=Path,
+                   help="Path to encoder meta snapshot (.meta.pkl)")
+    p.add_argument("--force-reinit", action="store_true",
+                   help="Rebuild input layers when feature sizes changed")
     p.add_argument("--head-checkpoint", type=Path,
                    help="Load head weights from this .pt file")
     p.add_argument("--head-class", type=str, default="sup_con",
@@ -139,9 +149,94 @@ def main(argv: list[str] | None = None) -> None:
         args.encoder_checkpoint, map_location=device
     )
 
+    meta_snapshot = None
+    if args.meta_path and args.meta_path.is_file():
+        try:
+            meta_snapshot = torch.load(args.meta_path)
+        except Exception as exc:  # pragma: no cover - I/O handling
+            LOGGER.warning("Failed to load meta snapshot %s: %s", args.meta_path, exc)
+
     train_dl, val_dl = make_dataloaders(
         root, args.batch_size, args.num_workers, attr_names=encoder.attr_names
     )
+    g0, _, _ = train_dl.dataset[0]
+    if isinstance(g0, HeteroData):
+        metadata = g0.metadata()
+        attr_names = {
+            nt: [k[:-3] for k in g0[nt].keys() if k.endswith("_id")]
+            for nt in g0.node_types
+        }
+        in_dims = {
+            nt: getattr(g0[nt], "x").size(-1) + len(attr_names[nt]) * encoder.attr_dim
+            for nt in g0.node_types
+        }
+    else:
+        metadata = ([], [])
+        attr_names = {}
+        in_dims = {"": getattr(g0, "x").size(-1)}
+
+    dim_mismatch = False
+    for nt, proj in encoder.input_proj.items():
+        ds_dim = in_dims.get(nt)
+        if ds_dim != proj.in_features:
+            LOGGER.warning(
+                "Input feature dimension mismatch for node type '%s': dataset=%s checkpoint=%s",
+                nt,
+                ds_dim,
+                proj.in_features,
+            )
+            dim_mismatch = True
+    for nt in in_dims.keys() - encoder.input_proj.keys():
+        LOGGER.warning(
+            "Node type '%s' present in dataset but missing in checkpoint",
+            nt,
+        )
+        dim_mismatch = True
+
+    auto_reinit = dim_mismatch
+    if meta_snapshot is not None:
+        snap_ntypes = set(meta_snapshot.get("node_types", []))
+        snap_etypes = set(tuple(e) for e in meta_snapshot.get("edge_types", []))
+        curr_ntypes = set(metadata[0])
+        curr_etypes = set(tuple(e) for e in metadata[1])
+        if snap_ntypes != curr_ntypes or snap_etypes != curr_etypes:
+            auto_reinit = True
+        else:
+            for nt, dim in in_dims.items():
+                if meta_snapshot.get("in_dims", {}).get(nt) != dim:
+                    auto_reinit = True
+                    break
+
+    if args.force_reinit or auto_reinit:
+        if auto_reinit and not args.force_reinit:
+            LOGGER.info(
+                "Dataset metadata mismatch with %s - reinitializing input layers",
+                args.meta_path,
+            )
+        hidden_dim = (
+            encoder.convs[0].sublayer.out_channels
+            if hasattr(encoder.convs[0], "sublayer")
+            else encoder.convs[0].out_channels
+        )
+        dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
+        residual = hasattr(encoder.convs[0], "sublayer")
+        new_enc = RGCNEncoder(
+            metadata=metadata,
+            in_dims=in_dims,
+            attr_names=attr_names if isinstance(g0, HeteroData) else None,
+            vocab_size=encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0,
+            attr_dim=encoder.attr_dim,
+            hidden_dim=hidden_dim,
+            num_layers=len(encoder.convs),
+            out_dim=encoder.out_dim,
+            dropout=dropout,
+            residual=residual,
+            target_node=encoder.target_node,
+        )
+        state = encoder.state_dict()
+        filtered = filter_state_dict(new_enc, state, logger=LOGGER)
+        new_enc.load_state_dict(filtered, strict=False)
+        encoder = new_enc
     if args.head_checkpoint:
         state = torch.load(args.head_checkpoint, map_location=device)
         head_state = {

--- a/tests/test_train_res_gcl_auto_reinit.py
+++ b/tests/test_train_res_gcl_auto_reinit.py
@@ -1,0 +1,73 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path, feat_dim: int) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, feat_dim)
+    g["n"].num_nodes = 2
+    g[("n", "r0", "n")].edge_index = torch.tensor([[0, 1], [1, 0]])
+    torch.save(g, path)
+
+
+def test_auto_reinit_with_meta(tmp_path, caplog):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", 6)
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt_path = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt_path)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save({"node_types": ["n"], "edge_types": [("n", "r0", "n")], "in_dims": {"n": 4}}, meta_path)
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt_path),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    caplog.set_level("INFO")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert any("reinitializing" in rec.message or "dimension mismatch" in rec.message for rec in caplog.records)
+    assert any("Epoch 1" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `--meta-path` and `--force-reinit` options to `train_res_gcl.py`
- automatically rebuild encoder input layers when feature dims differ
- document new options in the README example
- test auto-reinit logic for `train_res_gcl`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e6543924832e882079d6188db15a