### PR TITLE
Add explainer hint options

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -205,7 +205,21 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # ------------------------------------------------------------------
     train_feats = _read_json_lines(Path(args.train_features))
     val_feats = _read_json_lines(Path(args.val_features)) if args.val_features else []
-    hint_feats = _read_json_lines(Path(args.hint_features)) if args.hint_features else None
+
+    hint_feats = None
+    if getattr(args, "hint_file", None):
+        hint_feats = _read_json_lines(Path(args.hint_file))
+    elif getattr(args, "use_explainer_hints", False):
+        feats: list[str] = []
+        for item in train_feats:
+            fs = item.get("features")
+            if isinstance(fs, list):
+                feats.extend(str(f) for f in fs)
+        # deduplicate while preserving order
+        seen = set()
+        hint_feats = [f for f in feats if not (f in seen or seen.add(f))]
+    elif getattr(args, "hint_features", None):
+        hint_feats = _read_json_lines(Path(args.hint_features))
 
     # ------------------------------------------------------------------
     # 3) Environment & agent instantiation
@@ -355,6 +369,15 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--train-features", required=True, help="JSONL mined features")
     pt.add_argument("--val-features", help="Validation feature file (optional)")
     pt.add_argument("--hint-features", help="Optional JSON with rule hints")
+    pt.add_argument(
+        "--use-explainer-hints",
+        action="store_true",
+        help="Use mined train features as rule hints",
+    )
+    pt.add_argument(
+        "--hint-file",
+        help="Path to JSONL/JSON array with hint features",
+    )
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")
     pt.add_argument(

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -45,7 +45,7 @@ def test_ppo_train_checks_dataset(tmp_path, caplog, monkeypatch):
     assert "Dataset directory missing required files clean.pt and dummy.pt" in caplog.text
 
 
-def test_hint_features_passed(tmp_path, monkeypatch):
+def test_hint_file_passed(tmp_path, monkeypatch):
     torch_stub = types.SimpleNamespace(device=lambda *a, **k: None,
                                        cuda=types.SimpleNamespace(is_available=lambda: False))
     monkeypatch.setitem(sys.modules, "torch", torch_stub)
@@ -100,7 +100,7 @@ def test_hint_features_passed(tmp_path, monkeypatch):
     train_fp = tmp_path / "train.json"
     train_fp.write_text("[]")
     hint_fp = tmp_path / "hint.json"
-    hint_fp.write_text('[{"h": 1}]')
+    hint_fp.write_text('["H1"]')
 
     parser = rulegen_cli._build_parser()
     args = parser.parse_args([
@@ -109,7 +109,7 @@ def test_hint_features_passed(tmp_path, monkeypatch):
         str(train_fp),
         "--dataset-dir",
         str(ds),
-        "--hint-features",
+        "--hint-file",
         str(hint_fp),
         "--classifier-ckpt",
         str(ds / "clf.pt"),
@@ -119,5 +119,77 @@ def test_hint_features_passed(tmp_path, monkeypatch):
     ])
 
     args.func(args)
-    assert captured["hint_features"] == [{"h": 1}]
+    assert captured["hint_features"] == ["H1"]
     assert captured["classifier_ckpt"] == str(ds / "clf.pt")
+
+
+def test_use_explainer_hints(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(device=lambda *a, **k: None,
+                                       cuda=types.SimpleNamespace(is_available=lambda: False))
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            self.env = env
+
+        def train(self, **kw):
+            captured["train"] = kw
+            return []
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = lambda env=None: DummyAgent(env)
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner"); fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent"); ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    y_mod = types.ModuleType("rulegen.yara_builder"); y_mod.YaraBuilder = object
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder"); c_mod.CapaBuilder = object
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text('[{"features": ["A"]}, {"features": ["B", "C"]}]')
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args([
+        "ppo-train",
+        "--train-features",
+        str(train_fp),
+        "--dataset-dir",
+        str(ds),
+        "--use-explainer-hints",
+        "--epochs",
+        "1",
+        "--cpu",
+    ])
+
+    args.func(args)
+    assert set(captured["hint_features"]) == {"A", "B", "C"}

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -24,3 +24,10 @@ def test_read_json_array(tmp_path):
     fp.write_text('[{"sha": "a"}, {"sha": "b"}]')
     items = _read_json_lines(fp)
     assert items == [{"sha": "a"}, {"sha": "b"}]
+
+
+def test_read_string_array(tmp_path):
+    fp = tmp_path / "hints.json"
+    fp.write_text('["A", "B"]')
+    items = _read_json_lines(fp)
+    assert items == ["A", "B"]


### PR DESCRIPTION
## Summary
- expose new `--use-explainer-hints` and `--hint-file` flags for PPO training
- map explainer features to `hint_features` when requested
- verify hint handling through parser tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e7387db8832ebcc3597d939bb4ec