### PR TITLE
Add tests for hint usage and GRUPolicy input

### DIFF
--- a/tests/test_gru_policy_hint.py
+++ b/tests/test_gru_policy_hint.py
@@ -38,3 +38,12 @@ def test_policy_hint_none():
     logits, value = policy(obs)
     assert logits.shape == (1, 10)
     assert value.shape == (1,)
+
+
+def test_policy_single_dim_inputs():
+    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True)
+    obs = torch.tensor([1, 2, 0], dtype=torch.long)
+    hint = torch.tensor([5, 6], dtype=torch.long)
+    logits, value = policy(obs, hint)
+    assert logits.shape == (1, 10)
+    assert value.shape == (1,)

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -193,3 +193,76 @@ def test_use_explainer_hints(tmp_path, monkeypatch):
 
     args.func(args)
     assert set(captured["hint_features"]) == {"A", "B", "C"}
+
+
+def test_use_explainer_hints_env_instance(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(device=lambda *a, **k: None,
+                                       cuda=types.SimpleNamespace(is_available=lambda: False))
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        env = types.SimpleNamespace(**kw)
+        captured["env"] = env
+        return env
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["agent_env"] = env
+
+        def train(self, **kw):
+            return []
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = lambda env=None: DummyAgent(env)
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner"); fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent"); ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    y_mod = types.ModuleType("rulegen.yara_builder"); y_mod.YaraBuilder = object
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder"); c_mod.CapaBuilder = object
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text('[{"features": ["A"]}, {"features": ["B", "C"]}]')
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args([
+        "ppo-train",
+        "--train-features",
+        str(train_fp),
+        "--dataset-dir",
+        str(ds),
+        "--use-explainer-hints",
+        "--epochs",
+        "1",
+        "--cpu",
+    ])
+
+    args.func(args)
+    assert set(captured["env"].hint_features) == {"A", "B", "C"}
+    assert captured["agent_env"] is captured["env"]

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -70,3 +70,27 @@ def test_reset_with_hints(tmp_path):
 
     obs, _ = env.reset()
     assert obs[0] == env.token2id["A"]
+
+
+def test_reset_multiple_hints(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "B": 1, "<PAD>": 2, "<END>": 3}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_ckpt=tmp_path / "clf.pt",
+        device="cpu",
+        hint_features=["A", "B"],
+    )
+
+    obs, _ = env.reset()
+    assert obs[0] == env.token2id["A"]
+    assert obs[1] == env.token2id["B"]


### PR DESCRIPTION
## Summary
- ensure `RuleGenEnv.reset` includes hint features
- verify `--use-explainer-hints` passes hints to the environment instance
- test `GRUPolicy` forward with single-dimension inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e9733fec832e9b4578be0093a8e8