### PR TITLE
Add hint_features support in RuleGenEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ python -m cli.rulegen_cli ppo-train \
        --epochs 50000 \
        --checkpoint models/rulebank/ppo_agent.pt \
        --plot-path runs/rulegen/ppo_train.png
+# 간단한 환경 생성 예시
+```python
+from rulegen import make_env
+
+# 힌트 문구를 주면 초기 관측에 해당 토큰들이 포함됩니다
+env = make_env(hint_features=["import pe", "strings $a"])
+obs, _ = env.reset()  # `reset()` 호출 시 다른 힌트를 전달할 수도 있습니다.
+```
 # XAI selector 학습
 # 분류기가 HeteroData 그래프를 입력으로 받아도 동일하게 사용할 수 있습니다.
 

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -88,7 +88,7 @@ class RuleGenEnv(gym.Env):
         classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         seed: int = 2024,
-        hint_features: Optional[List[str]] = None,
+        hint_features: List[str] | None = None,
     ):
         """
         Parameters
@@ -129,19 +129,19 @@ class RuleGenEnv(gym.Env):
 
         # Hint features / tokens
         self.hint_features = hint_features or []
-        self.hint_tokens: List[int] = []
+        self._default_hint_tokens: List[int] = []
         for feat in self.hint_features:
             for tok in self._rule_tokenize(feat):
                 tok_id = self.token2id.get(tok)
                 if tok_id is not None:
-                    self.hint_tokens.append(tok_id)
+                    self._default_hint_tokens.append(tok_id)
 
         # Gym spaces
         self.action_space = gym.spaces.Discrete(self.vocab_size)
         self.observation_space = gym.spaces.Box(
             low=0,
             high=self.vocab_size,
-            shape=(self.max_len,),
+            shape=(self.max_len + len(self._default_hint_tokens),),
             dtype=np.int32,
         )
 
@@ -165,10 +165,29 @@ class RuleGenEnv(gym.Env):
 
     # ─────────────────────────────────────────────────── gym API —
     def reset(
-        self, *, seed: Optional[int] = None, options: Optional[dict] = None
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Optional[dict] = None,
+        hint_features: List[str] | None = None,
     ) -> Tuple[np.ndarray, dict]:
         super().reset(seed=seed)
-        self._tokens = list(self.hint_tokens)
+        feats = hint_features if hint_features is not None else self.hint_features
+        hint_tokens: List[int] = []
+        for feat in feats:
+            for tok in self._rule_tokenize(feat):
+                tok_id = self.token2id.get(tok)
+                if tok_id is not None:
+                    hint_tokens.append(tok_id)
+
+        self._tokens = list(hint_tokens)
+        # adjust observation space for current hint length
+        self.observation_space = gym.spaces.Box(
+            low=0,
+            high=self.vocab_size,
+            shape=(self.max_len + len(self._tokens),),
+            dtype=np.int32,
+        )
         obs = self._pad_obs(self._tokens)
         info = {}
         return obs, info
@@ -186,9 +205,10 @@ class RuleGenEnv(gym.Env):
         self._tokens.append(action)
 
         # 2) 종료 조건
-        if action == self.token2id[self.END] or len(self._tokens) >= self.max_len:
+        max_tokens = self.observation_space.shape[0]
+        if action == self.token2id[self.END] or len(self._tokens) >= max_tokens:
             done = True
-            truncated = len(self._tokens) >= self.max_len
+            truncated = len(self._tokens) >= max_tokens
             rule_text = self._tokens_to_rule(self._tokens)
             reward, metrics = self._compute_reward(rule_text)
             info["metrics"] = metrics
@@ -248,8 +268,9 @@ class RuleGenEnv(gym.Env):
 
     # 관측 pad
     def _pad_obs(self, toks: Sequence[int]) -> np.ndarray:
-        arr = np.full((self.max_len,), fill_value=self.token2id[self.PAD], dtype=np.int32)
-        n = min(len(toks), self.max_len)
+        obs_len = self.observation_space.shape[0]
+        arr = np.full((obs_len,), fill_value=self.token2id[self.PAD], dtype=np.int32)
+        n = min(len(toks), obs_len)
         if n:
             arr[:n] = list(toks)[:n]
         return arr


### PR DESCRIPTION
## Summary
- extend `RuleGenEnv` to accept `hint_features` in `__init__` and `reset`
- seed observation space and tokens using the provided hints
- update step termination logic and padding util
- document hint feature usage with an example in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e9795bfc832ebfb00267b3ee1bf5