### PR TITLE
Support hint vectors in GRUPolicy

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -86,11 +86,18 @@ class GRUPolicy(nn.Module):
         hidden_size: int = 256,
         gru_layers: int = 1,
         use_hint: bool = False,
+        hint_size: int | None = None,
     ):
         super().__init__()
         self.embed = nn.Embedding(vocab_size, embed_dim, padding_idx=0)
         self.ln = nn.LayerNorm(embed_dim)
         self.use_hint = use_hint
+        self.hint_size = hint_size
+        self.hint_proj: nn.Module | None = None
+        if self.use_hint and self.hint_size is not None:
+            # If hint_size is provided, expect a vector input of that size
+            # Map it to the embedding dimension via a learnable projection
+            self.hint_proj = nn.Linear(hint_size, embed_dim)
         self.gru = nn.GRU(
             input_size=embed_dim * (2 if use_hint else 1),
             hidden_size=hidden_size,
@@ -110,7 +117,7 @@ class GRUPolicy(nn.Module):
     def forward(
         self,
         obs: torch.Tensor,
-        hint_ids: torch.Tensor | None = None,
+        hint: torch.Tensor | None = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Parameters
@@ -131,10 +138,27 @@ class GRUPolicy(nn.Module):
         pooled = (x * mask.unsqueeze(-1)).sum(dim=1) / lengths.unsqueeze(-1)
 
         if self.use_hint:
-            if hint_ids is None:
-                hint_vec = torch.zeros_like(pooled)
+            if self.hint_size is None:
+                # Backward compatible: hint is a sequence of token IDs
+                if hint is None:
+                    hint_vec = torch.zeros_like(pooled)
+                else:
+                    hint_vec = self.embed(hint.long()).mean(dim=1)
             else:
-                hint_vec = self.embed(hint_ids).mean(dim=1)
+                if hint is None:
+                    hint_input = torch.zeros(
+                        (pooled.size(0), self.hint_size),
+                        device=pooled.device,
+                        dtype=pooled.dtype,
+                    )
+                else:
+                    if hint.ndim == 1:
+                        hint_input = hint.unsqueeze(0)
+                    else:
+                        hint_input = hint
+                    hint_input = hint_input.to(pooled.dtype)
+                hint_vec = self.hint_proj(hint_input)
+
             pooled = torch.cat([pooled, hint_vec], dim=1)
 
         gru_out, _ = self.gru(pooled.unsqueeze(1))
@@ -253,11 +277,14 @@ class PPORuleAgent:
         action, log_prob, value
         """
         obs_t = torch.from_numpy(obs).long().unsqueeze(0).to(self.device)
-        hint_t = (
-            torch.from_numpy(hint_obs).long().unsqueeze(0).to(self.device)
-            if hint_obs is not None
-            else None
-        )
+        if hint_obs is not None:
+            hint_t = torch.from_numpy(hint_obs).unsqueeze(0).to(self.device)
+            if self.policy.hint_size is None:
+                hint_t = hint_t.long()
+            else:
+                hint_t = hint_t.to(torch.float32)
+        else:
+            hint_t = None
         logits, value = self.policy(obs_t, hint_t)
         dist = torch.distributions.Categorical(logits=logits)
         action = dist.sample()
@@ -301,7 +328,13 @@ class PPORuleAgent:
                 self.rew_buf.append(reward)
                 self.done_buf.append(done or trunc)
                 if self.use_hint:
-                    self.hint_buf.append(hint if hint is not None else np.zeros_like(obs))
+                    if hint is not None:
+                        self.hint_buf.append(hint)
+                    else:
+                        if self.policy.hint_size is not None:
+                            self.hint_buf.append(np.zeros(self.policy.hint_size, dtype=np.float32))
+                        else:
+                            self.hint_buf.append(np.zeros_like(obs))
 
                 ep_return += reward
                 obs = next_obs
@@ -343,7 +376,12 @@ class PPORuleAgent:
         dones = torch.tensor(self.done_buf, dtype=torch.float32, device=self.device)
         hints = None
         if self.use_hint:
-            hints = torch.from_numpy(np.stack(self.hint_buf)).long().to(self.device)
+            hint_arr = np.stack(self.hint_buf)
+            hints = torch.from_numpy(hint_arr).to(self.device)
+            if self.policy.hint_size is None:
+                hints = hints.long()
+            else:
+                hints = hints.to(torch.float32)
 
         # 2) Compute GAE / returns
         advs = torch.zeros_like(rews, device=self.device)

--- a/tests/test_gru_policy_hint.py
+++ b/tests/test_gru_policy_hint.py
@@ -47,3 +47,18 @@ def test_policy_single_dim_inputs():
     logits, value = policy(obs, hint)
     assert logits.shape == (1, 10)
     assert value.shape == (1,)
+
+
+def test_policy_vector_hint():
+    policy = GRUPolicy(
+        vocab_size=10,
+        embed_dim=8,
+        hidden_size=16,
+        use_hint=True,
+        hint_size=4,
+    )
+    obs = torch.tensor([[1, 2, 0]], dtype=torch.long)
+    hint = torch.randn(1, 4)
+    logits, value = policy(obs, hint)
+    assert logits.shape == (1, 10)
+    assert value.shape == (1,)


### PR DESCRIPTION
## Summary
- extend GRUPolicy to accept an optional `hint_size`
- embed hint vectors and concatenate with pooled token embeddings
- update PPORuleAgent to handle hint tensors
- add unit test covering vector hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861eb7c75c8832e9a2749dfc8b340cd