### PR TITLE
Improve dataset metadata handling

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -367,21 +367,12 @@ def main() -> None:
         attr_names=encoder.attr_names,
         balanced=args.balanced,
     )
-    g0, _, _ = train_dl.dataset[0]
-    if isinstance(g0, HeteroData):
-        metadata = g0.metadata()
-        attr_names = {
-            nt: [k[:-3] for k in g0[nt].keys() if k.endswith("_id")]
-            for nt in g0.node_types
-        }
-        in_dims = {
-            nt: getattr(g0[nt], "x").size(-1) + len(attr_names[nt]) * encoder.attr_dim
-            for nt in g0.node_types
-        }
-    else:
-        metadata = ([], [])
-        attr_names = {}
-        in_dims = {"": getattr(g0, "x").size(-1)}
+
+    from graphs.dataset import collect_dataset_metadata
+
+    metadata, in_dims, attr_names = collect_dataset_metadata(
+        train_dl.dataset, attr_dim=encoder.attr_dim
+    )
 
     # automatically rebuild input layers if feature dimensions mismatch
     dim_mismatch = False
@@ -432,7 +423,7 @@ def main() -> None:
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,
-            attr_names=attr_names if isinstance(g0, HeteroData) else None,
+            attr_names=attr_names if metadata[0] else None,
             vocab_size=encoder.meta_embed.num_embeddings
             if encoder.meta_embed is not None
             else 0,

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -159,21 +159,12 @@ def main(argv: list[str] | None = None) -> None:
     train_dl, val_dl = make_dataloaders(
         root, args.batch_size, args.num_workers, attr_names=encoder.attr_names
     )
-    g0, _, _ = train_dl.dataset[0]
-    if isinstance(g0, HeteroData):
-        metadata = g0.metadata()
-        attr_names = {
-            nt: [k[:-3] for k in g0[nt].keys() if k.endswith("_id")]
-            for nt in g0.node_types
-        }
-        in_dims = {
-            nt: getattr(g0[nt], "x").size(-1) + len(attr_names[nt]) * encoder.attr_dim
-            for nt in g0.node_types
-        }
-    else:
-        metadata = ([], [])
-        attr_names = {}
-        in_dims = {"": getattr(g0, "x").size(-1)}
+
+    from graphs.dataset import collect_dataset_metadata
+
+    metadata, in_dims, attr_names = collect_dataset_metadata(
+        train_dl.dataset, attr_dim=encoder.attr_dim
+    )
 
     dim_mismatch = False
     for nt, proj in encoder.input_proj.items():

--- a/src/graphs/dataset/__init__.py
+++ b/src/graphs/dataset/__init__.py
@@ -25,11 +25,12 @@ from __future__ import annotations
 
 from typing import List
 
-from .graph_dataset import GraphDataset
+from .graph_dataset import GraphDataset, collect_dataset_metadata
 from .split_generator import split_by_time, split_random
 
 __all__: List[str] = [
     "GraphDataset",
+    "collect_dataset_metadata",
     "split_by_time",
     "split_random",
 ]

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -427,3 +427,55 @@ class GraphDataset(Dataset):
             process_store(g)
 
         return g
+
+
+def collect_dataset_metadata(
+    ds: "GraphDataset", *, attr_dim: int = 0
+) -> tuple[tuple[list[str], list[tuple[str, str, str]]], dict[str, int], dict[str, list[str]]]:
+    """Iterate over ``ds`` and gather dataset‑wide metadata.
+
+    Parameters
+    ----------
+    ds:
+        :class:`GraphDataset` instance to inspect.
+    attr_dim:
+        Embedding dimensionality for metadata attributes.  ``in_dims`` will be
+        computed as ``feat_dim + len(attr_names) * attr_dim`` per node type.
+
+    Returns
+    -------
+    metadata, in_dims, attr_names
+        ``metadata`` is the ``(node_types, edge_types)`` tuple suitable for
+        :class:`RGCNEncoder`.  ``in_dims`` maps node types to the required input
+        feature dimensions and ``attr_names`` lists metadata attribute names for
+        each node type.
+    """
+
+    from torch_geometric.data import HeteroData
+
+    node_types: set[str] = set()
+    edge_types: set[tuple[str, str, str]] = set()
+    feat_dim: dict[str, int] = defaultdict(int)
+    attr_map: dict[str, set[str]] = defaultdict(set)
+
+    for i in range(len(ds)):
+        g, _, _ = ds[i]
+        if isinstance(g, HeteroData):
+            node_types.update(g.node_types)
+            edge_types.update(g.edge_types)
+            for nt in g.node_types:
+                store = g[nt]
+                feat_dim[nt] = max(feat_dim[nt], getattr(store, "x").size(-1))
+                names = [k[:-3] for k in store.keys() if k.endswith("_id")]
+                attr_map[nt].update(names)
+        else:  # Data
+            node_types.add("")
+            if hasattr(g, "x"):
+                feat_dim[""] = max(feat_dim.get("", 0), g.x.size(-1))
+            names = [k[:-3] for k in g.keys() if k.endswith("_id")]
+            attr_map[""].update(names)
+
+    attr_names = {nt: sorted(names) for nt, names in attr_map.items()}
+    in_dims = {nt: feat_dim[nt] + len(attr_names.get(nt, [])) * attr_dim for nt in feat_dim}
+    metadata = (sorted(node_types), sorted(edge_types))
+    return metadata, in_dims, attr_names

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path, rels: list[str]) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    for r in rels:
+        g[("n", r, "n")].edge_index = torch.tensor([[0, 1], [1, 0]])
+    torch.save(g, path)
+
+
+def test_extra_edge_types(tmp_path, caplog):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", ["r0"])
+        _make_graph(gdir / "b.pt", ["r0", "r1"])
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\nb,1\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt_path = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt_path)
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    caplog.set_level("INFO")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert any("Epoch 1" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- provide `collect_dataset_metadata` helper for GraphDataset
- use this helper in `train_res_gcl` and `finetune_supcon` to determine input dims
- export new function from dataset package
- test that datasets with extra edge types no longer fail during training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f8a036f0832ea66e87c30139f747