### PR TITLE
Check dataset node order before finetune

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -374,6 +374,20 @@ def main() -> None:
         train_dl.dataset, attr_dim=encoder.attr_dim
     )
 
+    node_order_mismatch = metadata[0] != encoder.node_types
+    if node_order_mismatch:
+        LOGGER.warning(
+            "Dataset node type order %s differs from checkpoint %s",
+            metadata[0],
+            encoder.node_types,
+        )
+        if not args.force_reinit:
+            LOGGER.error(
+                "Node type order mismatch detected. "
+                "Use --force-reinit to rebuild encoder input layers."
+            )
+            return
+
     # automatically rebuild input layers if feature dimensions mismatch
     dim_mismatch = False
     for nt, proj in encoder.input_proj.items():
@@ -393,7 +407,7 @@ def main() -> None:
         )
         dim_mismatch = True
 
-    auto_reinit = dim_mismatch
+    auto_reinit = node_order_mismatch or dim_mismatch
     if meta_snapshot is not None:
         snap_ntypes = set(meta_snapshot.get("node_types", []))
         snap_etypes = set(tuple(e) for e in meta_snapshot.get("edge_types", []))


### PR DESCRIPTION
## Summary
- warn if dataset node order differs from checkpoint and halt unless `--force-reinit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68624f5a62c4832ebb238c20c85f956d