### PR TITLE
Add optional token embedding loading to GraphDataset

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -51,6 +51,8 @@ from ..builders.hetero_builder import (
     OverLengthPolicy,
 )
 
+from ..features.cache import load_tensor
+
 from ..loaders.factory import get_loader   # fallback json 로드용
 from ..utils import get_logger
 
@@ -80,6 +82,8 @@ class GraphDataset(Dataset):
         ``True`` 로 설정하면 레이블이 없는 샘플은 로드 후 즉시 제거한다.
     over_length_policy : OverLengthPolicy, default=OverLengthPolicy.TRIM
         Handling strategy when node features exceed ``num_nodes``.
+    load_embeds : bool, default True
+        ``root/embeds/<sha>.ftr`` 임베딩 파일을 자동 로드할지 여부.
     """
 
     def __init__(
@@ -93,6 +97,7 @@ class GraphDataset(Dataset):
         transform: Optional[Callable[[GraphT], GraphT]] = None,
         require_labels: bool = False,
         over_length_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
+        load_embeds: bool = True,
     ) -> None:
         self.root = Path(root)
         self.split = split
@@ -102,6 +107,8 @@ class GraphDataset(Dataset):
         self.label_col = label_col
         self.require_labels = require_labels
         self.over_length_policy = over_length_policy
+        self.load_embeds = load_embeds
+        self.embed_dir = self.root / "embeds"
 
         # ── 파일 목록 & 레이블 로드 ───────────────────────────────
         self.samples: List[str] = sorted(p.stem for p in self.graph_dir.iterdir() if p.is_file())
@@ -292,13 +299,15 @@ class GraphDataset(Dataset):
         # [A] .pt
         pt_file = self.graph_dir / f"{sha}.pt"
         if pt_file.is_file():
-            return torch.load(pt_file, weights_only=False)
+            g = torch.load(pt_file, weights_only=False)
+            return self._attach_embeds(sha, g)
 
         # [B] .pyg.pkl
         pkl_file = self.graph_dir / f"{sha}.pyg.pkl"
         if pkl_file.is_file():
             with pkl_file.open("rb") as f:
-                return pickle.load(f)
+                g = pickle.load(f)
+            return self._attach_embeds(sha, g)
 
         # [C] .json / .json.gz (+ view suffix)
         for view in ("ast", "cfg", "fcg", "sys"):
@@ -306,9 +315,32 @@ class GraphDataset(Dataset):
                 fp = self.graph_dir / f"{sha}.{view}{ext}"
                 if fp.is_file():
                     loader = get_loader(view)
-                    return loader.load(fp)
+                    g = loader.load(fp)
+                    return self._attach_embeds(sha, g)
 
         raise FileNotFoundError(f"graph file for '{sha}' not found")
+
+    def _attach_embeds(self, sha: str, g: GraphT) -> GraphT:
+        if not self.load_embeds:
+            return g
+        embed_file = self.embed_dir / f"{sha}.ftr"
+        if not embed_file.is_file():
+            return g
+        if not isinstance(g, HeteroData) or "token" not in g.node_types:
+            return g
+        try:
+            feat = load_tensor(sha, self.embed_dir)
+        except Exception as exc:  # pragma: no cover - unexpected I/O errors
+            warnings.warn(f"failed to load embed for {sha}: {exc}")
+            return g
+        store = g["token"]
+        if hasattr(store, "x"):
+            store.x = feat
+        elif hasattr(store, "feat"):
+            store.feat = feat
+        else:
+            store.x = feat
+        return g
 
     # --------------------------------------------------------------
     @staticmethod

--- a/tests/test_graph_dataset_embeds.py
+++ b/tests/test_graph_dataset_embeds.py
@@ -1,0 +1,35 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.graphs.dataset.graph_dataset import GraphDataset
+from src.graphs.features.cache import save_tensor
+
+
+def _setup(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+    g = HeteroData()
+    g["token"].num_nodes = 2
+    torch.save(g, graph_dir / "sample.pt")
+    feat = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    save_tensor("sample", feat, tmp_path / "embeds")
+    return feat
+
+
+def test_dataset_loads_embeds(tmp_path):
+    feat = _setup(tmp_path)
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    g, _, _ = ds[0]
+    assert torch.allclose(g["token"].x, feat)
+
+
+def test_dataset_disable_embeds(tmp_path):
+    _setup(tmp_path)
+    ds = GraphDataset(tmp_path, split="train", label_file=None, load_embeds=False)
+    g, _, _ = ds[0]
+    assert not hasattr(g["token"], "x")


### PR DESCRIPTION
## Summary
- optionally load precomputed token embeddings in `GraphDataset`
- add load_embeds parameter documented in the dataset
- implement embedding attachment logic
- test dataset behaviour with and without embeddings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68624f584118832eb33660b007b24f84