### PR TITLE
Preserve order in metadata collection

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -453,23 +453,28 @@ def collect_dataset_metadata(
 
     from torch_geometric.data import HeteroData
 
-    node_types: set[str] = set()
-    edge_types: set[tuple[str, str, str]] = set()
+    node_types: list[str] = []
+    edge_types: list[tuple[str, str, str]] = []
     feat_dim: dict[str, int] = defaultdict(int)
     attr_map: dict[str, set[str]] = defaultdict(set)
 
     for i in range(len(ds)):
         g, _, _ = ds[i]
         if isinstance(g, HeteroData):
-            node_types.update(g.node_types)
-            edge_types.update(g.edge_types)
+            for nt in g.node_types:
+                if nt not in node_types:
+                    node_types.append(nt)
+            for et in g.edge_types:
+                if et not in edge_types:
+                    edge_types.append(et)
             for nt in g.node_types:
                 store = g[nt]
                 feat_dim[nt] = max(feat_dim[nt], getattr(store, "x").size(-1))
                 names = [k[:-3] for k in store.keys() if k.endswith("_id")]
                 attr_map[nt].update(names)
         else:  # Data
-            node_types.add("")
+            if "" not in node_types:
+                node_types.append("")
             if hasattr(g, "x"):
                 feat_dim[""] = max(feat_dim.get("", 0), g.x.size(-1))
             names = [k[:-3] for k in g.keys() if k.endswith("_id")]
@@ -477,5 +482,5 @@ def collect_dataset_metadata(
 
     attr_names = {nt: sorted(names) for nt, names in attr_map.items()}
     in_dims = {nt: feat_dim[nt] + len(attr_names.get(nt, [])) * attr_dim for nt in feat_dim}
-    metadata = (sorted(node_types), sorted(edge_types))
+    metadata = (node_types, edge_types)
     return metadata, in_dims, attr_names

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -11,6 +11,7 @@ import torch
 from torch_geometric.data import HeteroData
 
 from src.models.gnn.encoder import RGCNEncoder
+from src.graphs.dataset.graph_dataset import GraphDataset, collect_dataset_metadata
 
 
 def _make_graph(path: Path, rels: list[str]) -> None:
@@ -67,3 +68,39 @@ def test_extra_edge_types(tmp_path, caplog):
         sys.argv = orig_argv
 
     assert any("Epoch 1" in rec.message for rec in caplog.records)
+
+
+def test_collect_metadata_preserves_order(tmp_path):
+    gdir = tmp_path / "train" / "graphs"
+    gdir.mkdir(parents=True)
+
+    g1 = HeteroData()
+    g1["n1"].x = torch.randn(1, 1)
+    g1["n1"].num_nodes = 1
+    g1["n2"].x = torch.randn(1, 1)
+    g1["n2"].num_nodes = 1
+    g1[("n1", "r1", "n2")].edge_index = torch.tensor([[0], [0]])
+    torch.save(g1, gdir / "a.pt")
+
+    g2 = HeteroData()
+    g2["n1"].x = torch.randn(1, 1)
+    g2["n1"].num_nodes = 1
+    g2["n3"].x = torch.randn(1, 1)
+    g2["n3"].num_nodes = 1
+    g2[("n1", "r2", "n3")].edge_index = torch.tensor([[0], [0]])
+    g2[("n3", "r3", "n1")].edge_index = torch.tensor([[0], [0]])
+    torch.save(g2, gdir / "b.pt")
+
+    (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\nb,1\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    metadata, _, _ = collect_dataset_metadata(ds)
+    node_types, edge_types = metadata
+
+    assert node_types == ["n1", "n2", "n3"]
+    assert edge_types == [
+        ("n1", "r1", "n2"),
+        ("n1", "r2", "n3"),
+        ("n3", "r3", "n1"),
+    ]
+


### PR DESCRIPTION
## Summary
- collect dataset metadata while preserving order of encountered node/edge types
- test that dataset metadata respects order of first graph

## Testing
- `pytest tests/test_collect_dataset_metadata.py::test_collect_metadata_preserves_order -q`

------
https://chatgpt.com/codex/tasks/task_e_68624f54541c832eb56245aa0f74525e