### PR TITLE
Fix g0 definition for RGCN reinit

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -166,6 +166,8 @@ def main(argv: list[str] | None = None) -> None:
         train_dl.dataset, attr_dim=encoder.attr_dim
     )
 
+    g0, _, _ = train_dl.dataset[0]
+
     dim_mismatch = False
     for nt, proj in encoder.input_proj.items():
         ds_dim = in_dims.get(nt)


### PR DESCRIPTION
## Summary
- load the first training sample after collecting dataset metadata
- safely pass `attr_names` on encoder re-initialization using the sample type

## Testing
- `pytest tests/test_train_res_gcl_auto_reinit.py -k test_auto_reinit_with_meta -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686266d811b8832e81feee7d01c9ad4f