### PR TITLE
Handle node order mismatch in RES-GCL training

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -12,8 +12,6 @@ from torch import nn, optim
 from torch.utils.data import DataLoader
 import torch.nn.functional as F
 import torch_geometric.transforms as T
-from torch_geometric.data import HeteroData
-
 from src.common.utils import (
     set_random_seed,
     ensure_dir,
@@ -166,6 +164,14 @@ def main(argv: list[str] | None = None) -> None:
         train_dl.dataset, attr_dim=encoder.attr_dim
     )
 
+    node_order_mismatch = metadata[0] != encoder.node_types
+    if node_order_mismatch:
+        LOGGER.warning(
+            "Dataset node type order %s differs from checkpoint %s",
+            metadata[0],
+            encoder.node_types,
+        )
+
     dim_mismatch = False
     for nt, proj in encoder.input_proj.items():
         ds_dim = in_dims.get(nt)
@@ -184,7 +190,7 @@ def main(argv: list[str] | None = None) -> None:
         )
         dim_mismatch = True
 
-    auto_reinit = dim_mismatch
+    auto_reinit = node_order_mismatch or dim_mismatch
     if meta_snapshot is not None:
         snap_ntypes = set(meta_snapshot.get("node_types", []))
         snap_etypes = set(tuple(e) for e in meta_snapshot.get("edge_types", []))
@@ -214,7 +220,7 @@ def main(argv: list[str] | None = None) -> None:
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,
-            attr_names=attr_names if isinstance(g0, HeteroData) else None,
+            attr_names=attr_names if metadata[0] else None,
             vocab_size=encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0,
             attr_dim=encoder.attr_dim,
             hidden_dim=hidden_dim,

--- a/tests/test_train_res_gcl_node_order.py
+++ b/tests/test_train_res_gcl_node_order.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path, order: list[str]) -> None:
+    g = HeteroData()
+    for nt in order:
+        g[nt].x = torch.randn(2, 4)
+        g[nt].num_nodes = 2
+    g[(order[0], "r0", order[1])].edge_index = torch.tensor([[0, 1], [1, 0]])
+    torch.save(g, path)
+
+
+def test_auto_reinit_node_order(tmp_path, caplog):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", ["n2", "n1"])
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n1", "n2"], [("n1", "r0", "n2")]),
+        in_dims={"n1": 4, "n2": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt_path = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt_path)
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    caplog.set_level("INFO")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert any("node type order" in rec.message for rec in caplog.records)
+    assert any("reinitializing" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- warn and auto reinit when dataset node type order differs from checkpoint
- skip attr name injection when dataset lacks node types
- add regression test covering mismatched node order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'graphs')*

------
https://chatgpt.com/codex/tasks/task_e_686266d91ed0832eade6204200139c8c