### PR TITLE
Add embed_dir option to GraphDataset and CLIs

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -79,6 +79,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Use class-balanced sampling for the training loader",
     )
+    p.add_argument(
+        "--embed-dir",
+        type=Path,
+        help="Directory containing token embeddings",
+    )
 
     # Model / Training ------------------------------------------------------ #
     p.add_argument(
@@ -139,6 +144,7 @@ def make_dataloaders(
     *,
     attr_names: dict[str, list[str]] | None = None,
     balanced: bool = False,
+    embed_dir: Path | None = None,
 ) -> Tuple[DataLoader, DataLoader]:
     """Load GraphDataset splits and wrap in PyG ``DataLoader`` objects.
 
@@ -151,6 +157,10 @@ def make_dataloaders(
     balanced:
         If ``True``, use :class:`WeightedRandomSampler` for class-balanced
         batches in the training loader.
+    embed_dir:
+        Optional directory containing token embeddings.  ``None`` uses
+        ``root/embeds`` where ``root`` is derived from ``splits_dir`` and
+        ``split``.
 
     ``pin_memory`` only makes sense when data is loaded on the CPU.  Graphs are
     now kept on the CPU and moved to the target device inside the training
@@ -174,12 +184,14 @@ def make_dataloaders(
         split="train",
         transform=transform,
         require_labels=True,
+        embed_dir=embed_dir,
     )
     val_ds = GraphDataset(
         root=root,
         split="val",
         transform=transform,
         require_labels=True,
+        embed_dir=embed_dir,
     )
 
     num_workers = 0 if use_cuda else os.cpu_count()
@@ -366,6 +378,7 @@ def main() -> None:
         args.batch_size,
         attr_names=encoder.attr_names,
         balanced=args.balanced,
+        embed_dir=args.embed_dir,
     )
 
     from graphs.dataset import collect_dataset_metadata

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -57,6 +57,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--weight-decay", type=float, default=1e-4)
     p.add_argument("--drop-prob", type=float, default=0.2,
                    help="Edge-drop probability during training")
+    p.add_argument("--embed-dir", type=Path,
+                   help="Directory containing token embeddings")
     p.add_argument("--device", type=str, default="cuda")
     p.add_argument("--num-workers", type=int, default=0)
     p.add_argument("--seed", type=int, default=42)
@@ -75,12 +77,25 @@ def make_dataloaders(
     num_workers: int,
     *,
     attr_names: dict[str, list[str]] | None = None,
+    embed_dir: Path | None = None,
 ) -> tuple[DataLoader, DataLoader]:
     transform = T.Compose([
         T.NormalizeFeatures(),
     ])
-    train_ds = GraphDataset(root=root, split="train", transform=transform, require_labels=True)
-    val_ds = GraphDataset(root=root, split="val", transform=transform, require_labels=True)
+    train_ds = GraphDataset(
+        root=root,
+        split="train",
+        transform=transform,
+        require_labels=True,
+        embed_dir=embed_dir,
+    )
+    val_ds = GraphDataset(
+        root=root,
+        split="val",
+        transform=transform,
+        require_labels=True,
+        embed_dir=embed_dir,
+    )
     use_cuda = torch.cuda.is_available()
     workers = 0 if use_cuda else num_workers
     train_dl = DataLoader(
@@ -157,7 +172,11 @@ def main(argv: list[str] | None = None) -> None:
             LOGGER.warning("Failed to load meta snapshot %s: %s", args.meta_path, exc)
 
     train_dl, val_dl = make_dataloaders(
-        root, args.batch_size, args.num_workers, attr_names=encoder.attr_names
+        root,
+        args.batch_size,
+        args.num_workers,
+        attr_names=encoder.attr_names,
+        embed_dir=args.embed_dir,
     )
 
     from graphs.dataset import collect_dataset_metadata

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -84,6 +84,9 @@ class GraphDataset(Dataset):
         Handling strategy when node features exceed ``num_nodes``.
     load_embeds : bool, default True
         ``root/embeds/<sha>.ftr`` 임베딩 파일을 자동 로드할지 여부.
+    embed_dir : Path | None, optional
+        ``load_embeds`` 가 ``True`` 일 때 임베딩을 찾을 디렉터리.
+        ``None`` 이면 ``root/embeds``를 사용한다.
     """
 
     def __init__(
@@ -98,6 +101,7 @@ class GraphDataset(Dataset):
         require_labels: bool = False,
         over_length_policy: OverLengthPolicy = OverLengthPolicy.TRIM,
         load_embeds: bool = True,
+        embed_dir: Path | None = None,
     ) -> None:
         self.root = Path(root)
         self.split = split
@@ -108,7 +112,7 @@ class GraphDataset(Dataset):
         self.require_labels = require_labels
         self.over_length_policy = over_length_policy
         self.load_embeds = load_embeds
-        self.embed_dir = self.root / "embeds"
+        self.embed_dir = Path(embed_dir) if embed_dir is not None else self.root / "embeds"
 
         # ── 파일 목록 & 레이블 로드 ───────────────────────────────
         self.samples: List[str] = sorted(p.stem for p in self.graph_dir.iterdir() if p.is_file())


### PR DESCRIPTION
## Summary
- add `embed_dir` parameter to `GraphDataset` for custom embedding folder
- extend training CLIs to accept `--embed-dir` argument and forward to datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862709fe59c832eb6e584777a5bceaa