### PR TITLE
Fix relation counting in dataset metadata

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -514,5 +514,30 @@ def collect_dataset_metadata(
 
     attr_names = {nt: sorted(names) for nt, names in attr_map.items()}
     in_dims = {nt: feat_dim[nt] + len(attr_names.get(nt, [])) * attr_dim for nt in feat_dim}
-    metadata = (node_types, edge_types)
+
+    # ------------------------------------------------------------------
+    # Determine number of relations from edge_type attributes
+    # ------------------------------------------------------------------
+    if len(ds) > 0 and edge_types:
+        num_relations = max(
+            int(ds[i][0][et].edge_type.max())
+            for i in range(len(ds))
+            for et in ds[i][0].edge_types
+        ) + 1
+    else:
+        num_relations = 0
+
+    from ..normalizers.schema import EDGE_TYPES
+
+    # align returned edge_types with global EDGE_TYPES up to num_relations
+    edge_types_full = list(EDGE_TYPES)
+    if num_relations > len(edge_types_full):  # pragma: no cover - unexpected
+        edge_types_full.extend(edge_types[len(edge_types_full):num_relations])
+        if len(edge_types_full) < num_relations:
+            # pad with dummy relations when names are unavailable
+            edge_types_full.extend(
+                [("", f"r{i}", "") for i in range(len(edge_types_full), num_relations)]
+            )
+
+    metadata = (node_types, edge_types_full[:num_relations])
     return metadata, in_dims, attr_names


### PR DESCRIPTION
## Summary
- infer relation count from `edge_type` across all graphs
- keep edge type metadata aligned with `EDGE_TYPES`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gensim')*

------
https://chatgpt.com/codex/tasks/task_e_68627085c3c8832ea7f90a34a7fadf8f