### PR TITLE
Add edge type mapping

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -383,9 +383,12 @@ def main() -> None:
 
     from graphs.dataset import collect_dataset_metadata
 
-    metadata, in_dims, attr_names = collect_dataset_metadata(
+    metadata, in_dims, attr_names, edge_map = collect_dataset_metadata(
         train_dl.dataset, attr_dim=encoder.attr_dim
     )
+
+    train_dl.dataset.set_edge_type_map(edge_map)
+    val_dl.dataset.set_edge_type_map(edge_map)
 
     node_order_mismatch = metadata[0] != encoder.node_types
     if node_order_mismatch:

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -181,9 +181,12 @@ def main(argv: list[str] | None = None) -> None:
 
     from graphs.dataset import collect_dataset_metadata
 
-    metadata, in_dims, attr_names = collect_dataset_metadata(
+    metadata, in_dims, attr_names, edge_map = collect_dataset_metadata(
         train_dl.dataset, attr_dim=encoder.attr_dim
     )
+
+    train_dl.dataset.set_edge_type_map(edge_map)
+    val_dl.dataset.set_edge_type_map(edge_map)
 
     g0, _, _ = train_dl.dataset[0]
 

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -114,6 +114,8 @@ class GraphDataset(Dataset):
         self.load_embeds = load_embeds
         self.embed_dir = Path(embed_dir) if embed_dir is not None else self.root / "embeds"
 
+        self.edge_type_map: Dict[int, int] | None = None
+
         # ── 파일 목록 & 레이블 로드 ───────────────────────────────
         self.samples: List[str] = sorted(p.stem for p in self.graph_dir.iterdir() if p.is_file())
         self.labels: Dict[str, int] = {}
@@ -145,9 +147,48 @@ class GraphDataset(Dataset):
     def __len__(self) -> int:
         return len(self.samples)
 
+    def set_edge_type_map(self, mapping: Dict[int, int]) -> None:
+        """Set mapping from original edge_type IDs to new IDs.
+
+        Parameters
+        ----------
+        mapping:
+            Dictionary mapping original ``edge_type`` integers to new values.
+
+        Any ``edge_type`` values not present in ``mapping`` will remain
+        unchanged during :meth:`__getitem__`.  A warning is logged if such
+        values are detected across the dataset when this method is called.
+        """
+
+        self.edge_type_map = mapping
+
+        if not mapping:
+            return
+
+        seen: set[int] = set()
+        for sha in self.samples:
+            g = self._load_graph(sha)
+            if isinstance(g, HeteroData):
+                for _, store in g.edge_items():
+                    if hasattr(store, "edge_type"):
+                        seen.update(int(x) for x in store.edge_type.unique().tolist())
+            else:
+                if hasattr(g, "edge_type"):
+                    seen.update(int(x) for x in g.edge_type.unique().tolist())
+
+        remaining = seen - set(mapping.keys())
+        if remaining:
+            _LOG.warning(
+                "GraphDataset [%s] edge_type IDs %s not covered by mapping",
+                self.split,
+                sorted(remaining),
+            )
+
     def __getitem__(self, idx: int) -> Tuple[GraphT, int | None, str]:
         sha = self.samples[idx]
         g = self._load_graph(sha)
+        if self.edge_type_map:
+            g = GraphDataset._apply_edge_type_map(g, self.edge_type_map, sha)
         g = GraphDataset._ensure_x(g, policy=self.over_length_policy)
         g = GraphDataset._ensure_num_nodes(g)
         if self.transform:
@@ -348,6 +389,36 @@ class GraphDataset(Dataset):
 
     # --------------------------------------------------------------
     @staticmethod
+    def _apply_edge_type_map(
+        g: GraphT, mapping: Dict[int, int], sha: str | None = None
+    ) -> GraphT:
+        """Remap ``edge_type`` attributes according to ``mapping``."""
+
+        unmapped: set[int] = set()
+
+        def process(store: Data | HeteroData) -> None:
+            if hasattr(store, "edge_type"):
+                et = store.edge_type.view(-1).cpu().tolist()
+                mapped = [mapping.get(int(e), int(e)) for e in et]
+                for e in et:
+                    if e not in mapping:
+                        unmapped.add(int(e))
+                store.edge_type = torch.tensor(mapped, dtype=store.edge_type.dtype, device=store.edge_type.device)
+
+        if isinstance(g, HeteroData):
+            for _, store in g.edge_items():
+                process(store)
+        else:
+            process(g)
+
+        if unmapped:
+            _LOG.warning(
+                "Graph %s contains unmapped edge_type IDs %s", sha, sorted(unmapped)
+            )
+        return g
+
+    # --------------------------------------------------------------
+    @staticmethod
     def _ensure_x(g: GraphT, *, policy: OverLengthPolicy = OverLengthPolicy.TRIM) -> GraphT:
         """Fill missing ``x`` attributes from ``feat`` in each node store.
 
@@ -467,7 +538,12 @@ class GraphDataset(Dataset):
 
 def collect_dataset_metadata(
     ds: "GraphDataset", *, attr_dim: int = 0
-) -> tuple[tuple[list[str], list[tuple[str, str, str]]], dict[str, int], dict[str, list[str]]]:
+) -> tuple[
+    tuple[list[str], list[tuple[str, str, str]]],
+    dict[str, int],
+    dict[str, list[str]],
+    dict[int, int],
+]:
     """Iterate over ``ds`` and gather dataset‑wide metadata.
 
     Parameters
@@ -480,11 +556,12 @@ def collect_dataset_metadata(
 
     Returns
     -------
-    metadata, in_dims, attr_names
+    metadata, in_dims, attr_names, edge_type_map
         ``metadata`` is the ``(node_types, edge_types)`` tuple suitable for
         :class:`RGCNEncoder`.  ``in_dims`` maps node types to the required input
-        feature dimensions and ``attr_names`` lists metadata attribute names for
-        each node type.
+        feature dimensions, ``attr_names`` lists metadata attribute names for
+        each node type, and ``edge_type_map`` provides a mapping from original
+        ``edge_type`` IDs to compact sequential IDs.
     """
 
     from torch_geometric.data import HeteroData
@@ -493,6 +570,7 @@ def collect_dataset_metadata(
     edge_types: list[tuple[str, str, str]] = []
     feat_dim: dict[str, int] = defaultdict(int)
     attr_map: dict[str, set[str]] = defaultdict(set)
+    relation_ids: set[int] = set()
 
     for i in range(len(ds)):
         g, _, _ = ds[i]
@@ -503,6 +581,9 @@ def collect_dataset_metadata(
             for et in g.edge_types:
                 if et not in edge_types:
                     edge_types.append(et)
+                store = g[et]
+                if hasattr(store, "edge_type"):
+                    relation_ids.update(int(x) for x in store.edge_type.view(-1).tolist())
             for nt in g.node_types:
                 store = g[nt]
                 feat_dim[nt] = max(feat_dim[nt], getattr(store, "x").size(-1))
@@ -515,33 +596,36 @@ def collect_dataset_metadata(
                 feat_dim[""] = max(feat_dim.get("", 0), g.x.size(-1))
             names = [k[:-3] for k in g.keys() if k.endswith("_id")]
             attr_map[""].update(names)
+            if hasattr(g, "edge_type"):
+                relation_ids.update(int(x) for x in g.edge_type.view(-1).tolist())
 
     attr_names = {nt: sorted(names) for nt, names in attr_map.items()}
     in_dims = {nt: feat_dim[nt] + len(attr_names.get(nt, [])) * attr_dim for nt in feat_dim}
 
     # ------------------------------------------------------------------
-    # Determine number of relations from edge_type attributes
+    # Determine relation mapping from edge_type attributes when present
     # ------------------------------------------------------------------
-    if len(ds) > 0 and edge_types:
-        num_relations = max(
-            int(ds[i][0][et].edge_type.max())
-            for i in range(len(ds))
-            for et in ds[i][0].edge_types
-        ) + 1
-    else:
-        num_relations = 0
-
     from ..normalizers.schema import EDGE_TYPES
 
-    # align returned edge_types with global EDGE_TYPES up to num_relations
-    edge_types_full = list(EDGE_TYPES)
-    if num_relations > len(edge_types_full):  # pragma: no cover - unexpected
-        edge_types_full.extend(edge_types[len(edge_types_full):num_relations])
-        if len(edge_types_full) < num_relations:
-            # pad with dummy relations when names are unavailable
-            edge_types_full.extend(
-                [("", f"r{i}", "") for i in range(len(edge_types_full), num_relations)]
-            )
+    if relation_ids:
+        sorted_ids = sorted(relation_ids)
+        edge_type_map = {rid: i for i, rid in enumerate(sorted_ids)}
 
-    metadata = (node_types, edge_types_full[:num_relations])
-    return metadata, in_dims, attr_names
+        edge_types_full = list(EDGE_TYPES)
+        if len(sorted_ids) > len(edge_types_full):  # pragma: no cover - unexpected
+            edge_types_full.extend(edge_types[len(edge_types_full) : len(sorted_ids)])
+            if len(edge_types_full) < len(sorted_ids):
+                edge_types_full.extend(
+                    [("", f"r{i}", "") for i in range(len(edge_types_full), len(sorted_ids))]
+                )
+
+        mapped_edge_types = [
+            edge_types_full[rid] if rid < len(edge_types_full) else ("", f"r{rid}", "")
+            for rid in sorted_ids
+        ]
+    else:
+        edge_type_map = {}
+        mapped_edge_types = edge_types
+
+    metadata = (node_types, mapped_edge_types)
+    return metadata, in_dims, attr_names, edge_type_map

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -94,7 +94,7 @@ def test_collect_metadata_preserves_order(tmp_path):
     (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\nb,1\n")
 
     ds = GraphDataset(tmp_path, split="train", require_labels=True)
-    metadata, _, _ = collect_dataset_metadata(ds)
+    metadata, _, _, _ = collect_dataset_metadata(ds)
     node_types, edge_types = metadata
 
     assert node_types == ["n1", "n2", "n3"]


### PR DESCRIPTION
## Summary
- allow remapping of edge types in GraphDataset
- collect edge type ID mapping from dataset
- apply mapping in `train_res_gcl.py` and `finetune_supcon.py`
- adapt tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686275400448832eba1466a7d51f3f09