### PR TITLE
Add empty edge_type test and fix collect_dataset_metadata

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -523,11 +523,15 @@ def collect_dataset_metadata(
     # Determine number of relations from edge_type attributes
     # ------------------------------------------------------------------
     if len(ds) > 0 and edge_types:
-        num_relations = max(
-            int(ds[i][0][et].edge_type.max())
-            for i in range(len(ds))
-            for et in ds[i][0].edge_types
-        ) + 1
+        max_rel = -1
+        for i in range(len(ds)):
+            g, _, _ = ds[i]
+            for et in g.edge_types:
+                et_attr = g[et].edge_type
+                if et_attr.numel() == 0:
+                    continue
+                max_rel = max(max_rel, int(et_attr.max()))
+        num_relations = max_rel + 1 if max_rel >= 0 else 0
     else:
         num_relations = 0
 

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -104,3 +104,23 @@ def test_collect_metadata_preserves_order(tmp_path):
         ("n3", "r3", "n1"),
     ]
 
+
+def test_collect_metadata_empty_edge_type(tmp_path):
+    gdir = tmp_path / "train" / "graphs"
+    gdir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["n"].x = torch.randn(1, 1)
+    g["n"].num_nodes = 1
+    g[("n", "r0", "n")].edge_index = torch.empty(2, 0, dtype=torch.long)
+    g[("n", "r0", "n")].edge_type = torch.empty(0, dtype=torch.long)
+    torch.save(g, gdir / "a.pt")
+
+    (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    metadata, _, _ = collect_dataset_metadata(ds)
+
+    assert metadata[0] == ["n"]
+    assert metadata[1] == []
+


### PR DESCRIPTION
## Summary
- account for empty edge_type tensors when gathering dataset metadata
- add regression test for edge stores without edges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c915fa78832eb639ca4386069480