### PR TITLE
Add dataset metadata edge_type test

### DIFF
--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -104,3 +104,23 @@ def test_collect_metadata_preserves_order(tmp_path):
         ("n3", "r3", "n1"),
     ]
 
+
+def test_collect_metadata_empty_edge_type(tmp_path):
+    gdir = tmp_path / "train" / "graphs"
+    gdir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["n"].x = torch.randn(1, 1)
+    g["n"].num_nodes = 1
+    g[("n", "r0", "n")].edge_index = torch.empty(2, 0, dtype=torch.long)
+    g[("n", "r0", "n")].edge_type = torch.empty(0, dtype=torch.long)
+    torch.save(g, gdir / "a.pt")
+
+    (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    metadata, _, _ = collect_dataset_metadata(ds)
+
+    assert metadata[0] == ["n"]
+    assert metadata[1] == []
+


### PR DESCRIPTION
## Summary
- add unit test for collecting dataset metadata when edge_type tensors are empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c9e78538832eb595aa6569447a7e