### PR TITLE
Handle empty edge relations in metadata collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ python -m cli.pretrain_selfgcl data/hetero \
 
 그래프 파일에 비숫자형 리스트 속성이 있을 경우 자동으로 메타에 저장됩니다.
 주소 정보가 없는 노드의 `addr` 속성은 0으로 채워집니다.
+관계가 하나도 없는 edge type(빈 relation)이 존재할 수 있으며,
+메타데이터 수집 시 이러한 relation은 무시됩니다.
 
 # GNN 학습
 

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -522,12 +522,16 @@ def collect_dataset_metadata(
     # ------------------------------------------------------------------
     # Determine number of relations from edge_type attributes
     # ------------------------------------------------------------------
-    if len(ds) > 0 and edge_types:
-        num_relations = max(
-            int(ds[i][0][et].edge_type.max())
-            for i in range(len(ds))
-            for et in ds[i][0].edge_types
-        ) + 1
+    relation_ids: set[int] = set()
+    for i in range(len(ds)):
+        g, _, _ = ds[i]
+        for et in g.edge_types:
+            et_tensor = g[et].edge_type
+            if et_tensor.numel() > 0:
+                relation_ids.update(et_tensor.unique().tolist())
+
+    if relation_ids:
+        num_relations = max(relation_ids) + 1
     else:
         num_relations = 0
 

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -18,8 +18,9 @@ def _make_graph(path: Path, rels: list[str]) -> None:
     g = HeteroData()
     g["n"].x = torch.randn(2, 4)
     g["n"].num_nodes = 2
-    for r in rels:
+    for idx, r in enumerate(rels):
         g[("n", r, "n")].edge_index = torch.tensor([[0, 1], [1, 0]])
+        g[("n", r, "n")].edge_type = torch.full((2,), idx, dtype=torch.long)
     torch.save(g, path)
 
 
@@ -80,6 +81,7 @@ def test_collect_metadata_preserves_order(tmp_path):
     g1["n2"].x = torch.randn(1, 1)
     g1["n2"].num_nodes = 1
     g1[("n1", "r1", "n2")].edge_index = torch.tensor([[0], [0]])
+    g1[("n1", "r1", "n2")].edge_type = torch.tensor([0], dtype=torch.long)
     torch.save(g1, gdir / "a.pt")
 
     g2 = HeteroData()
@@ -88,7 +90,9 @@ def test_collect_metadata_preserves_order(tmp_path):
     g2["n3"].x = torch.randn(1, 1)
     g2["n3"].num_nodes = 1
     g2[("n1", "r2", "n3")].edge_index = torch.tensor([[0], [0]])
+    g2[("n1", "r2", "n3")].edge_type = torch.tensor([1], dtype=torch.long)
     g2[("n3", "r3", "n1")].edge_index = torch.tensor([[0], [0]])
+    g2[("n3", "r3", "n1")].edge_type = torch.tensor([2], dtype=torch.long)
     torch.save(g2, gdir / "b.pt")
 
     (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\nb,1\n")
@@ -103,4 +107,33 @@ def test_collect_metadata_preserves_order(tmp_path):
         ("n1", "r2", "n3"),
         ("n3", "r3", "n1"),
     ]
+
+
+def test_collect_metadata_with_empty_relation(tmp_path):
+    gdir = tmp_path / "train" / "graphs"
+    gdir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["n"].x = torch.randn(1, 1)
+    g["n"].num_nodes = 1
+
+    # relation with edges
+    g[("n", "r1", "n")].edge_index = torch.tensor([[0], [0]])
+    g[("n", "r1", "n")].edge_type = torch.tensor([0], dtype=torch.long)
+
+    # relation without edges
+    g[("n", "r2", "n")].edge_index = torch.empty(2, 0, dtype=torch.long)
+    g[("n", "r2", "n")].edge_type = torch.empty(0, dtype=torch.long)
+
+    torch.save(g, gdir / "a.pt")
+
+    (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    metadata, _, _ = collect_dataset_metadata(ds)
+
+    node_types, edge_types = metadata
+
+    assert node_types == ["n"]
+    assert len(edge_types) == 1
 


### PR DESCRIPTION
## Summary
- support graphs with relations that have no edges when collecting dataset metadata
- add tests covering empty edge lists
- document this behavior in preprocessing section of README

## Testing
- `pytest tests/test_collect_dataset_metadata.py::test_collect_metadata_with_empty_relation -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c8a7bb08832eb9c106b7b4f27680