### PR TITLE
Update dataset metadata union handling

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -384,7 +384,7 @@ def main() -> None:
     from graphs.dataset import collect_dataset_metadata
 
     metadata, in_dims, attr_names = collect_dataset_metadata(
-        train_dl.dataset, attr_dim=encoder.attr_dim
+        [train_dl.dataset, val_dl.dataset], attr_dim=encoder.attr_dim
     )
 
     node_order_mismatch = metadata[0] != encoder.node_types

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -33,7 +33,7 @@ import logging
 import numpy as np
 
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
 from torch_geometric.data import Data, HeteroData, InMemoryDataset, Batch
 import torch.nn.functional as F
 from torch_geometric.loader import DataLoader as PyGLoader
@@ -47,6 +47,7 @@ from augment.basic import get_default_graphcl_transforms
 from models.contrast.self_gcl import SelfGraphCL
 from models.gnn.encoder import RGCNEncoder
 from evaluation.metrics import Alignment, Uniformity
+from graphs.dataset import collect_dataset_metadata
 import matplotlib.pyplot as plt
 
 LOGGER = get_logger(__name__)
@@ -576,8 +577,14 @@ def main():
         raise SystemExit(1)
     split_json = json.loads(Path(args.splits).read_text())
     train_shas = split_json["train"]
+    val_shas = split_json.get("val")
 
     train_ds = HeteroGraphDiskDataset(args.graph_dir, sha_list=train_shas)
+    val_ds = (
+        HeteroGraphDiskDataset(args.graph_dir, sha_list=val_shas)
+        if val_shas is not None
+        else None
+    )
 
     if not validate_dataset(train_ds):
         if args.reprocess:
@@ -600,11 +607,10 @@ def main():
     # --------------------------------------------------------------------- #
     # Model & Optimizer
     # --------------------------------------------------------------------- #
-    # ``train_ds._data`` represents the collated dataset containing the union of
-    # node types across all graphs, which ensures the encoder is aware of every
-    # possible node type.
+    datasets = [train_ds] + ([val_ds] if val_ds is not None else [])
+
     params, target_node, meta_info = _load_model_hparams(
-        args.config, train_ds._data, vocab_size=len(train_ds.vocab)
+        args.config, datasets, vocab_size=len(train_ds.vocab)
     )
     model = SelfGraphCL(**params)
 
@@ -749,18 +755,18 @@ def main():
 
 
 def _load_model_hparams(
-    cfg_path: Path, graph: HeteroData | Data, *, vocab_size: int = 0
+    cfg_path: Path, datasets: Sequence[Dataset], *, vocab_size: int = 0
 ) -> tuple[dict, str | None, dict]:
-    """Return ``SelfGraphCL`` kwargs loaded from ``cfg_path``.
+    """Return ``SelfGraphCL`` kwargs loaded from ``cfg_path`` and datasets.
 
     Expected YAML ``model`` keys are a subset of
     ``hidden_dim``, ``num_layers``, ``out_dim``, ``dropout``, ``proj_dim``,
     ``temperature``, ``gather_distributed`` and ``target_node``.  Unknown keys
     (e.g. ``name`` or ``backbone``) are ignored.
 
-    Node feature dimensions are inferred from ``graph``.  When a node type
-    lacks a ``.x`` attribute, ``.feat`` is used as a fallback and assigned to
-    ``.x`` so that downstream modules can rely on it.
+    Node feature dimensions are inferred from ``datasets`` using
+    :func:`collect_dataset_metadata`.  When an API node type required by
+    augmentation is missing, it is added automatically.
     """
     try:
         import yaml  # Lazy import (PyYAML optional)
@@ -787,24 +793,14 @@ def _load_model_hparams(
         if k in model_cfg:
             encoder_args[k] = model_cfg.pop(k)
 
-    metadata = graph.metadata() if isinstance(graph, HeteroData) else ([], [])
     attr_dim = int(model_cfg.get("attr_dim", 32))
-    if isinstance(graph, HeteroData):
+    metadata, in_dims, attr_names = collect_dataset_metadata(
+        datasets, attr_dim=attr_dim
+    )
+
+    # ensure API node/edge types for augmentation
+    if metadata[0]:
         node_types, edge_types = map(list, metadata)
-        in_dims: dict[str, int] = {}
-        attr_names: dict[str, list[str]] = {}
-        for nt in graph.node_types:
-            store = graph[nt]
-            if hasattr(store, "x"):
-                feat = store.x
-            elif hasattr(store, "feat"):
-                feat = store.feat
-                store.x = feat  # ensure downstream access
-            else:
-                raise AttributeError(f"Node type '{nt}' lacks '.x' or '.feat'")
-            meta_keys = [k[:-3] for k in store.keys() if k.endswith("_id")]
-            attr_names[nt] = meta_keys
-            in_dims[nt] = feat.size(-1) + len(meta_keys) * attr_dim
         api_nt = NodeType.API.value
         if api_nt not in node_types:
             node_types.append(api_nt)
@@ -813,21 +809,12 @@ def _load_model_hparams(
         if api_edge not in edge_types:
             edge_types.append(api_edge)
         metadata = (tuple(node_types), tuple(edge_types))
-    else:
-        if hasattr(graph, "x"):
-            feat = graph.x
-        elif hasattr(graph, "feat"):
-            feat = graph.feat
-            graph.x = feat  # type: ignore[attr-defined]
-        else:
-            raise AttributeError("Graph lacks '.x' or '.feat'")
-        in_dims = {"": feat.size(-1)}  # type: ignore[attr-defined]
 
     target_node = encoder_args.get("target_node")
     encoder = RGCNEncoder(
         metadata=metadata,
         in_dims=in_dims,
-        attr_names=attr_names if isinstance(graph, HeteroData) else None,
+        attr_names=attr_names if attr_names else None,
         vocab_size=vocab_size,
         attr_dim=attr_dim,
         **encoder_args,

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -182,7 +182,7 @@ def main(argv: list[str] | None = None) -> None:
     from graphs.dataset import collect_dataset_metadata
 
     metadata, in_dims, attr_names = collect_dataset_metadata(
-        train_dl.dataset, attr_dim=encoder.attr_dim
+        [train_dl.dataset, val_dl.dataset], attr_dim=encoder.attr_dim
     )
 
     g0, _, _ = train_dl.dataset[0]

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -35,7 +35,7 @@ import gzip
 import json
 import pickle
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Sequence
 import warnings
 from collections import defaultdict
 
@@ -466,16 +466,24 @@ class GraphDataset(Dataset):
 
 
 def collect_dataset_metadata(
-    ds: "GraphDataset", *, attr_dim: int = 0
-) -> tuple[tuple[list[str], list[tuple[str, str, str]]], dict[str, int], dict[str, list[str]]]:
-    """Iterate over ``ds`` and gather dataset‑wide metadata.
+    ds: "Dataset | Sequence[Dataset]",
+    *,
+    attr_dim: int = 0,
+) -> tuple[
+    tuple[list[str], list[tuple[str, str, str]]],
+    dict[str, int],
+    dict[str, list[str]],
+]:
+    """Iterate over one or more datasets and gather union metadata.
 
     Parameters
     ----------
     ds:
-        :class:`GraphDataset` instance to inspect.
+        Single dataset or sequence of datasets to inspect. Each dataset must
+        yield either a ``Data``/``HeteroData`` object or a tuple where the first
+        element is the graph.
     attr_dim:
-        Embedding dimensionality for metadata attributes.  ``in_dims`` will be
+        Embedding dimensionality for metadata attributes. ``in_dims`` will be
         computed as ``feat_dim + len(attr_names) * attr_dim`` per node type.
 
     Returns
@@ -489,32 +497,39 @@ def collect_dataset_metadata(
 
     from torch_geometric.data import HeteroData
 
+    datasets = [ds] if isinstance(ds, GraphDataset) else list(ds)
+
     node_types: list[str] = []
     edge_types: list[tuple[str, str, str]] = []
     feat_dim: dict[str, int] = defaultdict(int)
     attr_map: dict[str, set[str]] = defaultdict(set)
 
-    for i in range(len(ds)):
-        g, _, _ = ds[i]
-        if isinstance(g, HeteroData):
-            for nt in g.node_types:
-                if nt not in node_types:
-                    node_types.append(nt)
-            for et in g.edge_types:
-                if et not in edge_types:
-                    edge_types.append(et)
-            for nt in g.node_types:
-                store = g[nt]
-                feat_dim[nt] = max(feat_dim[nt], getattr(store, "x").size(-1))
-                names = [k[:-3] for k in store.keys() if k.endswith("_id")]
-                attr_map[nt].update(names)
-        else:  # Data
-            if "" not in node_types:
-                node_types.append("")
-            if hasattr(g, "x"):
-                feat_dim[""] = max(feat_dim.get("", 0), g.x.size(-1))
-            names = [k[:-3] for k in g.keys() if k.endswith("_id")]
-            attr_map[""].update(names)
+    for d in datasets:
+        for i in range(len(d)):
+            item = d[i]
+            if isinstance(item, tuple):
+                g = item[0]
+            else:
+                g = item
+            if isinstance(g, HeteroData):
+                for nt in g.node_types:
+                    if nt not in node_types:
+                        node_types.append(nt)
+                for et in g.edge_types:
+                    if et not in edge_types:
+                        edge_types.append(et)
+                for nt in g.node_types:
+                    store = g[nt]
+                    feat_dim[nt] = max(feat_dim[nt], getattr(store, "x").size(-1))
+                    names = [k[:-3] for k in store.keys() if k.endswith("_id")]
+                    attr_map[nt].update(names)
+            else:  # Data
+                if "" not in node_types:
+                    node_types.append("")
+                if hasattr(g, "x"):
+                    feat_dim[""] = max(feat_dim.get("", 0), g.x.size(-1))
+                names = [k[:-3] for k in g.keys() if k.endswith("_id")]
+                attr_map[""].update(names)
 
     attr_names = {nt: sorted(names) for nt, names in attr_map.items()}
     in_dims = {nt: feat_dim[nt] + len(attr_names.get(nt, [])) * attr_dim for nt in feat_dim}
@@ -522,14 +537,17 @@ def collect_dataset_metadata(
     # ------------------------------------------------------------------
     # Determine number of relations from edge_type attributes
     # ------------------------------------------------------------------
-    if len(ds) > 0 and edge_types:
+    total_len = sum(len(d) for d in datasets)
+    if total_len > 0 and edge_types:
         relation_ids: set[int] = set()
-        for i in range(len(ds)):
-            g, _, _ = ds[i]
-            for et in g.edge_types:
-                et_vals = g[et].edge_type
-                if et_vals.numel() > 0:
-                    relation_ids.update(map(int, et_vals.tolist()))
+        for d in datasets:
+            for i in range(len(d)):
+                item = d[i]
+                g = item[0] if isinstance(item, tuple) else item
+                for et in g.edge_types:
+                    et_vals = g[et].edge_type
+                    if et_vals.numel() > 0:
+                        relation_ids.update(map(int, et_vals.tolist()))
         if relation_ids:
             num_relations = max(relation_ids) + 1
         else:

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -124,3 +124,54 @@ def test_collect_metadata_empty_edge_type(tmp_path):
     assert metadata[0] == ["n"]
     assert metadata[1] == []
 
+
+def test_val_extra_relation(tmp_path, caplog):
+    data_root = tmp_path / "data"
+
+    train_gdir = data_root / "train" / "graphs"
+    train_gdir.mkdir(parents=True)
+    _make_graph(train_gdir / "a.pt", ["r0"])
+    (data_root / "train" / "labels.csv").write_text("sha256,label\na,0\n")
+
+    val_gdir = data_root / "val" / "graphs"
+    val_gdir.mkdir(parents=True)
+    _make_graph(val_gdir / "b.pt", ["r1"])
+    (data_root / "val" / "labels.csv").write_text("sha256,label\nb,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt_path = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt_path)
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    caplog.set_level("INFO")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert any("Epoch 1" in rec.message for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- generalize `collect_dataset_metadata` to aggregate multiple datasets
- rework CLI scripts to compute metadata across train+val splits
- ensure SelfGraphCL uses collected metadata
- cover new case where validation set introduces unseen relation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862da0e0848832eb1ad05996f62cced