### PR TITLE
Add edge type validation to RGCNEncoder

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -163,6 +163,13 @@ class RGCNEncoder(nn.Module):
         # 3) RGCN layers on the homogeneous representation
         edge_index = homo.edge_index
         edge_type = homo.edge_type
+        max_rel = int(edge_type.max()) if edge_type.numel() > 0 else -1
+        first_conv = getattr(self.convs[0], "sublayer", self.convs[0])
+        num_rel = getattr(first_conv, "num_relations", 0)
+        if max_rel >= num_rel:
+            raise ValueError(
+                f"Unsupported edge type index {max_rel} for encoder"
+            )
         for conv in self.convs:
             x = conv(x, edge_index, edge_type)  # type: ignore[arg-type]
             x = self.drop(self.act(x))

--- a/tests/test_rgcn_edge_type_check.py
+++ b/tests/test_rgcn_edge_type_check.py
@@ -1,0 +1,28 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def test_forward_raises_on_unknown_relation():
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    g["n"].batch = torch.zeros(2, dtype=torch.long)
+    g[("n", "r0", "n")].edge_index = torch.tensor([[0], [1]])
+    g[("n", "r1", "n")].edge_index = torch.tensor([[1], [0]])
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+
+    with pytest.raises(ValueError, match="edge type index 1"):
+        enc(g)


### PR DESCRIPTION
## Summary
- validate edge_type indices in `RGCNEncoder.forward`
- add regression test for unsupported relations

## Testing
- `pytest tests/test_rgcn_edge_type_check.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dccb3ce4832e8d960d4fede9030d