### PR TITLE
Persist dataset metadata for self-GCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ python -m cli.preprocessing --input-dir data/raw --out . --overwrite json
 # hetero graph 생성 (기존 *.pt를 삭제하려면 --clean)
 python -m cli.preprocessing --input-dir data/raw --out . graphs --normalise --rebuild --clean --with-feats
 
+# 이 단계에서 각 데이터셋 디렉터리에 `processed/metadata.pkl` 파일이 생성됩니다.
+
 python -m cli.preprocessing --input-dir data/hetero --out . splits --fallback random --strategy random --json-out split_fold.json
 # 학습, 평가, 테스트 데이터 분할
 

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -72,6 +72,15 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 self.vocab = json.load(f)
         else:
             self.vocab = {}
+        meta_file = Path(self.processed_dir) / "metadata.pkl"
+        if meta_file.is_file():
+            try:
+                self._metadata = torch.load(meta_file)
+            except Exception:
+                self._metadata = None
+        else:
+            self._metadata = None
+
         loaded = torch.load(self.processed_paths[0], weights_only=False)
         if isinstance(loaded, (list, tuple)) and len(loaded) == 3:
             self._data, self.slices, self.graph_meta = loaded
@@ -129,6 +138,10 @@ class HeteroGraphDiskDataset(InMemoryDataset):
     def processed_file_names(self) -> list[str]:
         return ["graph_dataset.pt"]
 
+    @property
+    def metadata(self) -> tuple | None:
+        return self._metadata
+
     def process(self):
         paths = sorted(Path(self.root).glob("*.pt"))
         data_list = []
@@ -138,6 +151,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         attr_union: dict[str, set[str]] = defaultdict(set)
         attr_example: dict[tuple[str, str], object] = {}
         meta_keys: dict[str, set[str]] = defaultdict(set)
+        node_types: list[str] = []
+        edge_types: list[tuple[str, str, str]] = []
 
         # ------------------------------------------------------------------
         # Build or load token vocabulary
@@ -268,6 +283,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             graph_meta: dict[str, str] = {}
             if isinstance(data, HeteroData):
                 for ntype in data.node_types:
+                    if ntype not in node_types:
+                        node_types.append(ntype)
                     store = data[ntype]
                     mval = getattr(store, "meta", "")
                     if mval:
@@ -279,6 +296,9 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                     graph_meta[ntype] = mval
                     if "meta" in store:
                         del store["meta"]
+                for et in data.edge_types:
+                    if et not in edge_types:
+                        edge_types.append(et)
             else:
                 graph_meta[""] = getattr(data, "meta", "")
                 if hasattr(data, "meta"):
@@ -300,6 +320,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         if isinstance(val, torch.Tensor) and val.dim() == 2:
                             max_dim[key] = max(max_dim[key], val.size(1))
             else:
+                if "" not in node_types:
+                    node_types.append("")
                 attr_union[""].update(data.keys())
                 for attr, val in data.items():
                     key = ("", attr)
@@ -425,6 +447,12 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 "Some node features may be missing."
             ) from exc
         torch.save((data, slices, meta_list), self.processed_paths[0])
+        meta_path = Path(self.processed_dir) / "metadata.pkl"
+        self._metadata = (tuple(node_types), tuple(edge_types))
+        try:
+            torch.save(self._metadata, meta_path)
+        except Exception as exc:  # pragma: no cover - safeguard
+            LOGGER.warning("Failed to save metadata: %s", exc)
         self.graph_meta = meta_list
 
 

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -233,3 +233,34 @@ def test_schema_addr_default(tmp_path, monkeypatch):
     batch = next(iter(loader))
     store = batch["token"] if not isinstance(batch, list) else batch[0]["token"]
     assert torch.all(store.addr.eq(torch.zeros(3, dtype=torch.long)))
+
+
+def test_metadata_file_saved(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g1 = HeteroData()
+    g1["n"].x = torch.randn(1, 1)
+    g1["n"].num_nodes = 1
+    g1[("n", "r0", "n")].edge_index = torch.tensor([[0], [0]])
+    g1[("n", "r0", "n")].edge_type = torch.tensor([0], dtype=torch.long)
+    torch.save(g1, graph_dir / "a.pt")
+
+    g2 = HeteroData()
+    g2["n"].x = torch.randn(1, 1)
+    g2["n"].num_nodes = 1
+    g2[("n", "r1", "n")].edge_index = torch.tensor([[0], [0]])
+    g2[("n", "r1", "n")].edge_type = torch.tensor([1], dtype=torch.long)
+    torch.save(g2, graph_dir / "b.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    meta_path = graph_dir / "processed" / "metadata.pkl"
+
+    assert meta_path.is_file()
+    assert ds.metadata == torch.load(meta_path)
+    assert ds.metadata == (("n",), (("n", "r0", "n"), ("n", "r1", "n")))
+    assert torch.all(ds[0][("n", "r0", "n")].edge_type.eq(0))
+    assert torch.all(ds[1][("n", "r1", "n")].edge_type.eq(1))


### PR DESCRIPTION
## Summary
- save `(node_types, edge_types)` as `metadata.pkl` when processing `HeteroGraphDiskDataset`
- load and expose metadata via property on dataset
- document new `metadata.pkl` output in README
- test that metadata file is created and matches relation IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862edbf8f6c832e8fbec66ebe884ae2