### PR TITLE
Update InjectAPICall to handle edge_type

### DIFF
--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -21,6 +21,17 @@ from torch_geometric.data import Data, HeteroData
 
 from augment import register_op
 from augment.base import SimpleAug, AugmentBase
+from importlib import util as _import_util
+from pathlib import Path
+
+_schema_spec = _import_util.spec_from_file_location(
+    "_schema", Path(__file__).resolve().parents[2] / "graphs" / "normalizers" / "schema.py"
+)
+_schema = _import_util.module_from_spec(_schema_spec)
+assert _schema_spec and _schema_spec.loader
+_schema_spec.loader.exec_module(_schema)
+EDGE_REL_ID = _schema.EDGE_REL_ID
+EdgeRel = _schema.EdgeRel
 
 
 @register_op
@@ -199,6 +210,17 @@ class InjectAPICall(SimpleAug, AugmentBase):
             edge_store.edge_index = torch.cat([edge_store.edge_index, new_edges], dim=1)
         else:
             edge_store.edge_index = new_edges
+        # edge_type 업데이트
+        new_types = torch.full(
+            (new_edges.size(1),),
+            EDGE_REL_ID[EdgeRel.CALLS.value],
+            dtype=torch.long,
+            device=device,
+        )
+        if "edge_type" in edge_store:
+            edge_store.edge_type = torch.cat([edge_store.edge_type, new_types])
+        else:
+            edge_store.edge_type = new_types
 
     # ================================================================== #
     #                               utils                                #

--- a/tests/test_inject_call.py
+++ b/tests/test_inject_call.py
@@ -6,6 +6,18 @@ pytest.importorskip("torch_geometric")
 from torch_geometric.data import HeteroData
 
 from src.augment.ops.inject_call import InjectAPICall
+import torch
+import importlib.util
+from pathlib import Path
+
+schema_spec = importlib.util.spec_from_file_location(
+    "schema", Path("src/graphs/normalizers/schema.py")
+)
+schema = importlib.util.module_from_spec(schema_spec)
+assert schema_spec.loader is not None
+schema_spec.loader.exec_module(schema)
+EDGE_REL_ID = schema.EDGE_REL_ID
+EdgeRel = schema.EdgeRel
 
 
 def test_inject_api_call_handles_missing_bb():
@@ -13,3 +25,23 @@ def test_inject_api_call_handles_missing_bb():
     aug = InjectAPICall()
     out = aug(g)
     assert isinstance(out, HeteroData)
+
+
+def test_inject_api_call_edge_type():
+    g = HeteroData()
+    g["bb"].num_nodes = 1
+    g["api"].num_nodes = 1
+    etype = ("bb", "calls", "api")
+    g[etype].edge_index = torch.tensor([[0], [0]])
+    g[etype].edge_type = torch.tensor(
+        [EDGE_REL_ID[EdgeRel.CALLS.value]], dtype=torch.long
+    )
+
+    aug = InjectAPICall(k=2, seed=0)
+    out = aug(g)
+
+    store = out[etype]
+    assert store.edge_type.size(0) == store.edge_index.size(1)
+    assert torch.all(
+        store.edge_type == EDGE_REL_ID[EdgeRel.CALLS.value]
+    )


### PR DESCRIPTION
## Summary
- update InjectAPICall to append edge_type when injecting edges
- test that injected `("bb","calls","api")` edges have correct edge_type

## Testing
- `pytest tests/test_inject_call.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ee5fc750832eba0ad5106181adb7