### PR TITLE
Ensure metadata covers global relations

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -557,6 +557,9 @@ def collect_dataset_metadata(
 
     from ..normalizers.schema import EDGE_TYPES
 
+    # ensure at least all schema relations are represented
+    num_relations = max(num_relations, len(EDGE_TYPES))
+
     # align returned edge_types with global EDGE_TYPES up to num_relations
     edge_types_full = list(EDGE_TYPES)
     if num_relations > len(edge_types_full):  # pragma: no cover - unexpected

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -97,12 +97,10 @@ def test_collect_metadata_preserves_order(tmp_path):
     metadata, _, _ = collect_dataset_metadata(ds)
     node_types, edge_types = metadata
 
+    from src.graphs.normalizers.schema import EDGE_TYPES
+
     assert node_types == ["n1", "n2", "n3"]
-    assert edge_types == [
-        ("n1", "r1", "n2"),
-        ("n1", "r2", "n3"),
-        ("n3", "r3", "n1"),
-    ]
+    assert edge_types == list(EDGE_TYPES)
 
 
 def test_collect_metadata_empty_edge_type(tmp_path):
@@ -121,8 +119,11 @@ def test_collect_metadata_empty_edge_type(tmp_path):
     ds = GraphDataset(tmp_path, split="train", require_labels=True)
     metadata, _, _ = collect_dataset_metadata(ds)
 
+    from src.graphs.normalizers.schema import EDGE_TYPES
+
     assert metadata[0] == ["n"]
-    assert metadata[1] == []
+    assert metadata[1][: len(EDGE_TYPES)] == list(EDGE_TYPES)
+    assert len(metadata[1]) >= len(EDGE_TYPES)
 
 
 def test_val_extra_relation(tmp_path, caplog):


### PR DESCRIPTION
## Summary
- update `collect_dataset_metadata` to always report at least all relations defined in the schema
- adjust dataset metadata tests to expect the base relation set

## Testing
- `pytest tests/test_collect_dataset_metadata.py::test_collect_metadata_empty_edge_type -q` *(fails: ImportError: cannot import name 'triu' from 'scipy.linalg')*

------
https://chatgpt.com/codex/tasks/task_e_6862f05bf010832e9e638ac11806c5e3