### PR TITLE
Fix ensure_x padding logic

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -360,7 +360,15 @@ class GraphDataset(Dataset):
 
         def _handle(store: Data | HeteroData, attr: str, n: int, node_type: str) -> None:
             tensor = getattr(store, attr)
-            if tensor.size(0) <= n:
+            if tensor.size(0) < n:
+                pad = n - tensor.size(0)
+                if tensor.dim() == 1:
+                    padded = F.pad(tensor, (0, pad))
+                else:
+                    padded = F.pad(tensor, (0, 0, 0, pad))
+                setattr(store, attr, padded)
+                return
+            if tensor.size(0) == n:
                 return
             if policy is OverLengthPolicy.ERROR:
                 raise ValueError(f"{tensor.size(0)} > num_nodes({n})")

--- a/tests/test_graph_dataset_loader.py
+++ b/tests/test_graph_dataset_loader.py
@@ -27,3 +27,19 @@ def test_ensure_x_trim_pad(tmp_path):
     assert record
     msg = str(record[0].message)
     assert "Data" in msg or "data" in msg
+
+
+def test_ensure_x_pad_missing(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = Data(x=torch.randn(1, 2))
+    g.num_nodes = 3
+    torch.save(g, graph_dir / "a.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    loaded, _, _ = ds[0]
+
+    assert loaded.x.size(0) == 3
+    assert torch.allclose(loaded.x[:1], g.x)
+    assert torch.all(loaded.x[1:].eq(0))


### PR DESCRIPTION
## Summary
- fix `_ensure_x` logic to pad node features when shorter than `num_nodes`
- add test for padding behaviour

## Testing
- `pytest tests/test_graph_dataset_loader.py::test_ensure_x_trim_pad tests/test_graph_dataset_loader.py::test_ensure_x_pad_missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fdde2568832e9b19ddce9b6e7546