### PR TITLE
Enhance encoder relation checks

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -371,8 +371,14 @@ def main() -> None:
         try:
             add_safe_globals([NodeType])
             meta_snapshot = torch.load(args.meta_path, weights_only=False)
+            if isinstance(meta_snapshot, dict):
+                meta_snapshot.setdefault(
+                    "num_relations", len(meta_snapshot.get("edge_types", []))
+                )
         except Exception as exc:  # pragma: no cover - I/O handling
-            LOGGER.warning("Failed to load meta snapshot %s: %s", args.meta_path, exc)
+            LOGGER.warning(
+                "Failed to load meta snapshot %s: %s", args.meta_path, exc
+            )
 
     # ---------------- DataLoaders ---------------------------------------- #
     train_dl, val_dl = make_dataloaders(
@@ -433,9 +439,15 @@ def main() -> None:
     if meta_snapshot is not None:
         snap_ntypes = set(meta_snapshot.get("node_types", []))
         snap_etypes = set(tuple(e) for e in meta_snapshot.get("edge_types", []))
+        snap_rels = meta_snapshot.get("num_relations", len(snap_etypes))
         curr_ntypes = set(metadata[0])
         curr_etypes = set(tuple(e) for e in metadata[1])
-        if snap_ntypes != curr_ntypes or snap_etypes != curr_etypes:
+        curr_rels = len(metadata[1])
+        if (
+            snap_ntypes != curr_ntypes
+            or snap_etypes != curr_etypes
+            or snap_rels != curr_rels
+        ):
             auto_reinit = True
         else:
             for nt, dim in in_dims.items():
@@ -475,6 +487,17 @@ def main() -> None:
         filtered = filter_state_dict(new_enc, state, logger=LOGGER)
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
+
+    dataset_rels = len(metadata[1])
+    first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
+    model_rels = first_conv.weight.size(0)
+    if dataset_rels != model_rels:
+        msg = (
+            f"Relation count mismatch: dataset has {dataset_rels} relations "
+            f"but encoder expects {model_rels}"
+        )
+        LOGGER.error(msg)
+        raise ValueError(msg)
 
     # Optional: check whether dataset provides required metadata attributes
     g0, _, _ = train_dl.dataset[0]

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -877,6 +877,7 @@ def _load_model_hparams(
         "node_types": list(metadata[0]),
         "edge_types": [tuple(e) for e in metadata[1]],
         "in_dims": {k: int(v) for k, v in in_dims.items()},
+        "num_relations": len(metadata[1]),
     }
     return params, target_node, meta_info
 

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -171,8 +171,14 @@ def main(argv: list[str] | None = None) -> None:
         try:
             add_safe_globals([NodeType])
             meta_snapshot = torch.load(args.meta_path, weights_only=False)
+            if isinstance(meta_snapshot, dict):
+                meta_snapshot.setdefault(
+                    "num_relations", len(meta_snapshot.get("edge_types", []))
+                )
         except Exception as exc:  # pragma: no cover - I/O handling
-            LOGGER.warning("Failed to load meta snapshot %s: %s", args.meta_path, exc)
+            LOGGER.warning(
+                "Failed to load meta snapshot %s: %s", args.meta_path, exc
+            )
 
     train_dl, val_dl = make_dataloaders(
         root,
@@ -212,9 +218,15 @@ def main(argv: list[str] | None = None) -> None:
     if meta_snapshot is not None:
         snap_ntypes = set(meta_snapshot.get("node_types", []))
         snap_etypes = set(tuple(e) for e in meta_snapshot.get("edge_types", []))
+        snap_rels = meta_snapshot.get("num_relations", len(snap_etypes))
         curr_ntypes = set(metadata[0])
         curr_etypes = set(tuple(e) for e in metadata[1])
-        if snap_ntypes != curr_ntypes or snap_etypes != curr_etypes:
+        curr_rels = len(metadata[1])
+        if (
+            snap_ntypes != curr_ntypes
+            or snap_etypes != curr_etypes
+            or snap_rels != curr_rels
+        ):
             auto_reinit = True
         else:
             for nt, dim in in_dims.items():
@@ -252,6 +264,17 @@ def main(argv: list[str] | None = None) -> None:
         filtered = filter_state_dict(new_enc, state, logger=LOGGER)
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
+
+    dataset_rels = len(metadata[1])
+    first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
+    model_rels = first_conv.weight.size(0)
+    if dataset_rels != model_rels:
+        msg = (
+            f"Relation count mismatch: dataset has {dataset_rels} relations "
+            f"but encoder expects {model_rels}"
+        )
+        LOGGER.error(msg)
+        raise ValueError(msg)
     if args.head_checkpoint:
         state = torch.load(args.head_checkpoint, map_location=device)
         head_state = {

--- a/tests/test_auto_reinit_input_dim.py
+++ b/tests/test_auto_reinit_input_dim.py
@@ -17,7 +17,9 @@ def _make_graph(path: Path, feat_dim: int) -> None:
     g = HeteroData()
     g["n"].x = torch.randn(2, feat_dim)
     g["n"].num_nodes = 2
-    g[("n", "r0", "n")].edge_index = torch.tensor([[0, 1], [1, 0]])
+    ei = torch.tensor([[0, 1], [1, 0]])
+    g[("n", "r0", "n")].edge_index = ei
+    g[("n", "r0", "n")].edge_type = torch.zeros(ei.size(1), dtype=torch.long)
     torch.save(g, path)
 
 

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -19,7 +19,12 @@ def _make_graph(path: Path, rels: list[str]) -> None:
     g["n"].x = torch.randn(2, 4)
     g["n"].num_nodes = 2
     for r in rels:
-        g[("n", r, "n")].edge_index = torch.tensor([[0, 1], [1, 0]])
+        ei = torch.tensor([[0, 1], [1, 0]])
+        g[("n", r, "n")].edge_index = ei
+        idx = int(r[1:]) if r.startswith("r") else 0
+        g[("n", r, "n")].edge_type = torch.full(
+            (ei.size(1),), idx, dtype=torch.long
+        )
     torch.save(g, path)
 
 

--- a/tests/test_relation_count_mismatch.py
+++ b/tests/test_relation_count_mismatch.py
@@ -13,22 +13,24 @@ from torch_geometric.data import HeteroData
 from src.models.gnn.encoder import RGCNEncoder
 
 
-def _make_graph(path: Path, feat_dim: int) -> None:
+def _make_graph(path: Path, rels: list[str]) -> None:
     g = HeteroData()
-    g["n"].x = torch.randn(2, feat_dim)
+    g["n"].x = torch.randn(2, 4)
     g["n"].num_nodes = 2
-    ei = torch.tensor([[0, 1], [1, 0]])
-    g[("n", "r0", "n")].edge_index = ei
-    g[("n", "r0", "n")].edge_type = torch.zeros(ei.size(1), dtype=torch.long)
+    for r in rels:
+        ei = torch.tensor([[0, 1], [1, 0]])
+        g[("n", r, "n")].edge_index = ei
+        idx = int(r[1:]) if r.startswith("r") else 0
+        g[("n", r, "n")].edge_type = torch.full((ei.size(1),), idx, dtype=torch.long)
     torch.save(g, path)
 
 
-def test_auto_reinit_with_meta(tmp_path, caplog):
+def test_relation_mismatch_raises(tmp_path):
     data_root = tmp_path / "data"
     for split in ("train", "val"):
         gdir = data_root / split / "graphs"
         gdir.mkdir(parents=True)
-        _make_graph(gdir / "a.pt", 6)
+        _make_graph(gdir / "a.pt", ["r0", "r1"])
         (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
 
     enc = RGCNEncoder(
@@ -41,15 +43,10 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
     ckpt_path = tmp_path / "enc.pt"
     torch.save({"model": enc.state_dict()}, ckpt_path)
 
-    meta_path = tmp_path / "enc.meta.pkl"
-    torch.save({"node_types": ["n"], "edge_types": [("n", "r0", "n")], "in_dims": {"n": 4}}, meta_path)
-
     argv = [
         "train_res_gcl",
         "--encoder-checkpoint",
         str(ckpt_path),
-        "--meta-path",
-        str(meta_path),
         "--splits-dir",
         str(data_root),
         "--epochs",
@@ -63,13 +60,10 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
     ]
 
     mod = importlib.import_module("src.cli.train_res_gcl")
-    caplog.set_level("INFO")
     orig_argv = sys.argv
     sys.argv = argv
     try:
-        mod.main()
+        with pytest.raises(ValueError, match="Relation count mismatch"):
+            mod.main()
     finally:
         sys.argv = orig_argv
-
-    assert any("reinitializing" in rec.message or "dimension mismatch" in rec.message for rec in caplog.records)
-    assert any("Epoch 1" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- load relation count from meta snapshots
- verify dataset relation count after encoder reinit
- save `num_relations` in pretraining metadata
- adjust CLI relation checks
- update test helpers and add a new mismatch test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863099089b8832e918835728680dec9