### PR TITLE
Add metadata mismatch tests and strict mode

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -477,6 +477,7 @@ def collect_dataset_metadata(
     ds: "Dataset | Sequence[Dataset]",
     *,
     attr_dim: int = 0,
+    strict: bool = False,
 ) -> tuple[
     tuple[list[str], list[tuple[str, str, str]]],
     dict[str, int],
@@ -494,6 +495,10 @@ def collect_dataset_metadata(
         Embedding dimensionality for metadata attributes. ``in_dims`` will be
         computed as ``feat_dim + len(attr_names) * attr_dim`` per node type.
 
+    strict:
+        When ``True`` raise ``ValueError`` if a graph contains an ``edge_type``
+        index outside the known range.
+
     Returns
     -------
     metadata, in_dims, attr_names
@@ -504,6 +509,7 @@ def collect_dataset_metadata(
     """
 
     from torch_geometric.data import HeteroData
+    from ..normalizers.schema import EDGE_TYPES
 
     datasets = [ds] if isinstance(ds, GraphDataset) else list(ds)
 
@@ -555,6 +561,9 @@ def collect_dataset_metadata(
                 for et in g.edge_types:
                     et_vals = g[et].edge_type
                     if et_vals.numel() > 0:
+                        if strict:
+                            if et_vals.min() < 0 or et_vals.max() >= len(EDGE_TYPES):
+                                raise ValueError("invalid edge_type index")
                         relation_ids.update(map(int, et_vals.tolist()))
         if relation_ids:
             num_relations = max(relation_ids) + 1
@@ -562,8 +571,6 @@ def collect_dataset_metadata(
             num_relations = 0
     else:
         num_relations = 0
-
-    from ..normalizers.schema import EDGE_TYPES
 
     # ensure at least all schema relations are represented
     num_relations = max(num_relations, len(EDGE_TYPES))

--- a/tests/test_metadata_mismatch.py
+++ b/tests/test_metadata_mismatch.py
@@ -1,0 +1,82 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+from src.graphs.dataset.graph_dataset import GraphDataset, collect_dataset_metadata
+
+
+def _make_graph(path: Path, rels: list[str], *, invalid_idx: int | None = None) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    for i, r in enumerate(rels):
+        ei = torch.tensor([[0, 1], [1, 0]])
+        g[("n", r, "n")].edge_index = ei
+        idx = invalid_idx if invalid_idx is not None and i == 0 else i
+        g[("n", r, "n")].edge_type = torch.full((ei.size(1),), idx, dtype=torch.long)
+    torch.save(g, path)
+
+
+def test_train_script_relation_mismatch(tmp_path):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", ["r0", "r1"])
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=( ["n"], [("n", "r0", "n")] ),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt_path = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt_path)
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        with pytest.raises(ValueError, match="Relation count mismatch"):
+            mod.main()
+    finally:
+        sys.argv = orig_argv
+
+
+def test_collect_metadata_strict_invalid(tmp_path):
+    gdir = tmp_path / "train" / "graphs"
+    gdir.mkdir(parents=True)
+    _make_graph(gdir / "a.pt", ["r0"], invalid_idx=99)
+    (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+    with pytest.raises(ValueError):
+        collect_dataset_metadata(ds, strict=True)
+


### PR DESCRIPTION
## Summary
- add `strict` option to `collect_dataset_metadata`
- test training script relation mismatch
- test strict metadata collection with invalid edge_type index

## Testing
- `pytest -q tests/test_metadata_mismatch.py`

------
https://chatgpt.com/codex/tasks/task_e_68630bdc258c832e91591afde651d8e9