### PR TITLE
Add relation count to meta loader

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -468,6 +468,12 @@ def main() -> None:
         )
         dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
         residual = hasattr(encoder.convs[0], "sublayer")
+        if meta_snapshot is not None and "num_relations" in meta_snapshot:
+            snap_rels = int(meta_snapshot["num_relations"])
+            snap_edges = [tuple(e) for e in meta_snapshot.get("edge_types", [])]
+            if len(snap_edges) < snap_rels:
+                snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
+            metadata = (metadata[0], snap_edges[:snap_rels])
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -247,6 +247,12 @@ def main(argv: list[str] | None = None) -> None:
         )
         dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
         residual = hasattr(encoder.convs[0], "sublayer")
+        if meta_snapshot is not None and "num_relations" in meta_snapshot:
+            snap_rels = int(meta_snapshot["num_relations"])
+            snap_edges = [tuple(e) for e in meta_snapshot.get("edge_types", [])]
+            if len(snap_edges) < snap_rels:
+                snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
+            metadata = (metadata[0], snap_edges[:snap_rels])
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,

--- a/tests/test_train_res_gcl_auto_reinit.py
+++ b/tests/test_train_res_gcl_auto_reinit.py
@@ -42,7 +42,15 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
     torch.save({"model": enc.state_dict()}, ckpt_path)
 
     meta_path = tmp_path / "enc.meta.pkl"
-    torch.save({"node_types": ["n"], "edge_types": [("n", "r0", "n")], "in_dims": {"n": 4}}, meta_path)
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n")],
+            "in_dims": {"n": 4},
+            "num_relations": 1,
+        },
+        meta_path,
+    )
 
     argv = [
         "train_res_gcl",
@@ -73,3 +81,63 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
 
     assert any("reinitializing" in rec.message or "dimension mismatch" in rec.message for rec in caplog.records)
     assert any("Epoch 1" in rec.message for rec in caplog.records)
+
+
+def test_meta_relation_count_used(tmp_path):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", 4)
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n"), ("n", "r1", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n"), ("n", "r1", "n")],
+            "in_dims": {"n": 4},
+            "num_relations": 2,
+        },
+        meta_path,
+    )
+
+    out_path = tmp_path / "model.pt"
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(out_path),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    state = torch.load(out_path)["model"]
+    assert state["encoder.convs.0.weight"].size(0) == 2


### PR DESCRIPTION
## Summary
- use `num_relations` from encoder meta snapshot when reinitializing
- test that relation count from meta info is respected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630bcbad70832ea459abbbd3681fe3