### PR TITLE
Add edge type validation in RGCNEncoder

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -163,12 +163,21 @@ class RGCNEncoder(nn.Module):
         # 3) RGCN layers on the homogeneous representation
         edge_index = homo.edge_index
         edge_type = homo.edge_type
-        max_rel = int(edge_type.max()) if edge_type.numel() > 0 else -1
         first_conv = getattr(self.convs[0], "sublayer", self.convs[0])
         num_rel = getattr(first_conv, "num_relations", 0)
+        if edge_type.numel() > 0:
+            min_rel = int(edge_type.min())
+            max_rel = int(edge_type.max())
+        else:
+            min_rel = 0
+            max_rel = -1
+        if min_rel < 0:
+            raise ValueError(
+                f"Invalid edge type index {min_rel} (< 0) for encoder"
+            )
         if max_rel >= num_rel:
             raise ValueError(
-                f"Unsupported edge type index {max_rel} for encoder"
+                f"Invalid edge type index {max_rel} (>= {num_rel}) for encoder"
             )
         for conv in self.convs:
             x = conv(x, edge_index, edge_type)  # type: ignore[arg-type]

--- a/tests/test_rgcn_edge_type_check.py
+++ b/tests/test_rgcn_edge_type_check.py
@@ -26,3 +26,33 @@ def test_forward_raises_on_unknown_relation():
 
     with pytest.raises(ValueError, match="edge type index 1"):
         enc(g)
+
+
+def test_forward_raises_on_negative_edge_type(monkeypatch):
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    g["n"].batch = torch.zeros(2, dtype=torch.long)
+    g[("n", "r0", "n")].edge_index = torch.tensor([[0], [1]])
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+
+    orig_to_homogeneous = HeteroData.to_homogeneous
+
+    def patched(self, *args, **kwargs):
+        homo = orig_to_homogeneous(self, *args, **kwargs)
+        homo.edge_type[0] = -1
+        return homo
+
+    monkeypatch.setattr(HeteroData, "to_homogeneous", patched)
+
+    with pytest.raises(ValueError, match="edge type index -1"):
+        enc(g)
+
+    monkeypatch.setattr(HeteroData, "to_homogeneous", orig_to_homogeneous)


### PR DESCRIPTION
## Summary
- validate `edge_type` indices inside `RGCNEncoder.forward`
- raise `ValueError` if indices are negative or exceed number of relations
- add unit test for negative edge type values

## Testing
- `pytest -q tests/test_rgcn_edge_type_check.py`
- `pytest -q` *(fails: ModuleNotFoundError: gensim, matplotlib, archinfo, sklearn, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68630dfc6bf0832eacf173a7b5faec35