### PR TITLE
Add meta snapshot saving and loading for RES-GCL

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -311,6 +311,17 @@ def main(argv: list[str] | None = None) -> None:
 
     ensure_dir(args.output.parent)
     torch.save({"model": model.state_dict()}, args.output)
+    meta_out = args.output.with_suffix(".meta.pkl")
+    meta_info = {
+        "node_types": list(metadata[0]),
+        "edge_types": [tuple(e) for e in metadata[1]],
+        "in_dims": {k: int(v) for k, v in in_dims.items()},
+        "num_relations": len(metadata[1]),
+    }
+    try:
+        torch.save(meta_info, meta_out)
+    except Exception as exc:  # pragma: no cover - I/O safeguard
+        LOGGER.warning("Failed to save meta snapshot: %s", exc)
     LOGGER.info("Saved model -> %s (best val loss %.4f)", args.output, best_val)
 
 

--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -27,6 +27,9 @@ probs = clf(data)                # (batch,)
 from __future__ import annotations
 
 from typing import Union, Optional, List, Dict, Callable
+from pathlib import Path
+from torch.serialization import add_safe_globals
+import logging
 
 import torch
 from torch import nn, Tensor
@@ -34,6 +37,10 @@ from torch import nn, Tensor
 from .layers.edge_smoothing import EdgeDropSmoothing
 from .heads import get_head, HEAD_REGISTRY  # registry helpers
 from .encoder import RGCNEncoder
+from src.graphs.normalizers.schema import NodeType
+from src.common.utils import get_logger
+
+LOGGER = get_logger(__name__)
 
 # --------------------------------------------------------------------------- #
 class RESGCLClassifier(nn.Module):
@@ -140,13 +147,60 @@ class RESGCLClassifier(nn.Module):
 
         if isinstance(obj, dict) and "model" in obj:
             state = obj["model"]
+            attr_names = obj.get("attr_names")
         elif isinstance(obj, dict):
             state = obj
+            attr_names = obj.get("attr_names")
         else:
             raise ValueError(f"Unrecognized checkpoint format: {path}")
 
         enc_state = {k[len("encoder."):]: v for k, v in state.items() if k.startswith("encoder.")}
-        encoder = RGCNEncoder._from_state_dict(enc_state)
+
+        meta_path = Path(path).with_suffix(".meta.pkl")
+        meta = None
+        if meta_path.is_file():
+            try:
+                add_safe_globals([NodeType])
+                meta = torch.load(meta_path, weights_only=False)
+                if isinstance(meta, dict):
+                    meta.setdefault("num_relations", len(meta.get("edge_types", [])))
+            except Exception as exc:  # pragma: no cover - I/O handling
+                LOGGER.warning("Failed to load meta snapshot %s: %s", meta_path, exc)
+                meta = None
+        else:
+            LOGGER.warning("Meta snapshot %s not found", meta_path)
+
+        if meta is not None:
+            node_types = list(meta.get("node_types", []))
+            edge_types = [tuple(e) for e in meta.get("edge_types", [])]
+            in_dims = {k: int(v) for k, v in meta.get("in_dims", {}).items()}
+            num_relations = int(meta.get("num_relations", len(edge_types)))
+
+            out_w = enc_state["out_proj.weight"]
+            out_dim = out_w.size(0)
+            hidden_dim = out_w.size(1)
+            conv_keys = [k for k in enc_state if k.startswith("convs.") and k.endswith(".weight")]
+            layer_ids = {int(k.split(".")[1]) for k in conv_keys}
+            num_layers = max(layer_ids) + 1 if layer_ids else 1
+            vocab_size = 0
+            attr_dim = 32
+            if "meta_embed.weight" in enc_state:
+                vocab_size = enc_state["meta_embed.weight"].size(0)
+                attr_dim = enc_state["meta_embed.weight"].size(1)
+
+            encoder = RGCNEncoder(
+                metadata=(node_types, edge_types[:num_relations]),
+                in_dims=in_dims,
+                attr_names=attr_names,
+                vocab_size=vocab_size,
+                attr_dim=attr_dim,
+                hidden_dim=hidden_dim,
+                num_layers=num_layers,
+                out_dim=out_dim,
+            )
+            encoder.load_state_dict(enc_state, strict=False)
+        else:
+            encoder = RGCNEncoder._from_state_dict(enc_state, attr_names=attr_names)
 
         model = cls(encoder=encoder)
         model.load_state_dict(state, strict=False)

--- a/tests/test_resgcl_load_meta.py
+++ b/tests/test_resgcl_load_meta.py
@@ -1,0 +1,54 @@
+import types
+import pytest
+
+pytest.importorskip("torch")
+
+import torch
+
+# stub modules for minimal encoder operations
+stub_tg = types.ModuleType("torch_geometric")
+stub_nn = types.ModuleType("torch_geometric.nn")
+
+class DummyRGCNConv(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, num_relations, num_bases):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(num_relations, in_channels, out_channels))
+    def forward(self, x, edge_index, edge_type):
+        return x
+
+def global_mean_pool(x, batch):
+    return x
+
+stub_nn.RGCNConv = DummyRGCNConv
+stub_nn.global_mean_pool = global_mean_pool
+stub_tg.nn = stub_nn
+import sys
+sys.modules.setdefault("torch_geometric", stub_tg)
+sys.modules.setdefault("torch_geometric.nn", stub_nn)
+
+from src.models.gnn.encoder import RGCNEncoder
+from src.models.gnn.res_wrapper import RESGCLClassifier
+
+
+def test_load_with_meta(tmp_path):
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    model = RESGCLClassifier(encoder=enc)
+    ckpt = tmp_path / "model.pt"
+    torch.save({"model": model.state_dict()}, ckpt)
+    meta = {
+        "node_types": ["n"],
+        "edge_types": [("n", "r0", "n")],
+        "in_dims": {"n": 4},
+        "num_relations": 1,
+    }
+    torch.save(meta, ckpt.with_suffix(".meta.pkl"))
+
+    loaded = RESGCLClassifier.load_from_checkpoint(ckpt)
+    assert isinstance(loaded.encoder, RGCNEncoder)
+    assert loaded.encoder.node_types == ["n"]

--- a/tests/test_train_res_gcl_auto_reinit.py
+++ b/tests/test_train_res_gcl_auto_reinit.py
@@ -52,6 +52,7 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
         meta_path,
     )
 
+    out_file = tmp_path / "model.pt"
     argv = [
         "train_res_gcl",
         "--encoder-checkpoint",
@@ -67,7 +68,7 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
         "--device",
         "cpu",
         "--output",
-        str(tmp_path / "model.pt"),
+        str(out_file),
     ]
 
     mod = importlib.import_module("src.cli.train_res_gcl")
@@ -81,6 +82,7 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
 
     assert any("reinitializing" in rec.message or "dimension mismatch" in rec.message for rec in caplog.records)
     assert any("Epoch 1" in rec.message for rec in caplog.records)
+    assert out_file.with_suffix(".meta.pkl").is_file()
 
 
 def test_meta_relation_count_used(tmp_path):
@@ -141,3 +143,4 @@ def test_meta_relation_count_used(tmp_path):
 
     state = torch.load(out_path)["model"]
     assert state["encoder.convs.0.weight"].size(0) == 2
+    assert out_path.with_suffix(".meta.pkl").is_file()


### PR DESCRIPTION
## Summary
- save encoder metadata when training RES-GCL
- improve `RESGCLClassifier.load_from_checkpoint` to use `.meta.pkl` snapshot
- check meta snapshot creation in tests
- add unit test for loading with meta information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630dfeaa30832e822c9cb322a99f6e