### PR TITLE
Add strict metadata validation and CLI option

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -86,6 +86,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Directory containing token embeddings",
     )
+    p.add_argument(
+        "--strict-metadata",
+        action="store_true",
+        help="Raise error on invalid edge_type indices in graphs",
+    )
 
     # Model / Training ------------------------------------------------------ #
     p.add_argument(
@@ -393,7 +398,9 @@ def main() -> None:
     from graphs.dataset import collect_dataset_metadata
 
     metadata, in_dims, attr_names = collect_dataset_metadata(
-        [train_dl.dataset, val_dl.dataset], attr_dim=encoder.attr_dim
+        [train_dl.dataset, val_dl.dataset],
+        attr_dim=encoder.attr_dim,
+        strict=args.strict_metadata,
     )
 
     node_order_mismatch = metadata[0] != encoder.node_types

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -586,6 +586,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--gpu", type=int, default=0, help="CUDA device id (‑1 ⇒ CPU)")
     p.add_argument("--num-workers", type=int, default=4)
     p.add_argument(
+        "--strict-metadata",
+        action="store_true",
+        help="Raise error on invalid edge_type indices in graphs",
+    )
+    p.add_argument(
         "--output", type=Path, required=True, help="Path to save encoder weights (\.pt)"
     )
     p.add_argument("--plot-path", type=Path, help="Path to save training plot (.png)")
@@ -657,7 +662,10 @@ def main():
     datasets = [train_ds] + ([val_ds] if val_ds is not None else [])
 
     params, target_node, meta_info = _load_model_hparams(
-        args.config, datasets, vocab_size=len(train_ds.vocab)
+        args.config,
+        datasets,
+        vocab_size=len(train_ds.vocab),
+        strict=args.strict_metadata,
     )
     model = SelfGraphCL(**params)
 
@@ -802,7 +810,11 @@ def main():
 
 
 def _load_model_hparams(
-    cfg_path: Path, datasets: Sequence[Dataset], *, vocab_size: int = 0
+    cfg_path: Path,
+    datasets: Sequence[Dataset],
+    *,
+    vocab_size: int = 0,
+    strict: bool = False,
 ) -> tuple[dict, str | None, dict]:
     """Return ``SelfGraphCL`` kwargs loaded from ``cfg_path`` and datasets.
 
@@ -842,7 +854,9 @@ def _load_model_hparams(
 
     attr_dim = int(model_cfg.get("attr_dim", 32))
     metadata, in_dims, attr_names = collect_dataset_metadata(
-        datasets, attr_dim=attr_dim
+        datasets,
+        attr_dim=attr_dim,
+        strict=strict,
     )
 
     # ensure API node/edge types for augmentation

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -63,6 +63,11 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Directory containing token embeddings")
     p.add_argument("--device", type=str, default="cuda")
     p.add_argument("--num-workers", type=int, default=0)
+    p.add_argument(
+        "--strict-metadata",
+        action="store_true",
+        help="Raise error on invalid edge_type indices in graphs",
+    )
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--output", type=Path, required=True,
                    help="Where to save trained model")
@@ -191,7 +196,9 @@ def main(argv: list[str] | None = None) -> None:
     from graphs.dataset import collect_dataset_metadata
 
     metadata, in_dims, attr_names = collect_dataset_metadata(
-        [train_dl.dataset, val_dl.dataset], attr_dim=encoder.attr_dim
+        [train_dl.dataset, val_dl.dataset],
+        attr_dim=encoder.attr_dim,
+        strict=args.strict_metadata,
     )
 
     g0, _, _ = train_dl.dataset[0]

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -60,6 +60,19 @@ GraphT = Data | HeteroData
 PathLike = str | Path
 
 _LOG = get_logger("dataset.graph")
+_META_LOG = get_logger("dataset.metadata")
+
+
+def _guess_graph_path(graph_dir: Path, sha: str) -> Path:
+    """Return an existing graph file path for *sha* under *graph_dir*."""
+    candidates = [graph_dir / f"{sha}.pt", graph_dir / f"{sha}.pyg.pkl"]
+    for view in ("ast", "cfg", "fcg", "sys"):
+        for ext in (".json", ".json.gz"):
+            candidates.append(graph_dir / f"{sha}.{view}{ext}")
+    for path in candidates:
+        if path.is_file():
+            return path
+    return graph_dir / f"{sha}"
 
 
 # ════════════════════════════════════════════════════════════════════════
@@ -554,17 +567,37 @@ def collect_dataset_metadata(
     total_len = sum(len(d) for d in datasets)
     if total_len > 0 and edge_types:
         relation_ids: set[int] = set()
+        invalid_found = False
         for d in datasets:
             for i in range(len(d)):
                 item = d[i]
                 g = item[0] if isinstance(item, tuple) else item
+                sha = item[2] if isinstance(item, tuple) and len(item) >= 3 else None
                 for et in g.edge_types:
                     et_vals = g[et].edge_type
                     if et_vals.numel() > 0:
-                        if strict:
-                            if et_vals.min() < 0 or et_vals.max() >= len(EDGE_TYPES):
-                                raise ValueError("invalid edge_type index")
+                        min_id = int(et_vals.min())
+                        max_id = int(et_vals.max())
+                        if min_id < 0 or max_id >= len(EDGE_TYPES):
+                            invalid_found = True
+                            if sha is not None and hasattr(d, "graph_dir"):
+                                path = _guess_graph_path(d.graph_dir, sha)
+                                _META_LOG.error(
+                                    "Invalid edge_type index in %s (min=%d max=%d)",
+                                    path,
+                                    min_id,
+                                    max_id,
+                                )
+                            else:
+                                _META_LOG.error(
+                                    "Invalid edge_type index in sample %s (min=%d max=%d)",
+                                    sha if sha is not None else i,
+                                    min_id,
+                                    max_id,
+                                )
                         relation_ids.update(map(int, et_vals.tolist()))
+        if strict and invalid_found:
+            raise ValueError("invalid edge_type index")
         if relation_ids:
             num_relations = max(relation_ids) + 1
         else:


### PR DESCRIPTION
## Summary
- detect invalid edge relation indices when collecting dataset metadata
- log offending graph file paths and raise on request
- expose `--strict-metadata` option in training/finetuning/pretraining CLIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630dec3bc8832eb34fd8edea64c101