### PR TITLE
Check edge_type range in dataset metadata

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -522,7 +522,7 @@ def collect_dataset_metadata(
     """
 
     from torch_geometric.data import HeteroData
-    from ..normalizers.schema import EDGE_TYPES
+    from ..normalizers.schema import EDGE_TYPES, EDGE_REL_ID
 
     datasets = [ds] if isinstance(ds, GraphDataset) else list(ds)
 
@@ -578,23 +578,16 @@ def collect_dataset_metadata(
                     if et_vals.numel() > 0:
                         min_id = int(et_vals.min())
                         max_id = int(et_vals.max())
-                        if min_id < 0 or max_id >= len(EDGE_TYPES):
+                        if min_id < 0 or max_id >= len(EDGE_REL_ID):
                             invalid_found = True
                             if sha is not None and hasattr(d, "graph_dir"):
                                 path = _guess_graph_path(d.graph_dir, sha)
-                                _META_LOG.error(
-                                    "Invalid edge_type index in %s (min=%d max=%d)",
-                                    path,
-                                    min_id,
-                                    max_id,
-                                )
                             else:
-                                _META_LOG.error(
-                                    "Invalid edge_type index in sample %s (min=%d max=%d)",
-                                    sha if sha is not None else i,
-                                    min_id,
-                                    max_id,
-                                )
+                                path = sha if sha is not None else str(i)
+                            msg = f"Invalid edge_type index in {path} (min={min_id} max={max_id})"
+                            _META_LOG.error(msg)
+                            if strict:
+                                raise ValueError(msg)
                         relation_ids.update(map(int, et_vals.tolist()))
         if strict and invalid_found:
             raise ValueError("invalid edge_type index")

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -28,6 +28,16 @@ def _make_graph(path: Path, rels: list[str]) -> None:
     torch.save(g, path)
 
 
+def _make_invalid_graph(path: Path, invalid_idx: int) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    ei = torch.tensor([[0, 1], [1, 0]])
+    g[("n", "r0", "n")].edge_index = ei
+    g[("n", "r0", "n")].edge_type = torch.full((ei.size(1),), invalid_idx, dtype=torch.long)
+    torch.save(g, path)
+
+
 def test_extra_edge_types(tmp_path, caplog):
     data_root = tmp_path / "data"
     for split in ("train", "val"):
@@ -180,4 +190,20 @@ def test_val_extra_relation(tmp_path, caplog):
         sys.argv = orig_argv
 
     assert any("Epoch 1" in rec.message for rec in caplog.records)
+
+
+def test_collect_metadata_invalid_edge_type_detail(tmp_path):
+    gdir = tmp_path / "train" / "graphs"
+    gdir.mkdir(parents=True)
+
+    from src.graphs.normalizers import schema
+
+    _make_invalid_graph(gdir / "a.pt", len(schema.EDGE_REL_ID))
+
+    (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\n")
+
+    ds = GraphDataset(tmp_path, split="train", require_labels=True)
+
+    with pytest.raises(ValueError, match="a.pt"):
+        collect_dataset_metadata(ds, strict=True)
 


### PR DESCRIPTION
## Summary
- ensure `collect_dataset_metadata` validates edge_type values against `EDGE_REL_ID`
- include the offending file name in the raised error
- add test covering this invalid edge type case

## Testing
- `pytest -k collect_dataset_metadata -q`

------
https://chatgpt.com/codex/tasks/task_e_68630f6c8058832ea442fd04e173f176