### PR TITLE
Add encoder metadata validation

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -397,11 +397,13 @@ def main() -> None:
 
     from graphs.dataset import collect_dataset_metadata
 
-    metadata, in_dims, attr_names = collect_dataset_metadata(
+    dataset_metadata, in_dims, attr_names = collect_dataset_metadata(
         [train_dl.dataset, val_dl.dataset],
         attr_dim=encoder.attr_dim,
         strict=args.strict_metadata,
     )
+
+    metadata = dataset_metadata
 
     node_order_mismatch = metadata[0] != encoder.node_types
     if node_order_mismatch:
@@ -501,16 +503,18 @@ def main() -> None:
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
 
-    dataset_rels = len(metadata[1])
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)
-    if dataset_rels != model_rels:
+    if (
+        encoder.node_types != list(dataset_metadata[0])
+        or model_rels != len(dataset_metadata[1])
+    ):
         msg = (
-            f"Relation count mismatch: dataset has {dataset_rels} relations "
-            f"but encoder expects {model_rels}"
+            "Dataset metadata incompatible with checkpoint; "
+            "rerun preprocessing or use --force-reinit"
         )
         LOGGER.error(msg)
-        raise ValueError(msg)
+        raise RuntimeError(msg)
 
     # Optional: check whether dataset provides required metadata attributes
     g0, _, _ = train_dl.dataset[0]

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -195,11 +195,15 @@ def main(argv: list[str] | None = None) -> None:
 
     from graphs.dataset import collect_dataset_metadata
 
-    metadata, in_dims, attr_names = collect_dataset_metadata(
+    dataset_metadata, in_dims, attr_names = collect_dataset_metadata(
         [train_dl.dataset, val_dl.dataset],
         attr_dim=encoder.attr_dim,
         strict=args.strict_metadata,
     )
+
+    # ``metadata`` may be adjusted later based on the checkpoint snapshot. Keep
+    # the raw dataset metadata for validation after reinitialisation.
+    metadata = dataset_metadata
 
     g0, _, _ = train_dl.dataset[0]
 
@@ -278,16 +282,18 @@ def main(argv: list[str] | None = None) -> None:
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
 
-    dataset_rels = len(metadata[1])
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)
-    if dataset_rels != model_rels:
+    if (
+        encoder.node_types != list(dataset_metadata[0])
+        or model_rels != len(dataset_metadata[1])
+    ):
         msg = (
-            f"Relation count mismatch: dataset has {dataset_rels} relations "
-            f"but encoder expects {model_rels}"
+            "Dataset metadata incompatible with checkpoint; "
+            "rerun preprocessing or use --force-reinit"
         )
         LOGGER.error(msg)
-        raise ValueError(msg)
+        raise RuntimeError(msg)
     if args.head_checkpoint:
         state = torch.load(args.head_checkpoint, map_location=device)
         head_state = {

--- a/tests/test_train_res_gcl_auto_reinit.py
+++ b/tests/test_train_res_gcl_auto_reinit.py
@@ -144,3 +144,61 @@ def test_meta_relation_count_used(tmp_path):
     state = torch.load(out_path)["model"]
     assert state["encoder.convs.0.weight"].size(0) == 2
     assert out_path.with_suffix(".meta.pkl").is_file()
+
+
+def test_reinit_metadata_mismatch_error(tmp_path):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", 4)
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n"), ("n", "r1", "n")],
+            "in_dims": {"n": 4},
+            "num_relations": 2,
+        },
+        meta_path,
+    )
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "out.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        with pytest.raises(RuntimeError,
+                           match="Dataset metadata incompatible"):
+            mod.main()
+    finally:
+        sys.argv = orig_argv


### PR DESCRIPTION
## Summary
- validate node and relation metadata after encoder reinit
- propagate the check to finetune_supcon CLI
- add regression test ensuring mismatch raises an error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630f6705f8832ea59c1e004b524b65