### PR TITLE
Support token embeddings in SelfGCL dataset

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -28,6 +28,7 @@ import argparse
 import json
 from pathlib import Path
 from typing import Sequence
+import warnings
 from collections import defaultdict
 import logging
 import numpy as np
@@ -41,6 +42,7 @@ from torch_geometric.loader import DataLoader as PyGLoader
 
 # Project internal imports ----------------------------------------------------
 from common.utils import set_random_seed, get_logger, ensure_dir
+from graphs.features.cache import load_tensor
 from src.graphs.normalizers.schema import NodeType, EdgeRel, NODE_ATTRS
 from augment.ops.inject_call import InjectAPICall
 from augment import auto_aug  # noqa: F401 (registers policies)
@@ -65,8 +67,19 @@ class HeteroGraphDiskDataset(InMemoryDataset):
     #: Shared vocabulary path used when encoding string metadata.
     VOCAB_PATH = Path("models/token_vocab.json")
 
-    def __init__(self, root: str | Path, sha_list: Sequence[str] | None = None):
+    def __init__(
+        self,
+        root: str | Path,
+        sha_list: Sequence[str] | None = None,
+        *,
+        load_embeds: bool = True,
+        embed_dir: Path | None = None,
+    ):
         self.sha_list = set(sha_list) if sha_list else None
+        self.load_embeds = load_embeds
+        self.embed_dir = (
+            Path(embed_dir) if embed_dir is not None else Path(root) / "embeds"
+        )
         super().__init__(root)
         if self.VOCAB_PATH.is_file():
             with open(self.VOCAB_PATH, "r", encoding="utf-8") as f:
@@ -84,11 +97,15 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             self._metadata = None
 
         loaded = torch.load(self.processed_paths[0], weights_only=False)
-        if isinstance(loaded, (list, tuple)) and len(loaded) == 3:
+        if isinstance(loaded, (list, tuple)) and len(loaded) == 4:
+            self._data, self.slices, self.graph_meta, self.names = loaded
+        elif isinstance(loaded, (list, tuple)) and len(loaded) == 3:
             self._data, self.slices, self.graph_meta = loaded
+            self.names = [p.stem for p in sorted(Path(self.root).glob("*.pt"))]
         else:  # Backwards compatibility
             self._data, self.slices = loaded
             self.graph_meta = None
+            self.names = [p.stem for p in sorted(Path(self.root).glob("*.pt"))]
 
         # Ensure every stored graph has an ``.x`` attribute for each node type.
         # Some legacy datasets only provide ``.feat`` which breaks newer
@@ -134,7 +151,32 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                     pass
             if not hasattr(data, "x") and hasattr(data, "feat"):
                 data.x = data.feat
+        sha = self.names[idx] if idx < len(self.names) else None
+        if sha is not None:
+            data = self._attach_embeds(sha, data)
         return data
+
+    def _attach_embeds(self, sha: str, g: Data | HeteroData) -> Data | HeteroData:
+        if not self.load_embeds:
+            return g
+        embed_file = self.embed_dir / f"{sha}.ftr"
+        if not embed_file.is_file():
+            return g
+        if not isinstance(g, HeteroData) or NodeType.TOKEN.value not in g.node_types:
+            return g
+        try:
+            feat = load_tensor(sha, self.embed_dir)
+        except Exception as exc:  # pragma: no cover - unexpected I/O errors
+            warnings.warn(f"failed to load embed for {sha}: {exc}")
+            return g
+        store = g[NodeType.TOKEN.value]
+        if hasattr(store, "x"):
+            store.x = feat
+        elif hasattr(store, "feat"):
+            store.feat = feat
+        else:
+            store.x = feat
+        return g
 
     @property
     def processed_file_names(self) -> list[str]:
@@ -209,9 +251,13 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 stores = {"": g}
 
             for ntype, st in stores.items():
-                allowed = (
-                    set(NODE_ATTRS.get(NodeType(ntype), ())) if ntype else None
-                )
+                if ntype:
+                    try:
+                        allowed = set(NODE_ATTRS.get(NodeType(ntype), ()))
+                    except ValueError:
+                        allowed = None
+                else:
+                    allowed = None
                 meta = getattr(st, "meta", {})
                 if isinstance(meta, str):
                     try:
@@ -229,9 +275,9 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                     if isinstance(val, str):
                         if attr == "addr" and val.lower().startswith("0x"):
                             try:
-                                st[attr] = torch.tensor([
-                                    int(val, 16)
-                                ], dtype=torch.long)
+                                st[attr] = torch.tensor(
+                                    [int(val, 16)], dtype=torch.long
+                                )
                             except ValueError:
                                 meta[attr] = val
                                 st[attr + "_id"] = torch.tensor(
@@ -363,24 +409,27 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         if isinstance(tmpl, torch.Tensor):
                             if tmpl.dim() == 2:
                                 dim = max_dim.get((ntype, attr), tmpl.size(1))
-                                store[attr] = torch.zeros((num_nodes, dim), dtype=tmpl.dtype)
+                                store[attr] = torch.zeros(
+                                    (num_nodes, dim), dtype=tmpl.dtype
+                                )
                             else:
-                                store[attr] = torch.zeros((num_nodes,), dtype=tmpl.dtype)
+                                store[attr] = torch.zeros(
+                                    (num_nodes,), dtype=tmpl.dtype
+                                )
                         elif isinstance(tmpl, Sequence):
                             store[attr] = []
                         else:
                             store[attr] = torch.zeros((num_nodes,), dtype=torch.long)
-                        msg = (
-                            "Filled missing attribute '%s' for node type '%s' in graph %s"
-                        )
+                        msg = "Filled missing attribute '%s' for node type '%s' in graph %s"
                         LOGGER.warning(msg, attr, ntype, path)
                         logging.getLogger().warning(msg, attr, ntype, path)
-                    allowed = set(NODE_ATTRS.get(NodeType(ntype), ()))
+                    try:
+                        allowed = set(NODE_ATTRS.get(NodeType(ntype), ()))
+                    except ValueError:
+                        allowed = set()
                     if "addr" in allowed and "addr" not in store:
                         store["addr"] = torch.zeros((num_nodes,), dtype=torch.long)
-                        msg = (
-                            "Added missing attribute 'addr' for node type '%s' in graph %s"
-                        )
+                        msg = "Added missing attribute 'addr' for node type '%s' in graph %s"
                         LOGGER.warning(msg, ntype, path)
                         logging.getLogger().warning(msg, ntype, path)
             else:
@@ -404,6 +453,15 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         attr,
                         path,
                     )
+
+        # --- ensure all graphs have every edge type ---
+        for g in data_list:
+            if not isinstance(g, HeteroData):
+                continue
+            for et in edge_types:
+                if et not in g.edge_types:
+                    g[et].edge_index = torch.empty((2, 0), dtype=torch.long)
+                    g[et].edge_type = torch.empty((0,), dtype=torch.long)
 
         # --- pad each tensor attribute to the maximum dimension ---
         for g in data_list:
@@ -448,7 +506,8 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                 f"Collation failed due to missing attribute '{missing_attr}'. "
                 "Some node features may be missing."
             ) from exc
-        torch.save((data, slices, meta_list), self.processed_paths[0])
+        names = [p.stem for p in source_paths]
+        torch.save((data, slices, meta_list, names), self.processed_paths[0])
         meta_path = Path(self.processed_dir) / "metadata.pkl"
         self._metadata = (tuple(node_types), tuple(edge_types))
         try:
@@ -456,6 +515,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
         except Exception as exc:  # pragma: no cover - safeguard
             LOGGER.warning("Failed to save metadata: %s", exc)
         self.graph_meta = meta_list
+        self.names = names
 
 
 def validate_dataset(dataset: HeteroGraphDiskDataset) -> bool:
@@ -488,11 +548,19 @@ def validate_dataset(dataset: HeteroGraphDiskDataset) -> bool:
             LOGGER.warning("Attribute set mismatch in %s", p)
             ok = False
     if not ok:
-        LOGGER.warning("Dataset has inconsistent attributes. Run with --reprocess to rebuild.")
+        LOGGER.warning(
+            "Dataset has inconsistent attributes. Run with --reprocess to rebuild."
+        )
     if dataset.metadata is not None and max_rel_index >= 0:
         num_relations = len(dataset.metadata[1])
         if max_rel_index >= num_relations:
             LOGGER.error(
+                "Edge relation index %d out of range (metadata defines %d relations). "
+                "Re-run with --reprocess to rebuild metadata.",
+                max_rel_index,
+                num_relations,
+            )
+            logging.getLogger().error(
                 "Edge relation index %d out of range (metadata defines %d relations). "
                 "Re-run with --reprocess to rebuild metadata.",
                 max_rel_index,

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -8,10 +8,19 @@ pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
 import torch
+import torch.serialization as torch_serial
 from torch_geometric.data import HeteroData
 from torch_geometric.loader import DataLoader
 
+if not hasattr(torch_serial, "add_safe_globals"):
+
+    def add_safe_globals(objs):
+        pass
+
+    torch_serial.add_safe_globals = add_safe_globals
+
 from src.cli.pretrain_selfgcl import HeteroGraphDiskDataset, validate_dataset
+from src.graphs.features.cache import save_tensor
 
 
 def test_hetero_disk_dataset_meta(tmp_path, monkeypatch):
@@ -293,3 +302,45 @@ def test_validate_dataset_relation_index(tmp_path, monkeypatch, caplog):
         ok = validate_dataset(ds)
     assert not ok
     assert any("reprocess" in rec.message.lower() for rec in caplog.records)
+
+
+def test_load_embeds(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g = HeteroData()
+    g["token"].num_nodes = 2
+    torch.save(g, graph_dir / "a.pt")
+
+    feat = torch.randn(2, 3)
+    save_tensor("a", feat, tmp_path / "embeds")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(
+        graph_dir, load_embeds=True, embed_dir=tmp_path / "embeds"
+    )
+    data = ds[0]
+    assert torch.allclose(data["token"].x, feat)
+
+
+def test_disable_embeds(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g = HeteroData()
+    g["token"].num_nodes = 1
+    torch.save(g, graph_dir / "a.pt")
+
+    feat = torch.randn(1, 2)
+    save_tensor("a", feat, tmp_path / "embeds")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(
+        graph_dir, load_embeds=False, embed_dir=tmp_path / "embeds"
+    )
+    data = ds[0]
+    assert not hasattr(data["token"], "x")


### PR DESCRIPTION
## Summary
- allow specifying token embedding directory and loading flag in `HeteroGraphDiskDataset`
- preserve original graph file names when processing for embedding lookup
- attach token embeddings when returning graphs
- fill in missing edge types when processing
- extend dataset tests for optional embedding loading

## Testing
- `pytest tests/test_selfgcl_dataset.py::test_metadata_file_saved tests/test_selfgcl_dataset.py::test_validate_dataset_relation_index -q`
- `pytest tests/test_selfgcl_dataset.py::test_load_embeds tests/test_selfgcl_dataset.py::test_disable_embeds -q`
- `pytest tests/test_selfgcl_dataset.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'archinfo')*

------
https://chatgpt.com/codex/tasks/task_e_68632c48e074832e84a8485367b3eee4