### PR TITLE
Support copying comp matrices

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -297,6 +297,54 @@ def filter_state_dict(
                 logger.info("copied %d/%d relations from checkpoint", copy_rel, old_rel)
                 continue
 
+            if (
+                k.startswith("convs")
+                and k.endswith(".comp")
+                and v.dim() == 2
+                and target.dim() == 2
+            ):
+                if v.shape[0] == v.shape[1] and target.shape[0] == target.shape[1]:
+                    old_rel = v.size(0)
+                    new_rel = target.size(0)
+                    copy_rel = min(old_rel, new_rel)
+                    if copy_rel == 0:
+                        logger.warning(
+                            "Ignoring checkpoint parameter '%s' with zero relations to copy",
+                            k,
+                        )
+                        continue
+                    new_comp = target.clone()
+                    new_comp[:copy_rel, :copy_rel] = v[:copy_rel, :copy_rel]
+                    filtered[k] = new_comp
+                    logger.info(
+                        "copied %d/%d relations from checkpoint", copy_rel, old_rel
+                    )
+                    continue
+
+                old_bases = v.size(0)
+                new_bases = target.size(0)
+                old_rel = v.size(1)
+                new_rel = target.size(1)
+                copy_bases = min(old_bases, new_bases)
+                copy_rel = min(old_rel, new_rel)
+                if copy_bases == 0 or copy_rel == 0:
+                    logger.warning(
+                        "Ignoring checkpoint parameter '%s' with zero bases/relations to copy",
+                        k,
+                    )
+                    continue
+                new_comp = target.clone()
+                new_comp[:copy_bases, :copy_rel] = v[:copy_bases, :copy_rel]
+                filtered[k] = new_comp
+                logger.info(
+                    "copied %d/%d bases and %d/%d relations from checkpoint",
+                    copy_bases,
+                    old_bases,
+                    copy_rel,
+                    old_rel,
+                )
+                continue
+
             logger.warning(
                 "Ignoring checkpoint parameter '%s' with shape %s (expected %s)",
                 k,

--- a/tests/test_filter_state_dict_rgcnconv.py
+++ b/tests/test_filter_state_dict_rgcnconv.py
@@ -17,6 +17,7 @@ class DummyRGCNConv(torch.nn.Module):
         self.weight = torch.nn.Parameter(
             torch.randn(num_relations, in_channels, out_channels)
         )
+        self.comp = torch.nn.Parameter(torch.randn(num_relations, num_relations))
 
     def forward(self, x, edge_index, edge_type):  # pragma: no cover
         return x
@@ -29,6 +30,21 @@ sys.modules.setdefault("torch_geometric.nn", stub_nn)
 
 from src.models.gnn.encoder import RGCNEncoder
 from src.common.utils import filter_state_dict
+
+
+class DummyCompConv(torch.nn.Module):
+    def __init__(self, rels: int, bases: int) -> None:
+        super().__init__()
+        self.comp = torch.nn.Parameter(torch.randn(bases, rels))
+
+    def forward(self, x):  # pragma: no cover - unused
+        return x
+
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self, rels: int, bases: int) -> None:
+        super().__init__()
+        self.convs = torch.nn.ModuleList([DummyCompConv(rels, bases)])
 
 
 def test_filter_rgcnconv_partial_copy(caplog):
@@ -56,4 +72,21 @@ def test_filter_rgcnconv_partial_copy(caplog):
 
     w_key = "convs.0.weight"
     assert torch.allclose(filtered[w_key], state[w_key][:1])
-    assert f"copied 1/3 relations" in caplog.text
+    c_key = "convs.0.comp"
+    assert torch.allclose(filtered[c_key], state[c_key][:1, :1])
+    assert caplog.text.count("copied 1/3 relations") == 2
+
+
+def test_filter_comp_rectangular(caplog):
+    old = SimpleModel(rels=3, bases=2)
+    new = SimpleModel(rels=1, bases=2)
+
+    state = old.state_dict()
+    logger = logging.getLogger("test")
+    caplog.set_level("INFO", logger="test")
+    filtered = filter_state_dict(new, state, logger=logger)
+
+    key = "convs.0.comp"
+    assert filtered[key].shape == (2, 1)
+    assert torch.allclose(filtered[key], state[key][:2, :1])
+    assert "bases and" in caplog.text


### PR DESCRIPTION
## Summary
- expand `filter_state_dict` to handle `.comp` params for RGCNConv
- test partial copying of square and rectangular `.comp` matrices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686330055760832e8c499e1a989e9e6e