### PR TITLE
Fix force-reinit relation handling

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -494,12 +494,19 @@ def main() -> None:
         )
         dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
         residual = hasattr(encoder.convs[0], "sublayer")
-        if meta_snapshot is not None and "num_relations" in meta_snapshot:
+        if (
+            meta_snapshot is not None
+            and "num_relations" in meta_snapshot
+            and not args.force_reinit
+        ):
             snap_rels = int(meta_snapshot["num_relations"])
             snap_edges = [tuple(e) for e in meta_snapshot.get("edge_types", [])]
             if len(snap_edges) < snap_rels:
-                snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
+                snap_edges.extend(metadata[1][len(snap_edges) : snap_rels])
             metadata = (metadata[0], snap_edges[:snap_rels])
+        elif args.force_reinit:
+            # rebuild using dataset metadata regardless of snapshot relations
+            metadata = dataset_metadata
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,
@@ -524,7 +531,7 @@ def main() -> None:
     model_rels = first_conv.weight.size(0)
     if (
         encoder.node_types != list(dataset_metadata[0])
-        or model_rels != len(dataset_metadata[1])
+        or (model_rels != len(dataset_metadata[1]) and not args.force_reinit)
     ):
         msg = (
             "Dataset metadata incompatible with checkpoint; "

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -258,12 +258,18 @@ def main(argv: list[str] | None = None) -> None:
         )
         dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
         residual = hasattr(encoder.convs[0], "sublayer")
-        if meta_snapshot is not None and "num_relations" in meta_snapshot:
+        if (
+            meta_snapshot is not None
+            and "num_relations" in meta_snapshot
+            and not args.force_reinit
+        ):
             snap_rels = int(meta_snapshot["num_relations"])
             snap_edges = [tuple(e) for e in meta_snapshot.get("edge_types", [])]
             if len(snap_edges) < snap_rels:
-                snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
+                snap_edges.extend(metadata[1][len(snap_edges) : snap_rels])
             metadata = (metadata[0], snap_edges[:snap_rels])
+        elif args.force_reinit:
+            metadata = dataset_metadata
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,
@@ -286,7 +292,7 @@ def main(argv: list[str] | None = None) -> None:
     model_rels = first_conv.weight.size(0)
     if (
         encoder.node_types != list(dataset_metadata[0])
-        or model_rels != len(dataset_metadata[1])
+        or (model_rels != len(dataset_metadata[1]) and not args.force_reinit)
     ):
         msg = (
             "Dataset metadata incompatible with checkpoint; "


### PR DESCRIPTION
## Summary
- ignore snapshot relation counts when forcing encoder reinitialisation
- relax compatibility check with `--force-reinit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686341c56094832eb64f553d1baa36b5