### PR TITLE
Validate embed input directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python -m cli.preprocessing --input-dir data/hetero --out . splits --fallback ra
 # 학습, 평가, 테스트 데이터 분할
 
 python -m cli.preprocessing --input-dir data/hetero --out . embeds --model-name microsoft/codebert-base --batch-size 64 --device cuda
-# graphs 단계에서 생성한 hetero 그래프가 필요합니다.
+# graphs 단계에서 생성한 hetero 그래프(`data/hetero`)가 필요합니다.
 
 python -m cli.pretrain_selfgcl data/hetero \
     --splits split_fold.json \

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -317,13 +317,23 @@ def run_embeds(args: argparse.Namespace) -> None:
     logger = _get_logger(args.log_level)
     logger.info("[EMBEDS] model=%s  device=%s", args.model_name, args.device)
     try:
+        hetero_dir = Path(args.out_dir, "data", "hetero")
+        if args.input_dir:
+            user_dir = Path(args.input_dir, "hetero")
+            if user_dir.resolve() != hetero_dir.resolve():
+                logger.error(
+                    "[EMBEDS] input-dir %s does not match expected %s",
+                    user_dir,
+                    hetero_dir,
+                )
+                raise StageError("Incorrect input directory for embed stage")
         encoder = CodeLLMNodeFeat(model_name=args.model_name)
         encoder.to(args.device)
         embeds_dir = Path(args.out_dir, "data", "embeds")
         ensure_dir(embeds_dir)
         embed_corpus(
             encoder,
-            hetero_dir=Path(args.out_dir, "data", "hetero"),
+            hetero_dir=hetero_dir,
             out_dir=embeds_dir,
             batch_size=args.batch_size,
             overwrite=args.overwrite,


### PR DESCRIPTION
## Summary
- validate the `embeds` stage input directory so it matches `OUT/data/hetero`
- clarify README example about using `data/hetero`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686341d04d18832eb0d26fbab33db347