### PR TITLE
Improve dataset mismatch logging

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -522,12 +522,15 @@ def main() -> None:
 
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)
-    if (
-        encoder.node_types != list(dataset_metadata[0])
-        or model_rels != len(dataset_metadata[1])
-    ):
+    dataset_ntypes = list(dataset_metadata[0])
+    dataset_rels = len(dataset_metadata[1])
+    if encoder.node_types != dataset_ntypes or model_rels != dataset_rels:
+        detail = (
+            f"node_types checkpoint={encoder.node_types} dataset={dataset_ntypes}; "
+            f"relations checkpoint={model_rels} dataset={dataset_rels}"
+        )
         msg = (
-            "Dataset metadata incompatible with checkpoint; "
+            "Dataset metadata incompatible with checkpoint (" + detail + "); "
             "rerun preprocessing or use --force-reinit"
         )
         LOGGER.error(msg)

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -284,12 +284,15 @@ def main(argv: list[str] | None = None) -> None:
 
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)
-    if (
-        encoder.node_types != list(dataset_metadata[0])
-        or model_rels != len(dataset_metadata[1])
-    ):
+    dataset_ntypes = list(dataset_metadata[0])
+    dataset_rels = len(dataset_metadata[1])
+    if encoder.node_types != dataset_ntypes or model_rels != dataset_rels:
+        detail = (
+            f"node_types checkpoint={encoder.node_types} dataset={dataset_ntypes}; "
+            f"relations checkpoint={model_rels} dataset={dataset_rels}"
+        )
         msg = (
-            "Dataset metadata incompatible with checkpoint; "
+            "Dataset metadata incompatible with checkpoint (" + detail + "); "
             "rerun preprocessing or use --force-reinit"
         )
         LOGGER.error(msg)


### PR DESCRIPTION
## Summary
- show detailed mismatch info when the dataset metadata and checkpoint differ

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686341c56a64832eb0eb94271fd7889d