### PR TITLE
Fix force reinit relation handling

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -494,7 +494,11 @@ def main() -> None:
         )
         dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
         residual = hasattr(encoder.convs[0], "sublayer")
-        if meta_snapshot is not None and "num_relations" in meta_snapshot:
+        if (
+            meta_snapshot is not None
+            and "num_relations" in meta_snapshot
+            and not args.force_reinit
+        ):
             snap_rels = int(meta_snapshot["num_relations"])
             snap_edges = [tuple(e) for e in meta_snapshot.get("edge_types", [])]
             if len(snap_edges) < snap_rels:
@@ -519,6 +523,7 @@ def main() -> None:
         filtered = filter_state_dict(new_enc, state, logger=LOGGER)
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
+        dataset_metadata = metadata
 
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -258,7 +258,11 @@ def main(argv: list[str] | None = None) -> None:
         )
         dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
         residual = hasattr(encoder.convs[0], "sublayer")
-        if meta_snapshot is not None and "num_relations" in meta_snapshot:
+        if (
+            meta_snapshot is not None
+            and "num_relations" in meta_snapshot
+            and not args.force_reinit
+        ):
             snap_rels = int(meta_snapshot["num_relations"])
             snap_edges = [tuple(e) for e in meta_snapshot.get("edge_types", [])]
             if len(snap_edges) < snap_rels:
@@ -281,6 +285,7 @@ def main(argv: list[str] | None = None) -> None:
         filtered = filter_state_dict(new_enc, state, logger=LOGGER)
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
+        dataset_metadata = metadata
 
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)

--- a/tests/test_finetune_force_reinit_relation.py
+++ b/tests/test_finetune_force_reinit_relation.py
@@ -1,0 +1,90 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path, rels: list[str]) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    for i, r in enumerate(rels):
+        ei = torch.tensor([[0, 1], [1, 0]])
+        g[("n", r, "n")].edge_index = ei
+        g[("n", r, "n")].edge_type = torch.full((ei.size(1),), i, dtype=torch.long)
+    torch.save(g, path)
+
+
+def test_force_reinit_ignores_meta_rel_count(tmp_path, caplog):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", ["r0", "r1", "r2", "r3"])
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [
+                ("n", "r0", "n"),
+                ("n", "r1", "n"),
+                ("n", "r2", "n"),
+                ("n", "r3", "n"),
+            ],
+            "in_dims": {"n": 4},
+            "num_relations": 5,
+        },
+        meta_path,
+    )
+
+    logdir = tmp_path / "log"
+    argv = [
+        "finetune_supcon",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--logdir",
+        str(logdir),
+        "--force-reinit",
+    ]
+
+    mod = importlib.import_module("src.cli.finetune_supcon")
+    caplog.set_level("INFO")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert any("Epoch 1" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- ignore meta snapshot relation count when `--force-reinit` is given
- keep `dataset_metadata` synced after encoder reinit
- test that `finetune_supcon` runs when snapshot relation count exceeds dataset relations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68634335876c832eb4a985a87019a199