### PR TITLE
Fix head registry imports

### DIFF
--- a/src/models/gnn/heads/binary_head.py
+++ b/src/models/gnn/heads/binary_head.py
@@ -74,7 +74,7 @@ class BinaryMLPHead(nn.Module):
 
 # (선택) 프로젝트 레지스트리에 등록
 try:
-    from .registry import register_head  # pragma: no cover
+    from . import register_head  # pragma: no cover
 
     register_head("binary_mlp", BinaryMLPHead)
 except ImportError:

--- a/src/models/gnn/heads/multi_class_head.py
+++ b/src/models/gnn/heads/multi_class_head.py
@@ -105,7 +105,7 @@ class MultiClassMLPHead(nn.Module):
 
 # (선택) 프로젝트 레지스트리에 자동 등록
 try:
-    from .registry import register_head  # pragma: no cover
+    from . import register_head  # pragma: no cover
 
     register_head("multi_class_mlp", MultiClassMLPHead)
 except ImportError:

--- a/src/models/gnn/heads/multi_label_head.py
+++ b/src/models/gnn/heads/multi_label_head.py
@@ -96,7 +96,7 @@ class MultiLabelMLPHead(nn.Module):
 
 # (선택) 레지스트리 등록
 try:
-    from .registry import register_head  # pragma: no cover
+    from . import register_head  # pragma: no cover
 
     register_head("multi_label_mlp", MultiLabelMLPHead)
 except ImportError:

--- a/src/models/gnn/heads/regression_head.py
+++ b/src/models/gnn/heads/regression_head.py
@@ -99,7 +99,7 @@ class RegressionMLPHead(nn.Module):
 
 # (선택) 프로젝트 레지스트리에 자동 등록
 try:
-    from .registry import register_head  # pragma: no cover
+    from . import register_head  # pragma: no cover
 
     register_head("regression_mlp", RegressionMLPHead)
 except ImportError:

--- a/tests/test_head_registry.py
+++ b/tests/test_head_registry.py
@@ -1,0 +1,13 @@
+import pytest
+
+pytest.importorskip("torch")
+
+from src.models.gnn import heads
+
+
+def test_default_head_registration():
+    available = heads.available_heads()
+    assert "binary_mlp" in available
+    assert "multi_class_mlp" in available
+    assert "multi_label_mlp" in available
+    assert "regression_mlp" in available


### PR DESCRIPTION
## Summary
- import `register_head` from package rather than non-existent `registry` module
- add tests ensuring default GNN heads are registered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686371b5a9e4832eb8ff401237f10e71