### PR TITLE
Fix head registration decorator usage

### DIFF
--- a/src/models/gnn/heads/binary_head.py
+++ b/src/models/gnn/heads/binary_head.py
@@ -76,6 +76,6 @@ class BinaryMLPHead(nn.Module):
 try:
     from . import register_head  # pragma: no cover
 
-    register_head("binary_mlp", BinaryMLPHead)
+    register_head("binary_mlp")(BinaryMLPHead)
 except ImportError:
     pass

--- a/src/models/gnn/heads/multi_class_head.py
+++ b/src/models/gnn/heads/multi_class_head.py
@@ -107,6 +107,6 @@ class MultiClassMLPHead(nn.Module):
 try:
     from . import register_head  # pragma: no cover
 
-    register_head("multi_class_mlp", MultiClassMLPHead)
+    register_head("multi_class_mlp")(MultiClassMLPHead)
 except ImportError:
     pass

--- a/src/models/gnn/heads/multi_label_head.py
+++ b/src/models/gnn/heads/multi_label_head.py
@@ -98,6 +98,6 @@ class MultiLabelMLPHead(nn.Module):
 try:
     from . import register_head  # pragma: no cover
 
-    register_head("multi_label_mlp", MultiLabelMLPHead)
+    register_head("multi_label_mlp")(MultiLabelMLPHead)
 except ImportError:
     pass

--- a/src/models/gnn/heads/regression_head.py
+++ b/src/models/gnn/heads/regression_head.py
@@ -101,6 +101,6 @@ class RegressionMLPHead(nn.Module):
 try:
     from . import register_head  # pragma: no cover
 
-    register_head("regression_mlp", RegressionMLPHead)
+    register_head("regression_mlp")(RegressionMLPHead)
 except ImportError:
     pass


### PR DESCRIPTION
## Summary
- fix the decorator call used to register GNN heads
- ensure tests verify registered head names

## Testing
- `pytest tests/test_head_registry.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6863765fa610832eb4ea27c1214372f6