### PR TITLE
Fix graph feature handling order

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -161,8 +161,8 @@ class GraphDataset(Dataset):
     def __getitem__(self, idx: int) -> Tuple[GraphT, int | None, str]:
         sha = self.samples[idx]
         g = self._load_graph(sha)
-        g = GraphDataset._ensure_x(g, policy=self.over_length_policy)
         g = GraphDataset._ensure_num_nodes(g)
+        g = GraphDataset._ensure_x(g, policy=self.over_length_policy)
         if self.transform:
             g = self.transform(g)
         label = self.labels.get(sha, None)
@@ -190,8 +190,10 @@ class GraphDataset(Dataset):
 
         graphs, labels, ids = zip(*batch)
 
-        # ensure num_nodes metadata is present for all graphs
+        # ensure num_nodes metadata is present for all graphs and
+        # populate missing 'x' tensors consistently
         graphs = [GraphDataset._ensure_num_nodes(g) for g in graphs]
+        graphs = [GraphDataset._ensure_x(g) for g in graphs]
         if attr_names:
             graphs = [GraphDataset._ensure_meta_ids(g, attr_names) for g in graphs]
 


### PR DESCRIPTION
## Summary
- adjust call order of `_ensure_num_nodes` and `_ensure_x` in `GraphDataset.__getitem__`
- call `_ensure_x` after `_ensure_num_nodes` inside `GraphDataset.collate_fn`

## Testing
- `pytest -k graph_dataset -q`

------
https://chatgpt.com/codex/tasks/task_e_686379c541b0832ea1a6edd98dce6500