### PR TITLE
Implement PPO rule sampling and CLI updates

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -60,6 +60,7 @@ import torch
 import matplotlib.pyplot as plt
 from omegaconf import OmegaConf
 from tqdm import tqdm
+from src.cli.preprocessing import ensure_dir
 
 # ---------------------------------------------------------------------------
 # Internal imports – lazily resolved to keep import‑time light‑weight.
@@ -261,6 +262,14 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         agent.save(args.checkpoint)
         logger.info("Agent checkpoint saved → %s", args.checkpoint)
 
+        builder = YaraBuilder()
+        sample_tokens = agent.sample_rules(n=1)[0]
+        sample_rule = builder.build(sample_tokens)
+        out_dir = Path("results")
+        ensure_dir(out_dir)
+        (out_dir / "sample_rule.yar").write_text(sample_rule, encoding="utf-8")
+        logger.info("Sample rule saved → %s", out_dir / "sample_rule.yar")
+
 
 RULE_TYPE_BUILDERS = {
     "yara": YaraBuilder if "YaraBuilder" in globals() else None,
@@ -285,7 +294,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
 
     builder = builder_cls()  # type: ignore[call-arg]
     rules = agent.sample_rules(n=args.n_rules, temperature=args.temperature)
-    rules_text = builder.build(rules)
+    rules_text = "\n\n".join(builder.build(r) for r in rules)
 
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -451,6 +451,65 @@ class PPORuleAgent:
         )
         _LOG.info("Loaded PPO policy ← %s", path)
 
+    @torch.no_grad()
+    def sample_rules(
+        self,
+        n: int = 1,
+        *,
+        temperature: float = 1.0,
+        max_len: int | None = None,
+    ) -> List[List[str]]:
+        """Sample ``n`` rule token sequences from the policy.
+
+        Parameters
+        ----------
+        n : number of rules to generate
+        temperature : sampling temperature for the policy logits
+        max_len : optional max token length (defaults to env max_len)
+        """
+
+        self.policy.eval()
+        max_len = max_len or self.env.max_len
+        rules: List[List[str]] = []
+
+        for _ in range(n):
+            obs, _ = self.env.reset()
+            hint = None
+            toks: List[int] = []
+            done = False
+            steps = 0
+
+            while not done and steps < max_len:
+                obs_t = torch.from_numpy(obs).long().unsqueeze(0).to(self.device)
+                hint_t = None
+                if hint is not None:
+                    hint_t = torch.from_numpy(hint).unsqueeze(0).to(self.device)
+                    if self.policy.hint_size is None:
+                        hint_t = hint_t.long()
+                    else:
+                        hint_t = hint_t.to(torch.float32)
+
+                logits, _ = self.policy(obs_t, hint_t)
+                if temperature != 1.0:
+                    logits = logits / float(temperature)
+                dist = torch.distributions.Categorical(logits=logits)
+                action = int(dist.sample().item())
+
+                toks.append(action)
+                obs, _, done, trunc, _ = self.env.step(action)
+                if trunc or action == self.env.token2id[self.env.END]:
+                    done = True
+                steps += 1
+
+            rule_tokens = [
+                self.env.id2token[t]
+                for t in toks
+                if t not in {self.env.token2id[self.env.END], self.env.token2id[self.env.PAD]}
+            ]
+            rules.append(rule_tokens)
+
+        return rules
+
 
 # ╔══════════════════════════════════════════════════════════════╗
 # ║                          CLI Entry                          ║


### PR DESCRIPTION
## Summary
- implement `sample_rules` for `PPORuleAgent`
- modify CLI to save sample rule after PPO training
- update rule generation command to handle multiple rules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686378982484832e8387a7504d6c0485