### PR TITLE
Validate edge_type indices before RES-GCL training

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ python -m cli.train_res_gcl \
        --lr 1e-3 \
        --output models/gnn/res_gcl.pt
 `--force-reinit` ignores the snapshot and always rebuilds input layers.
+`train_res_gcl` also checks that every `edge_type` value fits within the
+dataset relation count and raises a `ValueError` with the offending file name
+when an out-of-range index is found.
 
 # 분류기 head 학습
 

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -22,7 +22,7 @@ from src.common.utils import (
     filter_state_dict,
 )
 from src.models import get_model
-from graphs.dataset.graph_dataset import GraphDataset
+from graphs.dataset.graph_dataset import GraphDataset, _guess_graph_path
 from src.graphs.normalizers.schema import NodeType
 from src.models.gnn.encoder import RGCNEncoder
 from src.models.gnn.res_wrapper import RESGCLClassifier
@@ -302,6 +302,21 @@ def main(argv: list[str] | None = None) -> None:
         )
         LOGGER.error(msg)
         raise RuntimeError(msg)
+
+    num_rels = len(dataset_metadata[1])
+    for ds in (train_dl.dataset, val_dl.dataset):
+        for i in range(len(ds)):
+            g, _, sha = ds[i]
+            for et in g.edge_types:
+                vals = g[et].edge_type
+                if vals.numel() == 0:
+                    continue
+                if int(vals.min()) < 0 or int(vals.max()) >= num_rels:
+                    if sha is not None and hasattr(ds, "graph_dir"):
+                        path = _guess_graph_path(ds.graph_dir, sha)
+                    else:
+                        path = sha if sha is not None else str(i)
+                    raise ValueError(f"Invalid edge_type index in {path}")
     if args.head_checkpoint:
         state = torch.load(args.head_checkpoint, map_location=device)
         head_state = {

--- a/tests/test_train_res_gcl_edge_type_range.py
+++ b/tests/test_train_res_gcl_edge_type_range.py
@@ -1,0 +1,83 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    ei = torch.tensor([[0, 1], [1, 0]])
+    g[("n", "r0", "n")].edge_index = ei
+    g[("n", "r0", "n")].edge_type = torch.zeros(ei.size(1), dtype=torch.long)
+    g[("n", "r1", "n")].edge_index = ei
+    g[("n", "r1", "n")].edge_type = torch.full((ei.size(1),), 1, dtype=torch.long)
+    torch.save(g, path)
+
+
+def test_edge_type_range_checked(tmp_path):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt")
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n")],
+            "in_dims": {"n": 4},
+            "num_relations": 1,
+        },
+        meta_path,
+    )
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        with pytest.raises(ValueError, match="a.pt"):
+            mod.main()
+    finally:
+        sys.argv = orig_argv
+


### PR DESCRIPTION
## Summary
- validate `edge_type` values against the collected dataset metadata in `train_res_gcl`
- raise an error with offending file when out-of-range values are detected
- add a regression test for the new check
- document the validation behaviour in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68637ee55c64832ebc1725a6a9d9a609