### PR TITLE
Fix edge attribute deduplication in builder

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -207,11 +207,22 @@ class HeteroGraphBuilder:
         for key, edge_list in tmp_edges.items():
             edges = torch.cat(edge_list, dim=1)
             # deduplication
-            ei, _ = torch.unique(edges, dim=1, return_inverse=True)
+            ei, inverse = torch.unique(edges, dim=1, return_inverse=True)
             out[key].edge_index = ei
 
+            # aggregate edge attributes using the same mapping
             for k, tensors in tmp_attrs[key].items():
-                out[key][k] = torch.cat(tensors)
+                attr = torch.cat(tensors)
+                if attr.size(0) != edges.size(1):
+                    raise ValueError(
+                        f"edge attribute '{k}' count {attr.size(0)} does not match"
+                        f" edge count {edges.size(1)}"
+                    )
+                first_idx = torch.full((ei.size(1),), -1, dtype=torch.long)
+                for idx, uid in enumerate(inverse.tolist()):
+                    if first_idx[uid] == -1:
+                        first_idx[uid] = idx
+                out[key][k] = attr[first_idx]
 
             # edge_type auto fill if missing
             if "edge_type" not in out[key]:

--- a/tests/test_edge_merge_dedup.py
+++ b/tests/test_edge_merge_dedup.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.graphs.builders.hetero_builder import HeteroGraphBuilder
+
+
+def test_edge_merge_dedup_attributes():
+    g = HeteroData()
+    g["n"].num_nodes = 2
+    ei = torch.tensor([[0, 0], [1, 1]])
+    g[("n", "r", "n")].edge_index = ei
+    g[("n", "r", "n")].edge_type = torch.zeros(ei.size(1), dtype=torch.long)
+
+    builder = HeteroGraphBuilder()
+    builder.add_view(g, "v1")
+
+    hetero = builder.build()
+    store = hetero[("n", "r", "n")]
+    assert store.edge_index.size(1) == store.edge_type.size(0)
+    assert store.edge_index.size(1) == 1


### PR DESCRIPTION
## Summary
- ensure edge attributes are deduplicated when merging edge stores
- add regression test for duplicate edges

## Testing
- `pytest tests/test_edge_merge_dedup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68637fa653ac832eaa92f48543976005