### PR TITLE
Add edge index sanitization in GraphDataset

### DIFF
--- a/src/graphs/__init__.py
+++ b/src/graphs/__init__.py
@@ -26,10 +26,32 @@ from typing import List
 # Sub-package 핵심 심벌 re-export
 # ────────────────────────────────────────────────────────────────
 # loaders
-from .loaders import get_loader, available as loaders_available
+try:  # optional dependency on torch_geometric/torch
+    import torch
+    if getattr(torch, "Tensor", None) is None:
+        raise ImportError("invalid torch stub")
+    from .loaders import get_loader, available as loaders_available
+    from .dataset import GraphDataset, split_by_time, split_random
+    from .normalizers import get_normalizer, available as norms_available
+except Exception:  # pragma: no cover - optional heavy deps
+    def get_loader(*_args, **_kw):  # type: ignore
+        raise ImportError("torch_geometric is required")
 
-# normalizers
-from .normalizers import get_normalizer, available as norms_available
+    loaders_available = lambda: []  # type: ignore
+
+    class GraphDataset:  # type: ignore
+        pass
+
+    def split_by_time(*_args, **_kw):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    def split_random(*_args, **_kw):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    def get_normalizer(*_a, **_kw):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    norms_available = lambda: []  # type: ignore
 
 # builders
 from .builders import (
@@ -55,8 +77,7 @@ try:  # pragma: no cover - optional heavy deps
 except Exception:  # noqa: BLE001 - broad for optional import
     feats_available = lambda: []  # type: ignore
 
-# dataset
-from .dataset import GraphDataset, split_by_time, split_random
+# dataset (placeholder when optional deps missing handled above)
 
 # transforms (optional augment dependency)
 try:  # pragma: no cover - optional heavy deps

--- a/src/graphs/builders/__init__.py
+++ b/src/graphs/builders/__init__.py
@@ -27,18 +27,38 @@ from __future__ import annotations
 from typing import List
 
 # 핵심 빌더
-from .hetero_builder import HeteroGraphBuilder, OverLengthPolicy
-from .view_merger import ViewMerger
+try:  # optional torch_geometric dependency
+    from .hetero_builder import HeteroGraphBuilder, OverLengthPolicy
+    from .view_merger import ViewMerger
 
-# 유틸리티
-from .relabeler import relabel
-from .graph_sampler import (
-    sample_k_hop,
-    sample_random_walk,
-    sample_edge_drop,
-    sainth_loader,
-    cluster_loader,
-)
+    from .relabeler import relabel
+    from .graph_sampler import (
+        sample_k_hop,
+        sample_random_walk,
+        sample_edge_drop,
+        sainth_loader,
+        cluster_loader,
+    )
+except Exception:  # pragma: no cover - missing heavy deps
+    HeteroGraphBuilder = ViewMerger = None  # type: ignore
+    OverLengthPolicy = None  # type: ignore
+    def relabel(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    def sample_k_hop(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    def sample_random_walk(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    def sample_edge_drop(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    def sainth_loader(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
+    def cluster_loader(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
 
 __all__: List[str] = [
     # builders

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -51,7 +51,10 @@ from ..builders.hetero_builder import (
     OverLengthPolicy,
 )
 
-from ..features.cache import load_tensor
+try:  # optional dependency (pyarrow, pandas)
+    from ..features.cache import load_tensor
+except Exception:  # pragma: no cover - optional heavy deps
+    load_tensor = None  # type: ignore
 
 from ..loaders.factory import get_loader   # fallback json 로드용
 from ..utils import get_logger
@@ -342,6 +345,8 @@ class GraphDataset(Dataset):
     def _attach_embeds(self, sha: str, g: GraphT) -> GraphT:
         if not self.load_embeds:
             return g
+        if load_tensor is None:  # optional dependency missing
+            return g
         embed_file = self.embed_dir / f"{sha}.ftr"
         if not embed_file.is_file():
             return g
@@ -426,7 +431,7 @@ class GraphDataset(Dataset):
             hetero_ensure_num_nodes(g)
         elif isinstance(g, Data):
             g.num_nodes = _guess_num_nodes(g)
-        return g
+        return GraphDataset._sanitize_edges(g)
 
     # --------------------------------------------------------------
     @staticmethod
@@ -485,6 +490,49 @@ class GraphDataset(Dataset):
         else:
             process_store(g)
 
+        return g
+
+    # --------------------------------------------------------------
+    @staticmethod
+    def _sanitize_edge_index(
+        store: Data | HeteroData,
+        *,
+        src_nodes: int,
+        dst_nodes: int,
+    ) -> None:
+        """Remove edges referencing invalid node indices."""
+        edge_index = getattr(store, "edge_index", None)
+        if not isinstance(edge_index, torch.Tensor) or edge_index.numel() == 0:
+            return
+        num_e = edge_index.size(1)
+        src, dst = edge_index
+        valid = (
+            (src >= 0)
+            & (src < src_nodes)
+            & (dst >= 0)
+            & (dst < dst_nodes)
+        )
+        if valid.all():
+            return
+        store.edge_index = edge_index[:, valid]
+        for key, val in list(store.items()):
+            if key == "edge_index":
+                continue
+            if torch.is_tensor(val) and val.size(0) == num_e:
+                store[key] = val[valid]
+
+    # --------------------------------------------------------------
+    @staticmethod
+    def _sanitize_edges(g: GraphT) -> GraphT:
+        if isinstance(g, HeteroData):
+            for etype in g.edge_types:
+                src_t, _, dst_t = etype
+                src_n = g[src_t].num_nodes or 0
+                dst_n = g[dst_t].num_nodes or 0
+                GraphDataset._sanitize_edge_index(g[etype], src_nodes=src_n, dst_nodes=dst_n)
+        else:
+            n = g.num_nodes or 0
+            GraphDataset._sanitize_edge_index(g, src_nodes=n, dst_nodes=n)
         return g
 
 

--- a/tests/test_graph_dataset_sanitize.py
+++ b/tests/test_graph_dataset_sanitize.py
@@ -40,3 +40,46 @@ def test_collate_sanitizes_list_attrs(tmp_path):
     assert hasattr(batch["graph"]["n"], "meta")
     assert "bar" in batch["graph"]["n"].meta
     assert "name" in batch["graph"]["n"].meta
+
+
+def test_dataset_filters_invalid_edges_data(tmp_path):
+    from torch_geometric.data import Data
+
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = Data(
+        x=torch.randn(3, 1),
+        edge_index=torch.tensor([[0, 1, 2], [1, 4, -1]]),
+        edge_attr=torch.tensor([10, 20, 30]),
+        num_nodes=3,
+    )
+
+    torch.save(g, graph_dir / "a.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    loaded, _, _ = ds[0]
+
+    assert torch.equal(loaded.edge_index, torch.tensor([[0], [1]]))
+    assert torch.equal(loaded.edge_attr, torch.tensor([10]))
+
+
+def test_dataset_filters_invalid_edges_hetero(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["a"].x = torch.randn(2, 1)
+    g["a"].num_nodes = 2
+    g["b"].x = torch.randn(1, 1)
+    g["b"].num_nodes = 1
+    g[("a", "to", "b")].edge_index = torch.tensor([[0, 1], [0, 5]])
+    g[("b", "to", "a")].edge_index = torch.tensor([[0], [-1]])
+
+    torch.save(g, graph_dir / "s.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    loaded, _, _ = ds[0]
+
+    assert torch.equal(loaded[("a", "to", "b")].edge_index, torch.tensor([[0], [0]]))
+    assert loaded[("b", "to", "a")].edge_index.numel() == 0


### PR DESCRIPTION
## Summary
- ensure optional dependencies don't break imports
- sanitize edges referencing invalid nodes when loading graphs
- cover sanitization with new unit tests

## Testing
- `pytest tests/test_graph_dataset_sanitize.py::test_dataset_filters_invalid_edges_data tests/test_graph_dataset_sanitize.py::test_dataset_filters_invalid_edges_hetero tests/test_graph_dataset_sanitize.py::test_collate_sanitizes_list_attrs -q`

------
https://chatgpt.com/codex/tasks/task_e_68637f8fe044832eabfb078015693f72