### PR TITLE
Fix GraphDataset transform sanitation

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -168,6 +168,8 @@ class GraphDataset(Dataset):
         g = GraphDataset._ensure_x(g, policy=self.over_length_policy)
         if self.transform:
             g = self.transform(g)
+            g = GraphDataset._ensure_num_nodes(g)
+            g = GraphDataset._ensure_x(g, policy=self.over_length_policy)
         label = self.labels.get(sha, None)
         return g, label, sha
 

--- a/tests/test_graph_dataset_sanitize.py
+++ b/tests/test_graph_dataset_sanitize.py
@@ -83,3 +83,45 @@ def test_dataset_filters_invalid_edges_hetero(tmp_path):
 
     assert torch.equal(loaded[("a", "to", "b")].edge_index, torch.tensor([[0], [0]]))
     assert loaded[("b", "to", "a")].edge_index.numel() == 0
+
+
+def test_transform_sanitizes_edges_data(tmp_path):
+    from torch_geometric.data import Data
+
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = Data(x=torch.randn(2, 1), edge_index=torch.tensor([[0], [1]]), num_nodes=2)
+    torch.save(g, graph_dir / "a.pt")
+
+    def corrupt(graph: Data):
+        graph.edge_index = torch.tensor([[2], [3]])
+        return graph
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None, transform=corrupt)
+    loaded, _, _ = ds[0]
+
+    assert loaded.edge_index.numel() == 0
+
+
+def test_transform_sanitizes_edges_hetero(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    g = HeteroData()
+    g["a"].x = torch.randn(2, 1)
+    g["a"].num_nodes = 2
+    g["b"].x = torch.randn(1, 1)
+    g["b"].num_nodes = 1
+    g[("a", "to", "b")].edge_index = torch.tensor([[0], [0]])
+
+    torch.save(g, graph_dir / "s.pt")
+
+    def corrupt(graph: HeteroData):
+        graph[("a", "to", "b")].edge_index = torch.tensor([[1], [2]])
+        return graph
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None, transform=corrupt)
+    loaded, _, _ = ds[0]
+
+    assert loaded[("a", "to", "b")].edge_index.numel() == 0


### PR DESCRIPTION
## Summary
- re-run num_nodes/x checks after applying dataset transform
- verify transformed edges are sanitized

## Testing
- `pytest tests/test_graph_dataset_sanitize.py::test_transform_sanitizes_edges_data -vv`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'archinfo')*

------
https://chatgpt.com/codex/tasks/task_e_6863a42a213c832eaa52c3f932856efd