### PR TITLE
Require meta path for train_res_gcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ python -m cli.train_res_gcl \
        --epochs 50 --batch-size 256 \
        --lr 1e-3 \
        --output models/gnn/res_gcl.pt
+`--meta-path`에 지정한 메타 스냅샷이 존재하지 않으면 즉시 `RuntimeError`
+가 발생합니다.
 `--force-reinit` ignores the snapshot and always rebuilds input layers.
 `train_res_gcl` also checks that every `edge_type` value fits within the
 dataset relation count and raises a `ValueError` with the offending file name

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -41,8 +41,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--encoder-checkpoint", type=Path, required=True,
                    help="Pre-trained encoder .pt file")
-    p.add_argument("--meta-path", type=Path,
-                   help="Path to encoder meta snapshot (.meta.pkl)")
+    p.add_argument(
+        "--meta-path",
+        type=Path,
+        required=True,
+        help="Path to encoder meta snapshot (.meta.pkl)",
+    )
     p.add_argument("--force-reinit", action="store_true",
                    help="Rebuild input layers when feature sizes changed")
     p.add_argument("--head-checkpoint", type=Path,
@@ -161,6 +165,9 @@ def main(argv: list[str] | None = None) -> None:
     set_random_seed(args.seed)
     device = torch.device(args.device)
 
+    if not args.meta_path.is_file():
+        raise RuntimeError(f"Meta snapshot not found: {args.meta_path}")
+
     root = (
         args.splits_dir / args.split
         if (args.splits_dir / args.split).is_dir()
@@ -172,7 +179,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     meta_snapshot = None
-    if args.meta_path and args.meta_path.is_file():
+    if args.meta_path:
         try:
             add_safe_globals([NodeType])
             meta_snapshot = torch.load(args.meta_path, weights_only=False)


### PR DESCRIPTION
## Summary
- make `--meta-path` required for RES-GCL training
- abort training early if the meta snapshot is missing
- document the new requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864095c5dc0832ea3222c8556a60e05