### PR TITLE
Fix classifier head dimension detection

### DIFF
--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -73,8 +73,11 @@ class RESGCLClassifier(nn.Module):
         self.dropper = EdgeDropSmoothing(drop_prob=drop_prob)
         self.n_samples_cert = int(n_samples_cert)
 
-        # infer embedding dim from a dummy parameter
-        emb_dim = next(p for p in encoder.parameters()).shape[-1]
+        # infer embedding dim from encoder attribute if available
+        emb_dim = getattr(encoder, "out_dim", None)
+        if emb_dim is None:
+            # fallback to a dummy parameter's last dimension
+            emb_dim = next(p for p in encoder.parameters()).shape[-1]
         self.head = self._init_head(head, emb_dim)
 
     # ------------------------------------------------------------------ #

--- a/tests/test_resgcl_load_meta.py
+++ b/tests/test_resgcl_load_meta.py
@@ -52,3 +52,15 @@ def test_load_with_meta(tmp_path):
     loaded = RESGCLClassifier.load_from_checkpoint(ckpt)
     assert isinstance(loaded.encoder, RGCNEncoder)
     assert loaded.encoder.node_types == ["n"]
+
+
+def test_head_uses_encoder_out_dim():
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=5,
+    )
+    model = RESGCLClassifier(encoder=enc, head="binary_mlp")
+    assert model.head.fc1.in_features == enc.out_dim


### PR DESCRIPTION
## Summary
- initialize RESGCLClassifier heads using `encoder.out_dim`
- test that classifier heads pick up encoder out_dim

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686411e93418832e985760d0bab8b261