### PR TITLE
Fix dataloader attr names

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -192,20 +192,36 @@ def main(argv: list[str] | None = None) -> None:
                 "Failed to load meta snapshot %s: %s", args.meta_path, exc
             )
 
+    from graphs.dataset import collect_dataset_metadata
+
+    transform = T.Compose([T.NormalizeFeatures()])
+    train_ds = GraphDataset(
+        root=root,
+        split="train",
+        transform=transform,
+        require_labels=True,
+        embed_dir=args.embed_dir,
+    )
+    val_ds = GraphDataset(
+        root=root,
+        split="val",
+        transform=transform,
+        require_labels=True,
+        embed_dir=args.embed_dir,
+    )
+
+    dataset_metadata, in_dims, attr_names = collect_dataset_metadata(
+        [train_ds, val_ds],
+        attr_dim=encoder.attr_dim,
+        strict=args.strict_metadata,
+    )
+
     train_dl, val_dl = make_dataloaders(
         root,
         args.batch_size,
         args.num_workers,
-        attr_names=encoder.attr_names,
+        attr_names=attr_names,
         embed_dir=args.embed_dir,
-    )
-
-    from graphs.dataset import collect_dataset_metadata
-
-    dataset_metadata, in_dims, attr_names = collect_dataset_metadata(
-        [train_dl.dataset, val_dl.dataset],
-        attr_dim=encoder.attr_dim,
-        strict=args.strict_metadata,
     )
 
     # ``metadata`` may be adjusted later based on the checkpoint snapshot. Keep


### PR DESCRIPTION
## Summary
- build datasets before loaders in `train_res_gcl` so we can collect metadata
- use collected `attr_names` when making dataloaders

## Testing
- `pytest -k train_res_gcl -q`

------
https://chatgpt.com/codex/tasks/task_e_6864139d7064832ea59f2432656c4436