### PR TITLE
Fix RES-GCL dataloader rebuild after encoder reinit

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -293,6 +293,13 @@ def main(argv: list[str] | None = None) -> None:
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
         dataset_metadata = metadata
+        train_dl, val_dl = make_dataloaders(
+            root,
+            args.batch_size,
+            args.num_workers,
+            attr_names=encoder.attr_names,
+            embed_dir=args.embed_dir,
+        )
 
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)

--- a/tests/test_train_res_gcl_auto_reinit.py
+++ b/tests/test_train_res_gcl_auto_reinit.py
@@ -23,6 +23,18 @@ def _make_graph(path: Path, feat_dim: int) -> None:
     torch.save(g, path)
 
 
+def _make_attr_graph(path: Path) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    g["n"].bar_id = torch.tensor([0, 1])
+    g["n"].baz_id = torch.tensor([1, 0])
+    ei = torch.tensor([[0, 1], [1, 0]])
+    g[("n", "r0", "n")].edge_index = ei
+    g[("n", "r0", "n")].edge_type = torch.zeros(ei.size(1), dtype=torch.long)
+    torch.save(g, path)
+
+
 def test_auto_reinit_with_meta(tmp_path, caplog):
     data_root = tmp_path / "data"
     for split in ("train", "val"):
@@ -202,3 +214,80 @@ def test_reinit_metadata_mismatch_error(tmp_path):
             mod.main()
     finally:
         sys.argv = orig_argv
+
+
+def test_dataloaders_recreated_after_reinit(tmp_path, monkeypatch, caplog):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_attr_graph(gdir / "a.pt")
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 5},
+        attr_names={"n": ["foo"]},
+        attr_dim=1,
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n")],
+            "in_dims": {"n": 5},
+            "num_relations": 1,
+        },
+        meta_path,
+    )
+
+    calls = []
+    importlib.invalidate_caches()
+    mod = importlib.import_module("src.cli.train_res_gcl")
+
+    orig_make = mod.make_dataloaders
+
+    def rec_make(*args, **kwargs):
+        calls.append(kwargs.get("attr_names"))
+        return orig_make(*args, **kwargs)
+
+    monkeypatch.setattr(mod, "make_dataloaders", rec_make)
+
+    out_path = tmp_path / "model.pt"
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(out_path),
+    ]
+
+    orig_argv = sys.argv
+    sys.argv = argv
+    caplog.set_level("INFO")
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert len(calls) >= 2
+    assert calls[0] == {"n": ["foo"]}
+    assert calls[-1] == {"n": ["bar", "baz"]}
+    assert any("Epoch 1" in rec.message for rec in caplog.records)
+    assert out_path.with_suffix(".meta.pkl").is_file()


### PR DESCRIPTION
## Summary
- rebuild DataLoaders after RES-GCL encoder auto reinit
- regression test verifying dataloader recreation

## Testing
- `pytest -k train_res_gcl_auto_reinit -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68641389f5f4832ea618f905d6d586f5