### PR TITLE
Include vocab size in meta snapshots

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -508,9 +508,15 @@ def main() -> None:
             metadata=metadata,
             in_dims=in_dims,
             attr_names=attr_names if metadata[0] else None,
-            vocab_size=encoder.meta_embed.num_embeddings
-            if encoder.meta_embed is not None
-            else 0,
+            vocab_size=(
+                int(meta_snapshot.get("vocab_size"))
+                if meta_snapshot is not None and "vocab_size" in meta_snapshot
+                else (
+                    encoder.meta_embed.num_embeddings
+                    if encoder.meta_embed is not None
+                    else 0
+                )
+            ),
             attr_dim=encoder.attr_dim,
             hidden_dim=hidden_dim,
             num_layers=len(encoder.convs),
@@ -615,6 +621,20 @@ def main() -> None:
                 best_macro_f1 = val_metrics["MacroF1"]
             no_improve = 0
             torch.save(model.state_dict(), args.logdir / "best_model.pt")
+            meta_out = args.logdir / "best_model.meta.pkl"
+            meta_info = {
+                "node_types": list(dataset_metadata[0]),
+                "edge_types": [tuple(e) for e in dataset_metadata[1]],
+                "in_dims": {k: int(v) for k, v in in_dims.items()},
+                "num_relations": len(dataset_metadata[1]),
+                "vocab_size": encoder.meta_embed.num_embeddings
+                if encoder.meta_embed is not None
+                else 0,
+            }
+            try:
+                torch.save(meta_info, meta_out)
+            except Exception as exc:  # pragma: no cover - I/O safeguard
+                LOGGER.warning("Failed to save meta snapshot: %s", exc)
         else:
             no_improve += 1
             if no_improve >= args.patience:

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -295,7 +295,11 @@ def main(argv: list[str] | None = None) -> None:
             metadata=metadata,
             in_dims=in_dims,
             attr_names=attr_names if isinstance(g0, HeteroData) else None,
-            vocab_size=encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0,
+            vocab_size=(
+                int(meta_snapshot.get("vocab_size"))
+                if meta_snapshot is not None and "vocab_size" in meta_snapshot
+                else (encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0)
+            ),
             attr_dim=encoder.attr_dim,
             hidden_dim=hidden_dim,
             num_layers=len(encoder.convs),
@@ -383,6 +387,7 @@ def main(argv: list[str] | None = None) -> None:
         "edge_types": [tuple(e) for e in metadata[1]],
         "in_dims": {k: int(v) for k, v in in_dims.items()},
         "num_relations": len(metadata[1]),
+        "vocab_size": encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0,
     }
     try:
         torch.save(meta_info, meta_out)

--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -190,6 +190,8 @@ class RESGCLClassifier(nn.Module):
             if "meta_embed.weight" in enc_state:
                 vocab_size = enc_state["meta_embed.weight"].size(0)
                 attr_dim = enc_state["meta_embed.weight"].size(1)
+            if isinstance(meta, dict) and "vocab_size" in meta:
+                vocab_size = int(meta["vocab_size"])
 
             encoder = RGCNEncoder(
                 metadata=(node_types, edge_types[:num_relations]),

--- a/tests/test_train_res_gcl_auto_reinit.py
+++ b/tests/test_train_res_gcl_auto_reinit.py
@@ -94,7 +94,10 @@ def test_auto_reinit_with_meta(tmp_path, caplog):
 
     assert any("reinitializing" in rec.message or "dimension mismatch" in rec.message for rec in caplog.records)
     assert any("Epoch 1" in rec.message for rec in caplog.records)
-    assert out_file.with_suffix(".meta.pkl").is_file()
+    meta_file = out_file.with_suffix(".meta.pkl")
+    assert meta_file.is_file()
+    meta = torch.load(meta_file)
+    assert "vocab_size" in meta
 
 
 def test_meta_relation_count_used(tmp_path):


### PR DESCRIPTION
## Summary
- keep vocabulary size in `.meta.pkl` snapshots for RES-GCL and SupCon
- retain vocab size when reinitialising from snapshots or loading checkpoints
- cover new field in `train_res_gcl` tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686424a5b8d4832e99a2df5fc1e38701