### PR TITLE
Add meta ID range validation for encoders

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -413,6 +413,10 @@ def main() -> None:
         strict=args.strict_metadata,
     )
 
+    from graphs.dataset.graph_dataset import collect_max_meta_id
+
+    max_meta_id = collect_max_meta_id([train_dl.dataset, val_dl.dataset], attr_names)
+
     metadata = dataset_metadata
 
     node_order_mismatch = metadata[0] != encoder.node_types
@@ -481,6 +485,22 @@ def main() -> None:
                     auto_reinit = True
                     break
 
+    vocab_size = (
+        encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0
+    )
+    required_vocab = vocab_size
+    if max_meta_id >= vocab_size:
+        msg = (
+            f"Dataset metadata id {max_meta_id} exceeds encoder vocab size"
+            f" {vocab_size}"
+        )
+        if args.force_reinit or auto_reinit:
+            LOGGER.warning(msg + "; reinitializing meta embeddings")
+            required_vocab = max_meta_id + 1
+            auto_reinit = True
+        else:
+            raise RuntimeError(msg + "; rerun preprocessing or use --force-reinit")
+
     if args.force_reinit or auto_reinit:
         if auto_reinit and not args.force_reinit:
             LOGGER.info(
@@ -508,9 +528,7 @@ def main() -> None:
             metadata=metadata,
             in_dims=in_dims,
             attr_names=attr_names if metadata[0] else None,
-            vocab_size=encoder.meta_embed.num_embeddings
-            if encoder.meta_embed is not None
-            else 0,
+            vocab_size=required_vocab,
             attr_dim=encoder.attr_dim,
             hidden_dim=hidden_dim,
             num_layers=len(encoder.convs),

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -927,6 +927,15 @@ def _load_model_hparams(
         strict=strict,
     )
 
+    from graphs.dataset.graph_dataset import collect_max_meta_id
+
+    max_meta_id = collect_max_meta_id(datasets, attr_names)
+    if max_meta_id >= vocab_size:
+        raise RuntimeError(
+            f"Dataset metadata id {max_meta_id} exceeds vocab size {vocab_size};"
+            " adjust --vocab-size or re-preprocess"
+        )
+
     # ensure API node/edge types for augmentation
     if metadata[0]:
         node_types, edge_types = map(list, metadata)

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -216,6 +216,10 @@ def main(argv: list[str] | None = None) -> None:
         strict=args.strict_metadata,
     )
 
+    from graphs.dataset.graph_dataset import collect_max_meta_id
+
+    max_meta_id = collect_max_meta_id([train_ds, val_ds], attr_names)
+
     train_dl, val_dl = make_dataloaders(
         root,
         args.batch_size,
@@ -268,6 +272,22 @@ def main(argv: list[str] | None = None) -> None:
                     auto_reinit = True
                     break
 
+    vocab_size = (
+        encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0
+    )
+    required_vocab = vocab_size
+    if max_meta_id >= vocab_size:
+        msg = (
+            f"Dataset metadata id {max_meta_id} exceeds encoder vocab size"
+            f" {vocab_size}"
+        )
+        if args.force_reinit or auto_reinit:
+            LOGGER.warning(msg + "; reinitializing meta embeddings")
+            required_vocab = max_meta_id + 1
+            auto_reinit = True
+        else:
+            raise RuntimeError(msg + "; rerun preprocessing or use --force-reinit")
+
     if args.force_reinit or auto_reinit:
         if auto_reinit and not args.force_reinit:
             LOGGER.info(
@@ -295,7 +315,7 @@ def main(argv: list[str] | None = None) -> None:
             metadata=metadata,
             in_dims=in_dims,
             attr_names=attr_names if isinstance(g0, HeteroData) else None,
-            vocab_size=encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0,
+            vocab_size=required_vocab,
             attr_dim=encoder.attr_dim,
             hidden_dim=hidden_dim,
             num_layers=len(encoder.convs),

--- a/src/graphs/dataset/__init__.py
+++ b/src/graphs/dataset/__init__.py
@@ -25,12 +25,13 @@ from __future__ import annotations
 
 from typing import List
 
-from .graph_dataset import GraphDataset, collect_dataset_metadata
+from .graph_dataset import GraphDataset, collect_dataset_metadata, collect_max_meta_id
 from .split_generator import split_by_time, split_random
 
 __all__: List[str] = [
     "GraphDataset",
     "collect_dataset_metadata",
+    "collect_max_meta_id",
     "split_by_time",
     "split_random",
 ]

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -665,3 +665,49 @@ def collect_dataset_metadata(
 
     metadata = (node_types, edge_types_full[:num_relations])
     return metadata, in_dims, attr_names
+
+
+def collect_max_meta_id(
+    ds: "Dataset | Sequence[Dataset]",
+    attr_names: Dict[str, List[str]] | None = None,
+) -> int:
+    """Return the maximum metadata ID used across ``ds``.
+
+    ``ds`` may be a single :class:`GraphDataset` or a sequence thereof.  Each
+    dataset item must either be a ``Data``/``HeteroData`` object or a tuple
+    ``(graph, label, sha)`` where the first element is the graph instance.
+    ``attr_names`` specifies which ``*_id`` tensors to inspect per node type.
+    ``None`` falls back to all available ``*_id`` attributes encountered.
+    """
+
+    from torch_geometric.data import HeteroData
+
+    datasets = [ds] if isinstance(ds, GraphDataset) else list(ds)
+    max_id = -1
+
+    for d in datasets:
+        for i in range(len(d)):
+            item = d[i]
+            g = item[0] if isinstance(item, tuple) else item
+            if isinstance(g, HeteroData):
+                for nt in g.node_types:
+                    names = attr_names.get(nt, None) if attr_names else None
+                    store = g[nt]
+                    for key, val in store.items():
+                        if not key.endswith("_id"):
+                            continue
+                        if names is not None and key[:-3] not in names:
+                            continue
+                        if isinstance(val, torch.Tensor) and val.numel() > 0:
+                            max_id = max(max_id, int(val.max()))
+            else:
+                names = attr_names.get("", None) if attr_names else None
+                for key, val in g.items():
+                    if not key.endswith("_id"):
+                        continue
+                    if names is not None and key[:-3] not in names:
+                        continue
+                    if isinstance(val, torch.Tensor) and val.numel() > 0:
+                        max_id = max(max_id, int(val.max()))
+
+    return max_id

--- a/tests/test_meta_embed_range.py
+++ b/tests/test_meta_embed_range.py
@@ -1,0 +1,151 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path, max_id: int) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    g["n"].foo_id = torch.tensor([0, max_id])
+    ei = torch.tensor([[0, 1], [1, 0]])
+    g[("n", "r0", "n")].edge_index = ei
+    g[("n", "r0", "n")].edge_type = torch.zeros(ei.size(1), dtype=torch.long)
+    torch.save(g, path)
+
+
+def test_meta_id_range_error(tmp_path):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", 2)
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 5},
+        attr_names={"n": ["foo"]},
+        attr_dim=1,
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+        vocab_size=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n")],
+            "in_dims": {"n": 5},
+            "num_relations": 1,
+        },
+        meta_path,
+    )
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig = sys.argv
+    sys.argv = argv
+    try:
+        with pytest.raises(RuntimeError, match="exceeds encoder vocab"):
+            mod.main()
+    finally:
+        sys.argv = orig
+
+
+def test_meta_id_range_force_reinit(tmp_path, caplog):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", 2)
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 5},
+        attr_names={"n": ["foo"]},
+        attr_dim=1,
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+        vocab_size=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n")],
+            "in_dims": {"n": 5},
+            "num_relations": 1,
+        },
+        meta_path,
+    )
+
+    out_file = tmp_path / "model.pt"
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--force-reinit",
+        "--output",
+        str(out_file),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig = sys.argv
+    sys.argv = argv
+    caplog.set_level("INFO")
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig
+
+    state = torch.load(out_file)["model"]
+    assert state["encoder.meta_embed.weight"].size(0) >= 3
+    assert any("Epoch 1" in rec.message for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- add `collect_max_meta_id` helper to compute maximum `_id` tensor values
- rebuild `meta_embed` on demand when datasets require larger vocabularies
- error out when metadata IDs exceed available embeddings
- validate vocab size during SelfGCL pretraining
- test new behaviour for `train_res_gcl`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686424a0a4a8832ebcaae8e85213d202