### PR TITLE
Add metadata max id tracking and embedding resize

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -407,11 +407,13 @@ def main() -> None:
 
     from graphs.dataset import collect_dataset_metadata
 
-    dataset_metadata, in_dims, attr_names = collect_dataset_metadata(
+    dataset_metadata, in_dims, attr_names, max_ids = collect_dataset_metadata(
         [train_dl.dataset, val_dl.dataset],
         attr_dim=encoder.attr_dim,
         strict=args.strict_metadata,
     )
+
+    required_vocab = max(max_ids.values(), default=-1) + 1
 
     metadata = dataset_metadata
 
@@ -504,19 +506,22 @@ def main() -> None:
             if len(snap_edges) < snap_rels:
                 snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
             metadata = (metadata[0], snap_edges[:snap_rels])
+        vocab_size = (
+            int(meta_snapshot.get("vocab_size"))
+            if meta_snapshot is not None and "vocab_size" in meta_snapshot
+            else (
+                encoder.meta_embed.num_embeddings
+                if encoder.meta_embed is not None
+                else 0
+            )
+        )
+        if required_vocab > vocab_size:
+            vocab_size = required_vocab
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,
             attr_names=attr_names if metadata[0] else None,
-            vocab_size=(
-                int(meta_snapshot.get("vocab_size"))
-                if meta_snapshot is not None and "vocab_size" in meta_snapshot
-                else (
-                    encoder.meta_embed.num_embeddings
-                    if encoder.meta_embed is not None
-                    else 0
-                )
-            ),
+            vocab_size=vocab_size,
             attr_dim=encoder.attr_dim,
             hidden_dim=hidden_dim,
             num_layers=len(encoder.convs),
@@ -526,6 +531,12 @@ def main() -> None:
             target_node=encoder.target_node,
         )
         state = encoder.state_dict()
+        if "meta_embed.weight" in state and new_enc.meta_embed is not None:
+            old_w = state["meta_embed.weight"]
+            new_w = new_enc.meta_embed.weight.data
+            copy = min(old_w.size(0), new_w.size(0))
+            new_w[:copy] = old_w[:copy]
+            state["meta_embed.weight"] = new_w
         filtered = filter_state_dict(new_enc, state, logger=LOGGER)
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -921,7 +921,7 @@ def _load_model_hparams(
             encoder_args[k] = model_cfg.pop(k)
 
     attr_dim = int(model_cfg.get("attr_dim", 32))
-    metadata, in_dims, attr_names = collect_dataset_metadata(
+    metadata, in_dims, attr_names, _ = collect_dataset_metadata(
         datasets,
         attr_dim=attr_dim,
         strict=strict,

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -210,11 +210,13 @@ def main(argv: list[str] | None = None) -> None:
         embed_dir=args.embed_dir,
     )
 
-    dataset_metadata, in_dims, attr_names = collect_dataset_metadata(
+    dataset_metadata, in_dims, attr_names, max_ids = collect_dataset_metadata(
         [train_ds, val_ds],
         attr_dim=encoder.attr_dim,
         strict=args.strict_metadata,
     )
+
+    required_vocab = max(max_ids.values(), default=-1) + 1
 
     train_dl, val_dl = make_dataloaders(
         root,
@@ -291,15 +293,18 @@ def main(argv: list[str] | None = None) -> None:
             if len(snap_edges) < snap_rels:
                 snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
             metadata = (metadata[0], snap_edges[:snap_rels])
+        vocab_size = (
+            int(meta_snapshot.get("vocab_size"))
+            if meta_snapshot is not None and "vocab_size" in meta_snapshot
+            else (encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0)
+        )
+        if required_vocab > vocab_size:
+            vocab_size = required_vocab
         new_enc = RGCNEncoder(
             metadata=metadata,
             in_dims=in_dims,
             attr_names=attr_names if isinstance(g0, HeteroData) else None,
-            vocab_size=(
-                int(meta_snapshot.get("vocab_size"))
-                if meta_snapshot is not None and "vocab_size" in meta_snapshot
-                else (encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0)
-            ),
+            vocab_size=vocab_size,
             attr_dim=encoder.attr_dim,
             hidden_dim=hidden_dim,
             num_layers=len(encoder.convs),
@@ -309,6 +314,12 @@ def main(argv: list[str] | None = None) -> None:
             target_node=encoder.target_node,
         )
         state = encoder.state_dict()
+        if "meta_embed.weight" in state and new_enc.meta_embed is not None:
+            old_w = state["meta_embed.weight"]
+            new_w = new_enc.meta_embed.weight.data
+            copy = min(old_w.size(0), new_w.size(0))
+            new_w[:copy] = old_w[:copy]
+            state["meta_embed.weight"] = new_w
         filtered = filter_state_dict(new_enc, state, logger=LOGGER)
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -547,6 +547,7 @@ def collect_dataset_metadata(
     tuple[list[str], list[tuple[str, str, str]]],
     dict[str, int],
     dict[str, list[str]],
+    dict[str, int],
 ]:
     """Iterate over one or more datasets and gather union metadata.
 
@@ -582,6 +583,7 @@ def collect_dataset_metadata(
     edge_types: list[tuple[str, str, str]] = []
     feat_dim: dict[str, int] = defaultdict(int)
     attr_map: dict[str, set[str]] = defaultdict(set)
+    max_ids: dict[str, int] = defaultdict(int)
 
     for d in datasets:
         for i in range(len(d)):
@@ -600,15 +602,23 @@ def collect_dataset_metadata(
                 for nt in g.node_types:
                     store = g[nt]
                     feat_dim[nt] = max(feat_dim[nt], getattr(store, "x").size(-1))
-                    names = [k[:-3] for k in store.keys() if k.endswith("_id")]
-                    attr_map[nt].update(names)
+                    for key, val in store.items():
+                        if key.endswith("_id") and isinstance(val, torch.Tensor):
+                            name = key[:-3]
+                            attr_map[nt].add(name)
+                            if val.numel() > 0:
+                                max_ids[name] = max(max_ids[name], int(val.max()))
             else:  # Data
                 if "" not in node_types:
                     node_types.append("")
                 if hasattr(g, "x"):
                     feat_dim[""] = max(feat_dim.get("", 0), g.x.size(-1))
-                names = [k[:-3] for k in g.keys() if k.endswith("_id")]
-                attr_map[""].update(names)
+                for key, val in g.items():
+                    if key.endswith("_id") and isinstance(val, torch.Tensor):
+                        name = key[:-3]
+                        attr_map[""].add(name)
+                        if val.numel() > 0:
+                            max_ids[name] = max(max_ids[name], int(val.max()))
 
     attr_names = {nt: sorted(names) for nt, names in attr_map.items()}
     in_dims = {nt: feat_dim[nt] + len(attr_names.get(nt, [])) * attr_dim for nt in feat_dim}
@@ -664,4 +674,4 @@ def collect_dataset_metadata(
             )
 
     metadata = (node_types, edge_types_full[:num_relations])
-    return metadata, in_dims, attr_names
+    return metadata, in_dims, attr_names, dict(max_ids)

--- a/tests/test_collect_dataset_metadata.py
+++ b/tests/test_collect_dataset_metadata.py
@@ -109,7 +109,7 @@ def test_collect_metadata_preserves_order(tmp_path):
     (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\nb,1\n")
 
     ds = GraphDataset(tmp_path, split="train", require_labels=True)
-    metadata, _, _ = collect_dataset_metadata(ds)
+    metadata, _, _, _ = collect_dataset_metadata(ds)
     node_types, edge_types = metadata
 
     from src.graphs.normalizers.schema import EDGE_TYPES
@@ -132,7 +132,7 @@ def test_collect_metadata_empty_edge_type(tmp_path):
     (tmp_path / "train" / "labels.csv").write_text("sha256,label\na,0\n")
 
     ds = GraphDataset(tmp_path, split="train", require_labels=True)
-    metadata, _, _ = collect_dataset_metadata(ds)
+    metadata, _, _, _ = collect_dataset_metadata(ds)
 
     from src.graphs.normalizers.schema import EDGE_TYPES
 

--- a/tests/test_train_res_gcl_auto_reinit.py
+++ b/tests/test_train_res_gcl_auto_reinit.py
@@ -294,3 +294,61 @@ def test_dataloaders_recreated_after_reinit(tmp_path, monkeypatch, caplog):
     assert calls[-1] == {"n": ["bar", "baz"]}
     assert any("Epoch 1" in rec.message for rec in caplog.records)
     assert out_path.with_suffix(".meta.pkl").is_file()
+
+
+def test_meta_embed_expansion(tmp_path):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        g = HeteroData()
+        g["n"].x = torch.randn(1, 4)
+        g["n"].num_nodes = 1
+        g["n"].foo_id = torch.tensor([3])
+        ei = torch.tensor([[0], [0]])
+        g[("n", "r0", "n")].edge_index = ei
+        g[("n", "r0", "n")].edge_type = torch.zeros(1, dtype=torch.long)
+        torch.save(g, gdir / "a.pt")
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        attr_names={"n": ["foo"]},
+        vocab_size=2,
+        attr_dim=1,
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    out_path = tmp_path / "model.pt"
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(out_path),
+        "--force-reinit",
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    state = torch.load(out_path)["model"]
+    assert state["encoder.meta_embed.weight"].size(0) >= 4


### PR DESCRIPTION
## Summary
- track maximum metadata ids in `collect_dataset_metadata`
- reinitialize embedding layers to fit dataset when running `train_res_gcl.py` and `finetune_supcon.py`
- adjust CLI metadata collection and model hyperparam loader
- expand embedding during reinit and preserve old weights
- add unit test for embedding expansion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864266f723c832ea0d3560d47af1afd