### PR TITLE
Ensure loaders refresh after reinit

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -541,7 +541,14 @@ def main() -> None:
         new_enc.load_state_dict(filtered, strict=False)
         encoder = new_enc
         dataset_metadata = metadata
-
+        train_dl, val_dl = make_dataloaders(
+            args.splits_dir,
+            args.split,
+            args.batch_size,
+            attr_names=encoder.attr_names,
+            balanced=args.balanced,
+            embed_dir=args.embed_dir,
+        )
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)
     dataset_ntypes = list(dataset_metadata[0])
@@ -558,8 +565,8 @@ def main() -> None:
         LOGGER.error(msg)
         raise RuntimeError(msg)
 
-    # Optional: check whether dataset provides required metadata attributes
     g0, _, _ = train_dl.dataset[0]
+    # Optional: check whether dataset provides required metadata attributes
     if isinstance(g0, HeteroData):
         for nt, expected in encoder.attr_names.items():
             present = {k[:-3] for k in g0[nt].keys() if k.endswith("_id")}

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -331,6 +331,7 @@ def main(argv: list[str] | None = None) -> None:
             attr_names=encoder.attr_names,
             embed_dir=args.embed_dir,
         )
+        g0, _, _ = train_dl.dataset[0]
 
     first_conv = getattr(encoder.convs[0], "sublayer", encoder.convs[0])
     model_rels = first_conv.weight.size(0)


### PR DESCRIPTION
## Summary
- recreate dataloaders after regenerating encoders
- reload a sample graph from the updated loader for metadata checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643d94531c832ea04b2d704070b911