### PR TITLE
Track max_ids in metadata snapshots

### DIFF
--- a/src/cli/finetune_supcon.py
+++ b/src/cli/finetune_supcon.py
@@ -413,6 +413,7 @@ def main() -> None:
         strict=args.strict_metadata,
     )
 
+    # minimum vocabulary size needed for metadata attributes
     required_vocab = max(max_ids.values(), default=-1) + 1
 
     metadata = dataset_metadata
@@ -506,9 +507,19 @@ def main() -> None:
             if len(snap_edges) < snap_rels:
                 snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
             metadata = (metadata[0], snap_edges[:snap_rels])
+        snapshot_vocab = None
+        if meta_snapshot is not None:
+            if "vocab_size" in meta_snapshot:
+                snapshot_vocab = int(meta_snapshot["vocab_size"])
+            else:
+                LOGGER.warning(
+                    "Meta snapshot missing 'vocab_size' – using checkpoint embedding size"
+                )
+            if "max_ids" not in meta_snapshot:
+                LOGGER.warning("Meta snapshot missing 'max_ids'")
         vocab_size = (
-            int(meta_snapshot.get("vocab_size"))
-            if meta_snapshot is not None and "vocab_size" in meta_snapshot
+            snapshot_vocab
+            if snapshot_vocab is not None
             else (
                 encoder.meta_embed.num_embeddings
                 if encoder.meta_embed is not None
@@ -648,6 +659,7 @@ def main() -> None:
                 "vocab_size": encoder.meta_embed.num_embeddings
                 if encoder.meta_embed is not None
                 else 0,
+                "max_ids": {k: int(v) for k, v in max_ids.items()},
             }
             try:
                 torch.save(meta_info, meta_out)

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -216,6 +216,7 @@ def main(argv: list[str] | None = None) -> None:
         strict=args.strict_metadata,
     )
 
+    # minimum vocabulary size needed for metadata attributes
     required_vocab = max(max_ids.values(), default=-1) + 1
 
     train_dl, val_dl = make_dataloaders(
@@ -293,9 +294,19 @@ def main(argv: list[str] | None = None) -> None:
             if len(snap_edges) < snap_rels:
                 snap_edges.extend(metadata[1][len(snap_edges):snap_rels])
             metadata = (metadata[0], snap_edges[:snap_rels])
+        snapshot_vocab = None
+        if meta_snapshot is not None:
+            if "vocab_size" in meta_snapshot:
+                snapshot_vocab = int(meta_snapshot["vocab_size"])
+            else:
+                LOGGER.warning(
+                    "Meta snapshot missing 'vocab_size' – using checkpoint embedding size"
+                )
+            if "max_ids" not in meta_snapshot:
+                LOGGER.warning("Meta snapshot missing 'max_ids'")
         vocab_size = (
-            int(meta_snapshot.get("vocab_size"))
-            if meta_snapshot is not None and "vocab_size" in meta_snapshot
+            snapshot_vocab
+            if snapshot_vocab is not None
             else (encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0)
         )
         if required_vocab > vocab_size:
@@ -400,6 +411,7 @@ def main(argv: list[str] | None = None) -> None:
         "in_dims": {k: int(v) for k, v in in_dims.items()},
         "num_relations": len(metadata[1]),
         "vocab_size": encoder.meta_embed.num_embeddings if encoder.meta_embed is not None else 0,
+        "max_ids": {k: int(v) for k, v in max_ids.items()},
     }
     try:
         torch.save(meta_info, meta_out)

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -567,11 +567,14 @@ def collect_dataset_metadata(
 
     Returns
     -------
-    metadata, in_dims, attr_names
+    metadata, in_dims, attr_names, max_ids
         ``metadata`` is the ``(node_types, edge_types)`` tuple suitable for
         :class:`RGCNEncoder`.  ``in_dims`` maps node types to the required input
         feature dimensions and ``attr_names`` lists metadata attribute names for
-        each node type.
+        each node type. ``max_ids`` records the maximum observed ``<name>_id``
+        value for every metadata attribute across the dataset. The union of
+        these IDs determines the minimum ``vocab_size`` required when
+        constructing :class:`RGCNEncoder`.
     """
 
     from torch_geometric.data import HeteroData


### PR DESCRIPTION
## Summary
- document that `collect_dataset_metadata` returns `max_ids`
- compute minimal vocab size from `max_ids` in train and finetune CLIs
- warn if a loaded meta snapshot lacks `vocab_size` or `max_ids`
- save `max_ids` in new `.meta.pkl` files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68643f5a9968832e801c3c8d450e15d0