### PR TITLE
Filter unused checkpoint metadata

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -284,7 +284,40 @@ def main(argv: list[str] | None = None) -> None:
         )
         dropout = encoder.drop.p if isinstance(encoder.drop, nn.Dropout) else 0.0
         residual = hasattr(encoder.convs[0], "sublayer")
-        if (
+        if meta_snapshot is not None and not args.force_reinit:
+            snap_ntypes = list(meta_snapshot.get("node_types", []))
+            ds_ntypes = list(metadata[0])
+            new_ntypes: list[str] = []
+            for nt in snap_ntypes:
+                if nt in ds_ntypes:
+                    new_ntypes.append(nt)
+                else:
+                    LOGGER.info(
+                        "removed unused node type '%s' from checkpoint metadata",
+                        nt,
+                    )
+            for nt in ds_ntypes:
+                if nt not in new_ntypes:
+                    new_ntypes.append(nt)
+
+            snap_edges = [tuple(e) for e in meta_snapshot.get("edge_types", [])]
+            snap_rels = int(meta_snapshot.get("num_relations", len(snap_edges)))
+            snap_edges = snap_edges[:snap_rels]
+            ds_edges_set = {tuple(e) for e in metadata[1]}
+            new_edges: list[tuple[str, str, str]] = []
+            for et in snap_edges:
+                if et in ds_edges_set:
+                    new_edges.append(et)
+                else:
+                    LOGGER.info(
+                        "removed unused relation %s from checkpoint metadata", et
+                    )
+            for et in metadata[1]:
+                tup = tuple(et)
+                if tup not in new_edges:
+                    new_edges.append(tup)
+            metadata = (new_ntypes, new_edges)
+        elif (
             meta_snapshot is not None
             and "num_relations" in meta_snapshot
             and not args.force_reinit


### PR DESCRIPTION
## Summary
- filter node types and relations from checkpoint metadata when creating a new encoder
- log removed node types and relations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644078c488832ebd44ac2e2925d64c