### PR TITLE
Update README for embedding changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ step or provide `--embed-dir` to point to the cached embeddings.
 If feature dimensions are larger than the checkpoint expects, the projection
 layer will be reinitialised. Run pretraining with the same embeddings to reuse
 weights.
+If this simple reinitialisation does not resolve loading errors, you must
+restart from `pretrain_selfgcl` and run `finetune_supcon` again.
 `--meta-path` automatically handles mismatched input layers using the
 saved meta snapshot without needing `--force-reinit`.
 If omitted, `finetune_supcon` will look for `encoder.pt`'s sibling
@@ -141,6 +143,8 @@ If omitted, `finetune_supcon` will look for `encoder.pt`'s sibling
 `--monitor` chooses the metric used for early stopping (`f1`, `auroc`, or `both`).
 
 # RES-GCL 분류기 학습
+# 토큰 임베딩 차원을 변경했다면 `pretrain_selfgcl`과 `finetune_supcon`을 다시
+# 실행한 뒤에 이 단계를 수행해야 합니다.
 python -m cli.train_res_gcl \
        --encoder-checkpoint models/gnn/encoder.pt \
        --meta-path models/gnn/encoder.meta.pkl \


### PR DESCRIPTION
## Summary
- clarify that reinitialization may require starting from pretraining
- warn that RES-GCL training must rerun pretraining and fine-tuning when token embedding size changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644089339c832e98a49c11e125b12b