### PR TITLE
Check meta snapshot fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ python -m cli.pretrain_selfgcl data/hetero \
     --plot-path results/train_plot.png
 
 # 위 명령을 실행하면 encoder.pt와 함께 그래프 메타데이터가
-# models/gnn/encoder.meta.pkl로 저장됩니다.
+# models/gnn/encoder.meta.pkl로 저장됩니다. 이 파일에는
+# `node_types`, `edge_types`, `in_dims`, `num_relations`,
+# `vocab_size`, `max_ids` 필드가 포함되어야 합니다.
+# `vocab_size`나 `max_ids`가 빠진 스냅샷을 사용하면
+# `train_res_gcl` 실행 시 오류가 발생하며 `--force-reinit`
+# 옵션으로만 무시할 수 있습니다.
 
 그래프 간 노드 속성 집합을 먼저 검증하며, 불일치 시 경고가 출력됩니다.
 `--reprocess` 플래그를 주면 processed 데이터셋을 자동으로 다시 생성합니다.

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -192,6 +192,13 @@ def main(argv: list[str] | None = None) -> None:
                 meta_snapshot.setdefault(
                     "num_relations", len(meta_snapshot.get("edge_types", []))
                 )
+                missing = [k for k in ("vocab_size", "max_ids")
+                           if k not in meta_snapshot]
+                if missing and not args.force_reinit:
+                    raise RuntimeError(
+                        "Meta snapshot is missing required keys: "
+                        + ", ".join(missing)
+                    )
         except Exception as exc:  # pragma: no cover - I/O handling
             LOGGER.warning(
                 "Failed to load meta snapshot %s: %s", args.meta_path, exc

--- a/tests/test_train_res_gcl_meta_fields.py
+++ b/tests/test_train_res_gcl_meta_fields.py
@@ -1,0 +1,120 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+
+
+def _make_graph(path: Path) -> None:
+    g = HeteroData()
+    g["n"].x = torch.randn(2, 4)
+    g["n"].num_nodes = 2
+    ei = torch.tensor([[0, 1], [1, 0]])
+    g[("n", "r0", "n")].edge_index = ei
+    g[("n", "r0", "n")].edge_type = torch.zeros(ei.size(1), dtype=torch.long)
+    torch.save(g, path)
+
+
+def _prepare(tmp_path: Path):
+    data_root = tmp_path / "data"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt")
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=(["n"], [("n", "r0", "n")]),
+        in_dims={"n": 4},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": ["n"],
+            "edge_types": [("n", "r0", "n")],
+            "in_dims": {"n": 4},
+            "num_relations": 1,
+        },
+        meta_path,
+    )
+
+    return data_root, ckpt, meta_path
+
+
+def test_meta_missing_fields_error(tmp_path):
+    data_root, ckpt, meta_path = _prepare(tmp_path)
+
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(tmp_path / "model.pt"),
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        with pytest.raises(RuntimeError, match="missing required keys"):
+            mod.main()
+    finally:
+        sys.argv = orig_argv
+
+
+def test_force_reinit_allows_missing_fields(tmp_path):
+    data_root, ckpt, meta_path = _prepare(tmp_path)
+
+    out_path = tmp_path / "model.pt"
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(out_path),
+        "--force-reinit",
+    ]
+
+    mod = importlib.import_module("src.cli.train_res_gcl")
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert out_path.is_file()


### PR DESCRIPTION
## Summary
- validate `vocab_size` and `max_ids` when loading meta snapshot in `train_res_gcl`
- document required `encoder.meta.pkl` fields
- test failure on missing meta fields and success with `--force-reinit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686447813878832e9c2e93f27add73e6