### PR TITLE
Add metadata fields and improve snapshot warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ python -m cli.pretrain_selfgcl data/hetero \
 # `node_types`, `edge_types`, `in_dims`, `num_relations`,
 # `vocab_size`, `max_ids` 필드가 포함되어야 합니다.
 # `vocab_size`나 `max_ids`가 빠진 스냅샷을 사용하면
-# `train_res_gcl` 실행 시 오류가 발생하며 `--force-reinit`
-# 옵션으로만 무시할 수 있습니다.
+# `train_res_gcl` 실행 시 오류가 발생하며, 메시지에서
+# 재학습 또는 `--force-reinit` 옵션 사용을 안내합니다.
 
 그래프 간 노드 속성 집합을 먼저 검증하며, 불일치 시 경고가 출력됩니다.
 `--reprocess` 플래그를 주면 processed 데이터셋을 자동으로 다시 생성합니다.

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -921,7 +921,7 @@ def _load_model_hparams(
             encoder_args[k] = model_cfg.pop(k)
 
     attr_dim = int(model_cfg.get("attr_dim", 32))
-    metadata, in_dims, attr_names, _ = collect_dataset_metadata(
+    metadata, in_dims, attr_names, max_ids = collect_dataset_metadata(
         datasets,
         attr_dim=attr_dim,
         strict=strict,
@@ -960,6 +960,8 @@ def _load_model_hparams(
         "edge_types": [tuple(e) for e in metadata[1]],
         "in_dims": {k: int(v) for k, v in in_dims.items()},
         "num_relations": len(metadata[1]),
+        "vocab_size": vocab_size,
+        "max_ids": {k: int(v) for k, v in max_ids.items()},
     }
     return params, target_node, meta_info
 

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -198,6 +198,7 @@ def main(argv: list[str] | None = None) -> None:
                     raise RuntimeError(
                         "Meta snapshot is missing required keys: "
                         + ", ".join(missing)
+                        + ". Re-run pretraining or use --force-reinit."
                     )
         except Exception as exc:  # pragma: no cover - I/O handling
             LOGGER.warning(

--- a/tests/test_train_res_gcl_meta_fields.py
+++ b/tests/test_train_res_gcl_meta_fields.py
@@ -80,7 +80,7 @@ def test_meta_missing_fields_error(tmp_path):
     orig_argv = sys.argv
     sys.argv = argv
     try:
-        with pytest.raises(RuntimeError, match="missing required keys"):
+        with pytest.raises(RuntimeError, match="Re-run pretraining or use --force-reinit"):
             mod.main()
     finally:
         sys.argv = orig_argv


### PR DESCRIPTION
## Summary
- include dataset `max_ids` when loading hparams for pretraining
- store `vocab_size` and `max_ids` in encoder meta snapshots
- warn about re-training or `--force-reinit` when old snapshots are used
- document snapshot error guidance in README

## Testing
- `python -m py_compile src/cli/pretrain_selfgcl.py src/cli/train_res_gcl.py tests/test_train_res_gcl_meta_fields.py`
- `pytest tests/test_train_res_gcl_meta_fields.py -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6864670eae84832eb11b4ff4fa006db4