### PR TITLE
Warn when embedding files are missing

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -351,6 +351,9 @@ class GraphDataset(Dataset):
             return g
         embed_file = self.embed_dir / f"{sha}.ftr"
         if not embed_file.is_file():
+            if not getattr(self, "_warn_missing_embed", False):
+                _LOG.warning("embed file '%s' not found for %s", embed_file.name, sha)
+                self._warn_missing_embed = True
             return g
         if not isinstance(g, HeteroData) or "token" not in g.node_types:
             return g


### PR DESCRIPTION
## Summary
- log a warning if a graph embed file is missing
- only warn once per dataset instance to avoid spam

## Testing
- `pytest tests/test_graph_dataset_embeds.py -q`
- `pytest -k graph_dataset -q`

------
https://chatgpt.com/codex/tasks/task_e_68646ea8de78832ebcc899326877eec4