### PR TITLE
Add embed-dir option to SelfGraphCL CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ python -m cli.pretrain_selfgcl data/hetero \
     --config configs/self_gcl.yaml \
     --epochs 30 \
     --batch-size 256 \
+    --embed-dir data/embeds \
     --lr 1e-3 \
     --output models/gnn/encoder.pt \
     --plot-path results/train_plot.png

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -654,6 +654,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--gpu", type=int, default=0, help="CUDA device id (‑1 ⇒ CPU)")
     p.add_argument("--num-workers", type=int, default=4)
     p.add_argument(
+        "--embed-dir",
+        type=Path,
+        default=None,
+        help="Directory with cached token embeddings (default: <graph_dir>/embeds)",
+    )
+    p.add_argument(
         "--strict-metadata",
         action="store_true",
         help="Raise error on invalid edge_type indices in graphs",
@@ -699,9 +705,13 @@ def main():
     train_shas = split_json["train"]
     val_shas = split_json.get("val")
 
-    train_ds = HeteroGraphDiskDataset(args.graph_dir, sha_list=train_shas)
+    train_ds = HeteroGraphDiskDataset(
+        args.graph_dir, sha_list=train_shas, embed_dir=args.embed_dir
+    )
     val_ds = (
-        HeteroGraphDiskDataset(args.graph_dir, sha_list=val_shas)
+        HeteroGraphDiskDataset(
+            args.graph_dir, sha_list=val_shas, embed_dir=args.embed_dir
+        )
         if val_shas is not None
         else None
     )
@@ -710,7 +720,9 @@ def main():
         if args.reprocess:
             LOGGER.info("Reprocessing dataset …")
             train_ds.process()
-            train_ds = HeteroGraphDiskDataset(args.graph_dir, sha_list=train_shas)
+            train_ds = HeteroGraphDiskDataset(
+                args.graph_dir, sha_list=train_shas, embed_dir=args.embed_dir
+            )
         else:
             LOGGER.warning(
                 "Attribute mismatch detected. Re-run with --reprocess to rebuild"


### PR DESCRIPTION
## Summary
- support `--embed-dir` for `pretrain_selfgcl`
- document using cached embeddings in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646e907bd0832eb6376d430a21fde7