### PR TITLE
Update training instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ flowchart TD
 [11]: https://arxiv.org/abs/1707.06347?utm_source=chatgpt.com "Proximal Policy Optimization Algorithms"
 [12]: https://arxiv.org/pdf/2402.11565?utm_source=chatgpt.com "[PDF] Continual Learning on Graphs: Challenges, Solutions, and ... - arXiv"
 
+## 학습 절차
+
+1. `embeds`
+2. `pretrain_selfgcl`
+3. `finetune_supcon`
+4. `train_res_gcl`
+
 ```bash
 python -m cli.preprocessing --input-dir data/raw/benign --out . labels --label 0  --csv data/meta.csv
 python -m cli.preprocessing --input-dir data/raw/malware --out . labels --label 1 --csv data/meta.csv
@@ -102,13 +109,14 @@ python -m cli.pretrain_selfgcl data/hetero \
     --epochs 30 \
     --batch-size 256 \
     --lr 1e-3 \
+    --embed-dir data/embeds \
     --output models/gnn/encoder.pt \
     --plot-path results/train_plot.png
 
 # 위 명령을 실행하면 encoder.pt와 함께 그래프 메타데이터가
 # models/gnn/encoder.meta.pkl로 저장됩니다. 이 파일에는
-# `node_types`, `edge_types`, `in_dims`, `num_relations`,
-# `vocab_size`, `max_ids` 필드가 포함되어야 합니다.
+# `node_types`, `edge_types`, `in_dims`, `num_relations` 외에도
+# `vocab_size`와 `max_ids`가 저장됩니다.
 # `vocab_size`나 `max_ids`가 빠진 스냅샷을 사용하면
 # `train_res_gcl` 실행 시 오류가 발생하며, 메시지에서
 # 재학습 또는 `--force-reinit` 옵션 사용을 안내합니다.
@@ -128,6 +136,7 @@ python -m cli.finetune_supcon \
        --split "2023Q4" \
        --epochs 100 --batch-size 128 \
        --lr 1e-4 --patience 3 --monitor both \
+       --embed-dir data/embeds \
        --plot-path results/finetune_supcon/train.png
 # 훈련이 끝나면 새롭게 저장된 메타 스냅샷을 기존 경로에 덮어써야 합니다.
 # 예) `cp runs/finetune_supcon/best_model.meta.pkl models/gnn/encoder_v2.meta.pkl`
@@ -156,6 +165,7 @@ python -m cli.train_res_gcl \
        --splits-dir data/splits \
        --epochs 50 --batch-size 256 \
        --lr 1e-3 \
+       --embed-dir data/embeds \
        --output models/gnn/res_gcl.pt \
        --force-reinit
 `--meta-path`에 지정한 메타 스냅샷이 존재하지 않으면 즉시 `RuntimeError`


### PR DESCRIPTION
## Summary
- document sequential training order in README
- show `--embed-dir data/embeds` usage for each stage
- clarify `encoder.meta.pkl` fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646eaecad0832e9c4faca29ac1d9a1