### PR TITLE
Streamline embed logging

### DIFF
--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -315,7 +315,7 @@ def run_embeds(args: argparse.Namespace) -> None:
     from src.models.llm_embed import CodeLLMNodeFeat, embed_corpus
 
     logger = _get_logger(args.log_level)
-    logger.info("[EMBEDS] model=%s  device=%s", args.model_name, args.device)
+    logger.debug("[EMBEDS] model=%s  device=%s", args.model_name, args.device)
     try:
         hetero_dir = Path(args.out_dir, "data", "hetero")
         if args.input_dir:
@@ -500,7 +500,7 @@ def main(argv: Sequence[str] | None = None) -> None:  # noqa: D401
         parser.set_defaults(**cfg)        # CLI 인자 < YAML < 코드 default
         args = parser.parse_args(argv)    # 재‑파싱
 
-    _get_logger(args.log_level).info("robust‑malware‑graph stage: %s", args.command.upper())
+    _get_logger(args.log_level).debug("robust‑malware‑graph stage: %s", args.command.upper())
     try:
         STAGES[args.command](args)
     except StageError:

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -72,7 +72,7 @@ class _Config:
     GPU_ID: int = 0  # 첫 번째 GPU 기본
 
     # --- Misc --------------------------------------------------------------- #
-    PRINT_CONFIG: bool = True  # 시작 시 config 로그 출력 여부
+    PRINT_CONFIG: bool = False  # 시작 시 config 로그 출력 여부
     EXP_NAME: str = "debug"   # 실험 폴더 이름(logs/EXP_NAME)
 
     # Derived attributes (set in __post_init__)

--- a/src/graphs/features/cache.py
+++ b/src/graphs/features/cache.py
@@ -101,7 +101,7 @@ def save_tensor(
     else:  # parquet
         pq.write_table(tbl, p, compression=compression)
 
-    _LOG.info("saved feat %s (%.2f MB)", p.name, p.stat().st_size / 2**20)
+    _LOG.debug("saved feat %s (%.2f MB)", p.name, p.stat().st_size / 2**20)
     return p
 
 
@@ -147,7 +147,7 @@ def load_tensor(
 def clear_memory_cache() -> None:
     """LRU 메모리 캐시 비우기."""
     _load_table_cached.cache_clear()
-    _LOG.info("feature memory cache cleared")
+    _LOG.debug("feature memory cache cleared")
 
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -328,7 +328,7 @@ def embed_corpus(
 
         embeddings: list[torch.Tensor] = []
         ranges = range(0, input_ids.size(0), batch_size)
-        for start in tqdm_wrap(ranges, desc=out_name, unit="batch"):
+        for start in ranges:
             batch_ids = input_ids[start : start + batch_size].to(device)
             if attn_mask is not None:
                 batch_mask = attn_mask[start : start + batch_size].to(device)


### PR DESCRIPTION
## Summary
- turn off config print by default
- silence preprocessing logs and feature cache info
- remove inner tqdm bar for batches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686474ba5f50832ea14fdd2bd1489a6f