### PR TITLE
Add graph sanitisation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ python -m cli.pretrain_selfgcl data/hetero \
 그래프 파일에 비숫자형 리스트 속성이 있을 경우 자동으로 메타에 저장됩니다.
 주소 정보가 없는 노드의 `addr` 속성은 0으로 채워집니다.
 
+`edge_index contains invalid node id` 오류가 발생할 경우 그래프 파일을
+다음 스크립트로 정제하면 해결됩니다.
+
+```bash
+python scripts/sanitise_graphs.py data/hetero data/hetero_clean
+```
+
+# GNN 학습
+
 # GNN 학습
 
 python -m cli.finetune_supcon \

--- a/scripts/sanitise_graphs.py
+++ b/scripts/sanitise_graphs.py
@@ -1,0 +1,53 @@
+import argparse
+from pathlib import Path
+import pickle
+import torch
+
+from src.graphs.dataset import GraphDataset
+
+
+def load_graph(path: Path):
+    if path.suffix == ".pt":
+        return torch.load(path, weights_only=False)
+    if path.name.endswith(".pyg.pkl"):
+        with path.open("rb") as f:
+            return pickle.load(f)
+    raise ValueError(f"Unsupported file type: {path}")
+
+
+def save_graph(graph, path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix == ".pt":
+        torch.save(graph, path)
+    elif path.name.endswith(".pyg.pkl"):
+        with path.open("wb") as f:
+            pickle.dump(graph, f)
+    else:
+        raise ValueError(f"Unsupported file type: {path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Rewrite graph files with sanitised edge_index values"
+    )
+    parser.add_argument("input_dir", type=Path, help="directory with original graphs")
+    parser.add_argument(
+        "output_dir", type=Path, help="directory to save cleaned graphs"
+    )
+    args = parser.parse_args()
+
+    in_dir = args.input_dir
+    out_dir = args.output_dir
+
+    paths = list(in_dir.rglob("*.pt")) + list(in_dir.rglob("*.pyg.pkl"))
+    for src_path in paths:
+        rel = src_path.relative_to(in_dir)
+        dst_path = out_dir / rel
+        graph = load_graph(src_path)
+        graph = GraphDataset._sanitize_edges(graph)
+        save_graph(graph, dst_path)
+        print(f"sanitised {src_path} -> {dst_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/sanitise_graphs.py` to remove edges with invalid node ids
- document how to fix "edge_index contains invalid node id" errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864949ab160832e8921f4a3f25e212e