### PR TITLE
Fix sanitise_graphs import path

### DIFF
--- a/scripts/sanitise_graphs.py
+++ b/scripts/sanitise_graphs.py
@@ -1,7 +1,12 @@
 import argparse
 from pathlib import Path
 import pickle
+import sys
 import torch
+
+# Add the repository root to the module search path so that "src" can be
+# imported when this script is executed directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.graphs.dataset import GraphDataset
 


### PR DESCRIPTION
## Summary
- update `scripts/sanitise_graphs.py` to ensure the project root is added to `sys.path` when executed directly

## Testing
- `pytest -k sanitise_graphs -q`

------
https://chatgpt.com/codex/tasks/task_e_6864969d457c832e820bb910ce72b970