### PR TITLE
Clear PyArrow cache in train_res_gcl

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -26,6 +26,7 @@ from graphs.dataset.graph_dataset import GraphDataset, _guess_graph_path
 from src.graphs.normalizers.schema import NodeType
 from src.models.gnn.encoder import RGCNEncoder
 from src.models.gnn.res_wrapper import RESGCLClassifier
+from graphs.features.cache import clear_memory_cache
 
 LOGGER = get_logger(__name__)
 
@@ -228,6 +229,8 @@ def main(argv: list[str] | None = None) -> None:
         attr_dim=encoder.attr_dim,
         strict=args.strict_metadata,
     )
+    # 메타데이터 수집 시 열어둔 피처 파일을 닫아 메모리 사용을 줄임
+    clear_memory_cache()
 
     # minimum vocabulary size needed for metadata attributes
     required_vocab = max(max_ids.values(), default=-1) + 1


### PR DESCRIPTION
## Summary
- clear PyArrow feature cache after collecting dataset metadata
- import `clear_memory_cache` in train_res_gcl CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649e531fe8832eb37a9542f7fe06bd