### PR TITLE
Add PPO dataset build CLI

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -51,6 +51,7 @@ _COMMANDS: Final[Dict[str, str]] = {
     "certify-res": "certify_res",
     "train-resgcl": "train_res_gcl",
     "train-explainer": "explainer_train",
+    "build-ppo-dataset": "build_ppo_dataset",
 }
 
 # Expose publicly in case external plugins need to introspect

--- a/src/cli/build_ppo_dataset.py
+++ b/src/cli/build_ppo_dataset.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Build Clean/Dummy PPO Dataset CLI"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import torch
+
+from common.logger import get_logger
+from common.utils import ensure_dir
+from graphs.dataset.graph_dataset import _guess_graph_path
+
+LOGGER = get_logger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Split graphs into clean/dummy lists for PPO",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--hetero-dir", type=Path, required=True, help="Directory of graph files")
+    p.add_argument("--labels", type=Path, required=True, help="CSV or JSONL (sha256,label)")
+    p.add_argument("--out-dir", type=Path, required=True, help="Output directory")
+    p.add_argument("--clean-label", type=int, default=0)
+    p.add_argument("--dummy-label", type=int, default=1)
+    return p.parse_args()
+
+
+def _load_labels(path: Path) -> Dict[str, int]:
+    labels: Dict[str, int] = {}
+    suffix = path.suffix.lower()
+    if suffix in {".csv", ".tsv"}:
+        with path.open("r", newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                sha = row.get("sha256")
+                label = row.get("label")
+                if sha is None or label is None:
+                    continue
+                labels[sha] = int(label)
+    elif suffix in {".jsonl", ".json"}:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                obj = json.loads(line)
+                sha = obj.get("sha256")
+                label = obj.get("label")
+                if sha is None or label is None:
+                    continue
+                labels[sha] = int(label)
+    else:
+        raise ValueError(f"Unsupported labels file: {path}")
+    return labels
+
+
+def _load_graph(graph_dir: Path, sha: str):
+    path = _guess_graph_path(graph_dir, sha)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    if path.suffix == ".pyg.pkl":
+        import pickle
+
+        with path.open("rb") as f:
+            return pickle.load(f)
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = parse_args() if argv is None else parse_args()
+    ensure_dir(args.out_dir)
+
+    label_map = _load_labels(args.labels)
+    clean_graphs: List[object] = []
+    dummy_graphs: List[object] = []
+
+    for sha, lab in label_map.items():
+        try:
+            g = _load_graph(args.hetero_dir, sha)
+        except FileNotFoundError:
+            LOGGER.warning("Graph for %s not found", sha)
+            continue
+
+        if lab == args.clean_label:
+            clean_graphs.append(g)
+        elif lab == args.dummy_label:
+            dummy_graphs.append(g)
+        else:
+            LOGGER.warning("Unknown label %s for %s", lab, sha)
+
+    torch.save(clean_graphs, args.out_dir / "clean.pt")
+    torch.save(dummy_graphs, args.out_dir / "dummy.pt")
+    LOGGER.info(
+        "Saved dataset \u2192 %s (clean:%d, dummy:%d)",
+        args.out_dir,
+        len(clean_graphs),
+        len(dummy_graphs),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new CLI tool `build_ppo_dataset` for preparing PPO rule training datasets
- register the command in the unified CLI package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649f509614832ea5f370671660269e