### PR TITLE
Add build-dataset CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,13 @@ python -m cli.rulegen_cli feature-mine \
        --graph-dir data/splits/ \
        --labels data/meta.csv \
        --out features.json
-       
+
+# 데이터셋 변환 예시
+python -m cli.rulegen_cli build-dataset \
+       --hetero-dir data/hetero \
+       --labels data/meta.csv \
+       --out-dir data/rulegen_dataset
+
 # 강화학습용 feature 추출
 
 python -m cli.rulegen_cli ppo-train \

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -53,6 +53,7 @@ import json
 import csv
 import logging
 import sys
+import subprocess
 from pathlib import Path
 from typing import List, Sequence
 
@@ -351,6 +352,28 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
         logger.info("%s = %.4f", k.upper(), v)
 
 
+def cmd_build_dataset(args: argparse.Namespace) -> None:
+    """Convert labeled graphs into PPO dataset format."""
+    logger = logging.getLogger("build-dataset")
+    cmd = [
+        sys.executable,
+        "-m",
+        "cli.build_ppo_dataset",
+        "--hetero-dir",
+        args.hetero_dir,
+        "--labels",
+        args.labels,
+        "--out-dir",
+        args.out_dir,
+        "--clean-label",
+        str(args.clean_label),
+        "--dummy-label",
+        str(args.dummy_label),
+    ]
+    logger.debug("Running %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
 # ---------------------------------------------------------------------------
 # Argument parser setup
 # ---------------------------------------------------------------------------
@@ -377,6 +400,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     fm.add_argument("--out", required=True, help="Output path for mined features (.json)")
     fm.set_defaults(func=cmd_feature_mine)
+
+    # ------------------- build-dataset ------------------- #
+    bd = sub.add_parser("build-dataset", help="Convert graphs to PPO dataset")
+    bd.add_argument("--hetero-dir", required=True, help="Directory of graph files")
+    bd.add_argument("--labels", required=True, help="CSV or JSONL (sha256,label)")
+    bd.add_argument("--out-dir", required=True, help="Output directory")
+    bd.add_argument("--clean-label", type=int, default=0, help="Label for clean graphs")
+    bd.add_argument("--dummy-label", type=int, default=1, help="Label for dummy graphs")
+    bd.set_defaults(func=cmd_build_dataset)
 
     # ------------------- ppo‑train ------------------- #
     pt = sub.add_parser("ppo-train", help="Train PPO rule agent")


### PR DESCRIPTION
## Summary
- wrap `build_ppo_dataset` in `cmd_build_dataset`
- add `build-dataset` sub-command to rulegen CLI
- document dataset conversion example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a05bb558832e8fc6c57204ffe506