### PR TITLE
Add load_pretrained alias for RESGCLClassifier

### DIFF
--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -210,3 +210,9 @@ class RESGCLClassifier(nn.Module):
         model = cls(encoder=encoder)
         model.load_state_dict(state, strict=False)
         return model
+
+    # ------------------------------------------------------------------ #
+    @classmethod
+    def load_pretrained(cls, path, *, map_location=None) -> "RESGCLClassifier":
+        """Backward-compatible alias for :meth:`load_from_checkpoint`."""
+        return cls.load_from_checkpoint(path, map_location=map_location)


### PR DESCRIPTION
## Summary
- add `load_pretrained` class method to `RESGCLClassifier`
- maintain backward compatibility with `load_from_checkpoint`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b66c097c832e949b755a0b20b61b