### PR TITLE
Fix dataset reload after cache clear

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -84,30 +84,52 @@ def build_parser() -> argparse.ArgumentParser:
 # --------------------------------------------------------------------------- #
 
 def make_dataloaders(
-    root: Path,
+    root: Path | None,
     batch_size: int,
     num_workers: int,
     *,
     attr_names: dict[str, list[str]] | None = None,
     embed_dir: Path | None = None,
+    train_ds: GraphDataset | None = None,
+    val_ds: GraphDataset | None = None,
 ) -> tuple[DataLoader, DataLoader]:
-    transform = T.Compose([
-        T.NormalizeFeatures(),
-    ])
-    train_ds = GraphDataset(
-        root=root,
-        split="train",
-        transform=transform,
-        require_labels=True,
-        embed_dir=embed_dir,
-    )
-    val_ds = GraphDataset(
-        root=root,
-        split="val",
-        transform=transform,
-        require_labels=True,
-        embed_dir=embed_dir,
-    )
+    """Construct :class:`~torch.utils.data.DataLoader` objects.
+
+    Parameters
+    ----------
+    root:
+        Dataset root directory. Only required when ``train_ds``/``val_ds`` are
+        not provided.
+    batch_size:
+        Batch size for the dataloaders.
+    num_workers:
+        Number of dataloader worker processes.
+    attr_names:
+        Optional attribute names for collation.
+    embed_dir:
+        Directory with token embeddings.
+    train_ds, val_ds:
+        Prebuilt datasets. If omitted, new :class:`GraphDataset` instances will
+        be created from ``root``.
+    """
+    if train_ds is None or val_ds is None:
+        if root is None:
+            raise ValueError("root is required when datasets are not provided")
+        transform = T.Compose([T.NormalizeFeatures()])
+        train_ds = GraphDataset(
+            root=root,
+            split="train",
+            transform=transform,
+            require_labels=True,
+            embed_dir=embed_dir,
+        )
+        val_ds = GraphDataset(
+            root=root,
+            split="val",
+            transform=transform,
+            require_labels=True,
+            embed_dir=embed_dir,
+        )
     use_cuda = torch.cuda.is_available()
     workers = 0 if use_cuda else num_workers
     train_dl = DataLoader(
@@ -232,6 +254,23 @@ def main(argv: list[str] | None = None) -> None:
     # 메타데이터 수집 시 열어둔 피처 파일을 닫아 메모리 사용을 줄임
     clear_memory_cache()
 
+    # reopen datasets to ensure feature handles are reset
+    del train_ds, val_ds
+    train_ds = GraphDataset(
+        root=root,
+        split="train",
+        transform=transform,
+        require_labels=True,
+        embed_dir=args.embed_dir,
+    )
+    val_ds = GraphDataset(
+        root=root,
+        split="val",
+        transform=transform,
+        require_labels=True,
+        embed_dir=args.embed_dir,
+    )
+
     # minimum vocabulary size needed for metadata attributes
     required_vocab = max(max_ids.values(), default=-1) + 1
 
@@ -250,11 +289,13 @@ def main(argv: list[str] | None = None) -> None:
                 break
 
     train_dl, val_dl = make_dataloaders(
-        root,
+        None,
         args.batch_size,
         args.num_workers,
         attr_names=attr_names,
         embed_dir=args.embed_dir,
+        train_ds=train_ds,
+        val_ds=val_ds,
     )
 
     # ``metadata`` may be adjusted later based on the checkpoint snapshot. Keep


### PR DESCRIPTION
## Summary
- reload GraphDataset instances after clearing the feature cache in `train_res_gcl`
- allow passing prebuilt datasets to `make_dataloaders`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c222cd54832e9e80b7dcf9b73180