### PR TITLE
Fix memory cache clearing location

### DIFF
--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -230,7 +230,8 @@ def main(argv: list[str] | None = None) -> None:
         strict=args.strict_metadata,
     )
     # 메타데이터 수집 시 열어둔 피처 파일을 닫아 메모리 사용을 줄임
-    clear_memory_cache()
+    # 학습 중에 캐시가 비워지면 DataLoader 를 다시 생성해야 하므로 호출을
+    # 학습 종료 시점으로 이동하거나 이후 DataLoader 재생성을 수행해야 한다.
 
     # minimum vocabulary size needed for metadata attributes
     required_vocab = max(max_ids.values(), default=-1) + 1
@@ -472,6 +473,8 @@ def main(argv: list[str] | None = None) -> None:
         )
         best_val = min(best_val, val_loss)
 
+    # 학습 과정에서 사용된 캐시를 정리하여 메모리 사용량을 최소화한다
+    clear_memory_cache()
     ensure_dir(args.output.parent)
     torch.save({"model": model.state_dict()}, args.output)
     meta_out = args.output.with_suffix(".meta.pkl")


### PR DESCRIPTION
## Summary
- adjust when `clear_memory_cache` is called in `train_res_gcl`
- free feature cache right before saving the model

## Testing
- `pytest -k train_res_gcl -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c2522d0c832ea77253b135455cbc