### PR TITLE
Add --no-embeds option for RES-GCL training

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ python -m cli.train_res_gcl \
        --epochs 50 --batch-size 256 \
        --lr 1e-3 \
        --embed-dir data/embeds \
+       [--no-embeds] \
        --output models/gnn/res_gcl.pt \
        --force-reinit
 `--meta-path`에 지정한 메타 스냅샷이 존재하지 않으면 즉시 `RuntimeError`

--- a/src/cli/train_res_gcl.py
+++ b/src/cli/train_res_gcl.py
@@ -67,6 +67,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--embed-dir", type=Path,
                    help="Directory containing token embeddings")
     p.add_argument("--device", type=str, default="cuda")
+    p.add_argument(
+        "--no-embeds",
+        action="store_true",
+        help="Skip loading token embeddings",
+    )
     p.add_argument("--num-workers", type=int, default=0)
     p.add_argument(
         "--strict-metadata",
@@ -90,6 +95,7 @@ def make_dataloaders(
     *,
     attr_names: dict[str, list[str]] | None = None,
     embed_dir: Path | None = None,
+    load_embeds: bool = True,
     train_ds: GraphDataset | None = None,
     val_ds: GraphDataset | None = None,
 ) -> tuple[DataLoader, DataLoader]:
@@ -108,6 +114,8 @@ def make_dataloaders(
         Optional attribute names for collation.
     embed_dir:
         Directory with token embeddings.
+    load_embeds:
+        Whether to load token embeddings stored under ``embed_dir``.
     train_ds, val_ds:
         Prebuilt datasets. If omitted, new :class:`GraphDataset` instances will
         be created from ``root``.
@@ -122,6 +130,7 @@ def make_dataloaders(
             transform=transform,
             require_labels=True,
             embed_dir=embed_dir,
+            load_embeds=load_embeds,
         )
         val_ds = GraphDataset(
             root=root,
@@ -129,6 +138,7 @@ def make_dataloaders(
             transform=transform,
             require_labels=True,
             embed_dir=embed_dir,
+            load_embeds=load_embeds,
         )
     use_cuda = torch.cuda.is_available()
     workers = 0 if use_cuda else num_workers
@@ -237,6 +247,7 @@ def main(argv: list[str] | None = None) -> None:
         transform=transform,
         require_labels=True,
         embed_dir=args.embed_dir,
+        load_embeds=not args.no_embeds,
     )
     val_ds = GraphDataset(
         root=root,
@@ -244,6 +255,7 @@ def main(argv: list[str] | None = None) -> None:
         transform=transform,
         require_labels=True,
         embed_dir=args.embed_dir,
+        load_embeds=not args.no_embeds,
     )
 
     dataset_metadata, in_dims, attr_names, max_ids = collect_dataset_metadata(
@@ -263,6 +275,7 @@ def main(argv: list[str] | None = None) -> None:
         transform=transform,
         require_labels=True,
         embed_dir=args.embed_dir,
+        load_embeds=not args.no_embeds,
     )
     val_ds = GraphDataset(
         root=root,
@@ -270,6 +283,7 @@ def main(argv: list[str] | None = None) -> None:
         transform=transform,
         require_labels=True,
         embed_dir=args.embed_dir,
+        load_embeds=not args.no_embeds,
     )
 
     # minimum vocabulary size needed for metadata attributes
@@ -295,6 +309,7 @@ def main(argv: list[str] | None = None) -> None:
         args.num_workers,
         attr_names=attr_names,
         embed_dir=args.embed_dir,
+        load_embeds=not args.no_embeds,
         train_ds=train_ds,
         val_ds=val_ds,
     )
@@ -453,6 +468,7 @@ def main(argv: list[str] | None = None) -> None:
             args.num_workers,
             attr_names=encoder.attr_names,
             embed_dir=args.embed_dir,
+            load_embeds=not args.no_embeds,
         )
         g0, _, _ = train_dl.dataset[0]
 

--- a/tests/test_train_res_gcl_no_embeds.py
+++ b/tests/test_train_res_gcl_no_embeds.py
@@ -1,0 +1,100 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.encoder import RGCNEncoder
+from src.graphs.normalizers.schema import NodeType, EdgeRel
+from src.graphs.features.cache import save_tensor
+
+
+def _make_graph(path: Path, embed_dir: Path) -> None:
+    g = HeteroData()
+    g[NodeType.TOKEN.value].x = torch.randn(1, 2)
+    g[NodeType.TOKEN.value].num_nodes = 1
+    ei = torch.tensor([[0], [0]])
+    et = (NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)
+    g[et].edge_index = ei
+    g[et].edge_type = torch.zeros(1, dtype=torch.long)
+    torch.save(g, path)
+    save_tensor(path.stem, torch.randn(1, 2), embed_dir)
+
+
+def test_train_res_gcl_no_embeds(tmp_path, monkeypatch):
+    data_root = tmp_path / "data"
+    embed_dir = data_root / "embeds"
+    for split in ("train", "val"):
+        gdir = data_root / split / "graphs"
+        gdir.mkdir(parents=True)
+        _make_graph(gdir / "a.pt", embed_dir)
+        (data_root / split / "labels.csv").write_text("sha256,label\na,0\n")
+
+    enc = RGCNEncoder(
+        metadata=([NodeType.TOKEN.value], [(NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)]),
+        in_dims={NodeType.TOKEN.value: 2},
+        hidden_dim=4,
+        num_layers=1,
+        out_dim=2,
+    )
+    ckpt = tmp_path / "enc.pt"
+    torch.save({"model": enc.state_dict()}, ckpt)
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {
+            "node_types": [NodeType.TOKEN.value],
+            "edge_types": [(NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)],
+            "in_dims": {NodeType.TOKEN.value: 2},
+            "num_relations": 1,
+        },
+        meta_path,
+    )
+
+    out_file = tmp_path / "model.pt"
+    argv = [
+        "train_res_gcl",
+        "--encoder-checkpoint",
+        str(ckpt),
+        "--meta-path",
+        str(meta_path),
+        "--splits-dir",
+        str(data_root),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--device",
+        "cpu",
+        "--output",
+        str(out_file),
+        "--no-embeds",
+    ]
+
+    importlib.invalidate_caches()
+    mod = importlib.import_module("src.cli.train_res_gcl")
+
+    calls = []
+    orig_init = mod.GraphDataset.__init__
+
+    def rec_init(self, *args, **kwargs):
+        calls.append(kwargs.get("load_embeds", True))
+        orig_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(mod.GraphDataset, "__init__", rec_init)
+
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert calls
+    assert all(c is False for c in calls)


### PR DESCRIPTION
## Summary
- add `--no-embeds` option to train_res_gcl CLI
- allow `make_dataloaders` to control embedding loading
- document optional flag in README
- test that the flag disables embedding loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686551c83f44832eb79f4164e36ce25a