### PR TITLE
Fix GumbelMaskSelector step parameter

### DIFF
--- a/src/explain/cfg_explainer/selector.py
+++ b/src/explain/cfg_explainer/selector.py
@@ -169,7 +169,7 @@ class GumbelMaskSelector(nn.Module):
     # --------------------------- single step API -------------------------- #
     def step(
         self,
-        sub_graph: Data | HeteroData,
+        graph: Data | HeteroData,
         full_graph_score: torch.Tensor,
         score_fn: Callable[[Data | HeteroData], torch.Tensor],
         optimizer: torch.optim.Optimizer,
@@ -179,51 +179,15 @@ class GumbelMaskSelector(nn.Module):
         hard: bool = False,
         loss_type: str = "bce",
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        Perform 1 optimization step on a subgraph.
-        """
+        """Perform 1 optimization step on ``graph``."""
         if not self.initialized:
             # This should be initialized on the full graph before calling this
             raise RuntimeError("Selector not initialized.")
 
         optimizer.zero_grad()
 
-        # Sample mask for the edges present in the subgraph
-        masks = {}
-        τ = float(self.tau)
-        for etype in iter_edge_types(sub_graph, self.view):
-            # The logits correspond to the full graph, so we need to find the
-            # original indices of the edges present in the subgraph.
-            # This information is not directly available in the subgraph object
-            # from k_hop_subgraph. We need to rethink this part.
-            # For now, let's assume we can get a mask for the subgraph edges.
-            # This part of the logic is complex and may need a different approach.
-            # A temporary simplification: apply mask to the subgraph edges directly.
-            # This is not entirely correct as logits are for the full graph.
-            num_edges = sub_graph[etype].edge_index.size(1)
-            # We need a way to map subgraph edges to full graph logit indices.
-            # Let's assume for now we train logits directly on the sampled subgraphs,
-            # which is a deviation from the original intent but might work under memory constraints.
-            # A better approach would be to pass the edge_mask from k_hop_subgraph.
-            
-            # Let's stick to the original logic but on the subgraph
-            # This requires initializing logits for the subgraph, which is not right.
-            # The logic needs to be reworked to handle logits for the full graph
-            # while operating on subgraphs.
-
-            # Let's revert to a simpler sampling inside train_loop and fix the step method.
-            # The issue is that the logits are per-edge of the *full* graph.
-            # When we sample a subgraph, we need to apply the corresponding logits.
-            
-            # The logic here is getting complicated. Let's simplify the whole process.
-            # We will stick to the original `step` function and modify `train_loop`
-            # to be more memory-efficient without subgraphing `score_fn`.
-            
-        # The error is likely not in the logic but in how tensors are handled.
-        # Let's re-implement the original step function with careful memory management.
-        
-        full_score = full_graph_score # Use the pre-computed score
-
+        # Use the pre-computed score for the full graph
+        full_score = full_graph_score
         masks = {}
         τ = float(self.tau)
         for etype in iter_edge_types(graph, self.view):
@@ -240,14 +204,14 @@ class GumbelMaskSelector(nn.Module):
                     keep[mask.argmax()] = True
                 else:
                     continue
-            
+
             store = masked_graph[etype]
             for k, v in store.items():
                 if torch.is_tensor(v) and v.size(0) == mask.size(0):
                     store[k] = v[keep]
-        
+
         masked_score = score_fn(masked_graph)
-        
+
         loss = self.loss(full_score, masked_score, m_prob, alpha=alpha, beta=beta, loss_type=loss_type)
         loss.backward()
         optimizer.step()


### PR DESCRIPTION
## Summary
- rename `sub_graph` parameter to `graph` in `GumbelMaskSelector.step`
- clean up outdated subgraph comments and use the passed graph parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686711d3479c832e8dd86eca899c7240