### PR TITLE
Disable classifier grad in explainer trainer

### DIFF
--- a/run_explainer_training.py
+++ b/run_explainer_training.py
@@ -37,6 +37,8 @@ def main():
     # Load the main classifier model
     model = RESGCLClassifier.load_from_checkpoint(args.model_path, map_location=device)
     model.to(device).eval()
+    for p in model.parameters():
+        p.requires_grad_(False)
     LOGGER.info("✓ Classifier loaded")
 
     # Create output directory


### PR DESCRIPTION
## Summary
- freeze parameters in `run_explainer_training.py` so gradients are not tracked

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686715c40538832eba3b74690d8eb163