### PR TITLE
Improve logger in explainer CLI

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -284,7 +284,9 @@ def mine_features(args: argparse.Namespace) -> None:
 
                     all_features.append({"sha256": sha, "features": features})
         except Exception as e:
-            LOGGER.error(f"Failed to process graph {g_path.name}: {e}")
+            LOGGER.error(
+                "Failed to process graph %s: %s", g_path.name, e, exc_info=True
+            )
             continue
 
     args.output_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- log full stacktrace in `explainer_train` when a graph fails to process

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686720364e24832eb3d79d9cff7ba81c