### PR TITLE
Add view option to train_selector utility

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -42,6 +42,7 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--alpha", type=float, default=1.0)
         pp.add_argument("--beta", type=float, default=2e-2)
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
+        pp.add_argument("--view", type=str, default="cfg", help="Edge relation view")
 
     # --- single graph ---
     s = sub.add_parser("single", help="Train selector on a single graph")
@@ -139,6 +140,7 @@ def _train_selector_for_graph(graph: HeteroData, model, args, device: torch.devi
     selector = train_selector(
         graph,
         model,
+        view=args.view,
         device=device,
         epochs=args.epochs,
         lr=args.lr,

--- a/src/explain/__init__.py
+++ b/src/explain/__init__.py
@@ -90,6 +90,7 @@ def run_full_pipeline(
     sha256: str,
     out_dir: str | Path = "./reports",
     device: str | torch.device = "cpu",
+    view: str = "cfg",
     selector_kwargs: Dict | None = None,
     ranker_kwargs: Dict | None = None,
     report_kwargs: Dict | None = None,
@@ -110,6 +111,8 @@ def run_full_pipeline(
         Output directory for HTML / MD / JSON.
     device : torch device
         GPU/CPU for selector & ranking ops.
+    view : str
+        Edge relation view for explanation.
     *kwargs
         Forwarded to underlying functions:
           • selector_kwargs → `train_selector`
@@ -125,6 +128,7 @@ def run_full_pipeline(
         cfg_graph,
         ast_graph,
         model,
+        view=view,
         device=device,
         selector_kwargs=selector_kwargs,
         ranker_kwargs=ranker_kwargs,

--- a/src/explain/cfg_explainer/__init__.py
+++ b/src/explain/cfg_explainer/__init__.py
@@ -60,6 +60,7 @@ def train_selector(
     cfg_graph: Data,
     model,
     *,
+    view: str = "cfg",
     device: str | torch.device = "cpu",
     epochs: int = 1_000,
     lr: float = 2e-3,
@@ -78,6 +79,8 @@ def train_selector(
         Full CFG graph.
     model : nn.Module or callable
         Frozen classifier that returns a single logit/score.
+    view : str
+        Edge relation view to train on (e.g., "cfg", "ast").
     device : str or torch.device
         Compute device for selector parameters.
     epochs, lr, alpha, beta
@@ -101,7 +104,7 @@ def train_selector(
         else:
             score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
 
-    selector = GumbelMaskSelector(view="cfg", device=device, **selector_kwargs)
+    selector = GumbelMaskSelector(view=view, device=device, **selector_kwargs)
     ensure_edgeaware_selector(selector, cfg_graph)
     selector.train_loop(
         cfg_graph.to(device),
@@ -121,6 +124,7 @@ def explain_cfg(
     ast_graph: Data,
     model,
     *,
+    view: str = "cfg",
     device: str | torch.device = "cpu",
     selector_kwargs: Dict | None = None,
     ranker_kwargs: Dict | None = None,
@@ -162,6 +166,7 @@ def explain_cfg(
     selector = train_selector(
         cfg_graph,
         model,
+        view=view,
         device=device,
         score_fn=score_fn,
         **selector_kwargs,

--- a/src/explain/train_selector.py
+++ b/src/explain/train_selector.py
@@ -25,6 +25,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--batch-size", type=int, default=2048, help="Number of target-type nodes per mini-batch")
     p.add_argument("--num-neighbors", type=int, default=15, help="Neighbors to sample per hop")
     p.add_argument("--num-hops", type=int, default=2, help="K-hop neighborhood")
+    p.add_argument("--view", type=str, default="cfg", help="Edge relation view")
     return p
 
 def select_cfg_graph(dataset, model, selector_type) -> HeteroData:
@@ -143,6 +144,7 @@ def main():
     selector = train_selector(
         graph,
         model,
+        view=args.view,
         device=device,
         epochs=args.epochs,
         lr=args.lr,

--- a/tests/test_selector_init.py
+++ b/tests/test_selector_init.py
@@ -23,3 +23,16 @@ def test_selector_initializes_on_hetero():
     assert selector.logits[key].shape == (ei.size(1),)
     assert mask.numel() == ei.size(1)
 
+
+def test_selector_initializes_custom_view():
+    g = HeteroData()
+    g["bb"].num_nodes = 2
+    ei = torch.tensor([[0], [1]], dtype=torch.long)
+    g[("bb", "ast", "bb")].edge_index = ei
+
+    selector = GumbelMaskSelector(view="ast")
+    mask = selector(g)
+    key = str(("bb", "ast", "bb"))
+    assert key in selector.logits
+    assert mask.numel() == ei.size(1)
+


### PR DESCRIPTION
## Summary
- allow specifying `view` when training GumbelMaskSelector
- update helper functions and CLI to forward the parameter
- add test for `GumbelMaskSelector(view="ast")`

## Testing
- `pytest tests/test_selector_init.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686764592424832e94bb169d1c380b45