### PR TITLE
Add graph pruning utility and integrate into explainer training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -16,7 +16,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from robust_malware_graph.explain import train_selector, explain_cfg
-from explain.utils import ensure_edgeaware_selector
+from explain.utils import ensure_edgeaware_selector, prune_to_selected
 from src.common.utils import get_logger
 from src.graphs.dataset.graph_dataset import collect_dataset_metadata
 
@@ -186,6 +186,21 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         score_fn=score_fn,
     )
     ensure_edgeaware_selector(selector, graph)
+
+    sel = selector.hard_selection(graph)
+    if isinstance(sel, dict):
+        sel_list = torch.cat(list(sel.values())).tolist()
+    else:
+        sel_list = sel.tolist()  # type: ignore[attr-defined]
+
+    pruned = prune_to_selected(graph, sel_list)
+    with torch.no_grad():
+        _ = model(pruned, return_logits=True)
+
+    del pruned
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
     return selector, graph
 
 

--- a/src/explain/utils/__init__.py
+++ b/src/explain/utils/__init__.py
@@ -7,10 +7,12 @@ from .hetero import (
     iter_edge_types,
     ensure_edgeaware_selector,
 )
+from .prune import prune_to_selected
 
 __all__ = [
     "get_edge_store",
     "edge_mask_to_global",
     "iter_edge_types",
     "ensure_edgeaware_selector",
+    "prune_to_selected",
 ]

--- a/src/explain/utils/prune.py
+++ b/src/explain/utils/prune.py
@@ -1,0 +1,46 @@
+"""Subgraph pruning helpers."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Dict
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.graphs.transforms import GraphPruner
+
+
+def prune_to_selected(graph: HeteroData, selected_nodes) -> HeteroData:
+    """Return a subgraph containing only ``selected_nodes``.
+
+    Parameters
+    ----------
+    graph : HeteroData
+        Input heterogeneous graph.
+    selected_nodes : Sequence[int] | Mapping[str, Sequence[int]]
+        Nodes to keep. When a mapping is provided, keys should be node types.
+        Node types not present in the mapping are pruned entirely.
+    """
+    scores: Dict[str, torch.Tensor] = {}
+
+    if isinstance(selected_nodes, Mapping):
+        for ntype in graph.node_types:
+            N = graph[ntype].num_nodes
+            idx = torch.as_tensor(selected_nodes.get(ntype, []), dtype=torch.long)
+            mask = torch.zeros(N, dtype=torch.float)
+            if idx.numel() > 0:
+                mask[idx] = 1.0
+            scores[ntype] = mask
+    else:
+        # assume single node type or apply to the first node type
+        ntype = graph.node_types[0]
+        idx = torch.as_tensor(selected_nodes, dtype=torch.long)
+        mask = torch.zeros(graph[ntype].num_nodes, dtype=torch.float)
+        if idx.numel() > 0:
+            mask[idx] = 1.0
+        scores = {ntype: mask}
+        for other in graph.node_types[1:]:
+            scores[other] = torch.zeros(graph[other].num_nodes, dtype=torch.float)
+
+    pruner = GraphPruner(scores, thresh=0.5)
+    return pruner.apply(graph)

--- a/tests/test_prune_to_selected.py
+++ b/tests/test_prune_to_selected.py
@@ -1,0 +1,23 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.explain.utils.prune import prune_to_selected
+
+
+def build_graph():
+    g = HeteroData()
+    g["n"].x = torch.zeros(3, 1)
+    g["n"].num_nodes = 3
+    g[("n", "r", "n")].edge_index = torch.tensor([[0, 1, 0], [1, 2, 2]], dtype=torch.long)
+    return g
+
+
+def test_prune_to_selected_keeps_nodes():
+    g = build_graph()
+    out = prune_to_selected(g, [0, 2])
+    assert out["n"].num_nodes == 2
+    assert out[("n", "r", "n")].edge_index.tolist() == [[0], [1]]


### PR DESCRIPTION
## Summary
- create `prune_to_selected` helper using `GraphPruner`
- expose new helper in utilities
- call pruning step in `explainer_train` after training selector
- add unit test for pruning on simple hetero graph

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68676e5a2c10832ebf120054039e0773