### PR TITLE
Update setuptools config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,9 @@ Homepage = "https://example.com"
 [project.scripts]
 rmg-cli = "robust_malware_graph.cli:main"
 
+[tool.setuptools]
+package-dir = {"robust_malware_graph" = ".", "robust_malware_graph.cli" = "src/robust_malware_graph/cli"}
+
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ["src", "."]
+include = ["robust_malware_graph*"]


### PR DESCRIPTION
## Summary
- extend setuptools search paths to include root and src
- tweak package_dir for root module

## Testing
- `pip install .` *(fails: package directory 'src/robust_malware_graph/explain' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68676e7f6490832e973cb68b4616bab4