### PR TITLE
Add explain-refine CLI for graph pruning

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -51,6 +51,7 @@ _COMMANDS: Final[Dict[str, str]] = {
     "certify-res": "certify_res",
     "train-resgcl": "train_res_gcl",
     "train-explainer": "explainer_train",
+    "explain-refine": "explain_refine",
     "build-ppo-dataset": "build_ppo_dataset",
 }
 

--- a/src/cli/explain_refine.py
+++ b/src/cli/explain_refine.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Refine explanation by pruning and re-evaluating a graph."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import torch
+from torch_geometric.data import HeteroData
+from torch.serialization import add_safe_globals
+from torch_geometric.data import storage
+
+from src.common.utils import get_logger
+from src.graphs.loaders import get_loader
+from src.graphs.builders import HeteroGraphBuilder
+from src.graphs.dataset.graph_dataset import GraphDataset
+from robust_malware_graph.explain import ensure_edgeaware_selector
+from src.explain.utils.prune import prune_to_selected
+from src.models.gnn.res_wrapper import RESGCLClassifier
+
+LOGGER = get_logger(__name__)
+
+
+def _load_graph(path: Path, view: str) -> HeteroData:
+    if path.suffix in {".pt", ".pkl", ".pyg.pkl"}:
+        g = torch.load(path, weights_only=False)
+    else:
+        g = get_loader(view).load(path)
+    if not isinstance(g, HeteroData):
+        builder = HeteroGraphBuilder()
+        builder.add_view(g, view)
+        g = builder.build()
+    g = GraphDataset._ensure_num_nodes(g)
+    g = GraphDataset._ensure_x(g)
+    for nt in g.node_types:
+        g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
+    return g
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Prune a graph with a selector and re-evaluate",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("selector", type=Path, help="Trained selector checkpoint")
+    p.add_argument("graph", type=Path, help="Single-view graph path")
+    p.add_argument("--model", type=Path, required=True, help="RESGCL checkpoint")
+    p.add_argument("--view", type=str, default="cfg", help="Graph view name")
+    p.add_argument("--device", type=str, default="cpu")
+    p.add_argument("--save-path", type=Path, help="Optional output *.pt for pruned graph")
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+
+    add_safe_globals([storage.BaseStorage, storage.NodeStorage, storage.EdgeStorage, storage.GlobalStorage])
+    selector = torch.load(args.selector, map_location="cpu")
+    LOGGER.info("Selector loaded: %s", args.selector)
+
+    graph = _load_graph(args.graph, args.view)
+    LOGGER.info("Graph loaded: %s", args.graph)
+
+    ensure_edgeaware_selector(selector, graph)
+    sel = selector.hard_selection(graph)
+    if isinstance(sel, dict):
+        keep = torch.cat(list(sel.values())).tolist()
+    else:
+        keep = sel.tolist()
+    pruned = prune_to_selected(graph, keep)
+
+    if args.save_path:
+        args.save_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(pruned, args.save_path)
+        LOGGER.info("Pruned graph saved → %s", args.save_path)
+
+    device = torch.device(args.device)
+    model = RESGCLClassifier.load_from_checkpoint(args.model, map_location=device)
+    model.to(device).eval()
+    with torch.no_grad():
+        prob = model(pruned.to(device)).sigmoid().item()
+    print(f"probability={prob:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_explain_refine_cli.py
+++ b/tests/test_explain_refine_cli.py
@@ -1,0 +1,50 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+
+def test_cli_prunes_and_saves(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(2, 1)
+    g["bb"].num_nodes = 2
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [1]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    class DummySelector:
+        initialized = True
+        view = "cfg"
+        def hard_selection(self, graph):
+            return {"bb": torch.tensor([0])}
+
+    sel_path = tmp_path / "selector.pt"
+    torch.save(DummySelector(), sel_path)
+
+    class DummyModel:
+        def to(self, device):
+            return self
+        def eval(self):
+            return self
+        def __call__(self, data, return_logits=False):
+            return torch.tensor(1.0)
+
+    def fake_load(path, map_location=None):
+        return DummyModel()
+    monkeypatch.setattr(
+        "src.models.gnn.res_wrapper.RESGCLClassifier.load_from_checkpoint",
+        fake_load,
+    )
+
+    mod = importlib.import_module("src.cli.explain_refine")
+    out_path = tmp_path / "pruned.pt"
+    mod.main([str(sel_path), str(gpath), "--model", str(tmp_path / "model.pt"), "--save-path", str(out_path)])
+
+    assert out_path.exists()
+


### PR DESCRIPTION
## Summary
- add `explain_refine` command to prune single view graphs with a selector and re-evaluate
- register command in unified CLI
- test the new command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686770a25760832e99d1576150e76a2d