### PR TITLE
Add node pruning helper and prediction saving

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -16,9 +16,12 @@ import pandas as pd
 from tqdm import tqdm
 
 from robust_malware_graph.explain import train_selector, explain_cfg
-from explain.utils import ensure_edgeaware_selector, prune_to_selected
+from explain.utils import ensure_edgeaware_selector
+from explain.utils.hetero import iter_edge_types, drop_unselected_nodes
 from src.common.utils import get_logger
 from src.graphs.dataset.graph_dataset import collect_dataset_metadata
+from src.graphs.builders.hetero_builder import HeteroGraphBuilder
+from src.graphs.loaders.factory import get_loader
 
 LOGGER = get_logger(__name__)
 
@@ -187,21 +190,34 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     )
     ensure_edgeaware_selector(selector, graph)
 
-    sel = selector.hard_selection(graph)
-    if isinstance(sel, dict):
-        sel_list = torch.cat(list(sel.values())).tolist()
-    else:
-        sel_list = sel.tolist()  # type: ignore[attr-defined]
+    pred_info = None
+    try:
+        sel = selector.hard_selection(graph)
+        keep: dict[str, set[int]] = {}
+        for et in iter_edge_types(graph, args.view):
+            idx = sel.get(str(et))
+            if idx is None or len(idx) == 0:
+                continue
+            ei = graph[et].edge_index[:, idx]
+            keep.setdefault(et[0], set()).update(ei[0].tolist())
+            keep.setdefault(et[2], set()).update(ei[1].tolist())
+        keep_idx = {nt: sorted(v) for nt, v in keep.items()}
+        pruned = drop_unselected_nodes(graph, keep_idx, args.view)
+        builder = HeteroGraphBuilder()
+        builder.add_view(pruned, args.view)
+        pruned_graph = builder.build()
+        with torch.no_grad():
+            logits = model(pruned_graph, return_logits=True).squeeze()
+            prob = float(logits.sigmoid().cpu().item())
+            pred = int(prob >= 0.5)
+            pred_info = {"pred": pred, "prob": prob}
+    except Exception as e:  # pragma: no cover - best effort
+        LOGGER.warning("Prediction on pruned graph failed: %s", e)
 
-    pruned = prune_to_selected(graph, sel_list)
-    with torch.no_grad():
-        _ = model(pruned, return_logits=True)
-
-    del pruned
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
 
-    return selector, graph
+    return selector, graph, pred_info
 
 
 def _train_batch_impl(args, model, device: torch.device) -> None:
@@ -242,12 +258,16 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
 
                 _attach_embeddings(graph_input, sha, Path("data/embeds"))
 
-            selector, graph = _train_selector_for_graph(graph_input, model, args, device)
+            selector, graph, pred_info = _train_selector_for_graph(graph_input, model, args, device)
 
             out_path = args.output_dir / f"{sha}_selector.pt"
             args.output_dir.mkdir(parents=True, exist_ok=True)
             torch.save(selector, out_path)
             LOGGER.debug(f"Selector saved → {out_path}")
+            if pred_info is not None:
+                pred_path = args.output_dir / f"{sha}_pred.json"
+                with pred_path.open("w", encoding="utf-8") as fp:
+                    json.dump(pred_info, fp)
 
             if args.mine_features:
                 try:
@@ -304,11 +324,16 @@ def train_single(args: argparse.Namespace) -> None:
             _attach_embeddings(cfg_graph, sha, Path("data/embeds"))
         graph_input = cfg_graph
 
-    selector, cfg_graph = _train_selector_for_graph(graph_input, model, args, device)
+    selector, cfg_graph, pred_info = _train_selector_for_graph(graph_input, model, args, device)
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     torch.save(selector, args.output)
     LOGGER.info("Saved selector → %s", args.output)
+    if pred_info is not None:
+        pred_path = args.output.with_suffix(".pred.json")
+        with pred_path.open("w", encoding="utf-8") as fp:
+            json.dump(pred_info, fp)
+        LOGGER.info("Saved prediction → %s", pred_path)
 
     if args.mine_features:
         feats = _mine_tokens(cfg_graph, model, device)

--- a/src/explain/utils/__init__.py
+++ b/src/explain/utils/__init__.py
@@ -6,6 +6,7 @@ from .hetero import (
     edge_mask_to_global,
     iter_edge_types,
     ensure_edgeaware_selector,
+    drop_unselected_nodes,
 )
 from .prune import prune_to_selected
 
@@ -14,5 +15,6 @@ __all__ = [
     "edge_mask_to_global",
     "iter_edge_types",
     "ensure_edgeaware_selector",
+    "drop_unselected_nodes",
     "prune_to_selected",
 ]

--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -66,3 +66,53 @@ def ensure_edgeaware_selector(selector, g: HeteroData) -> None:
         # ``_init_params`` is an internal helper on ``GumbelMaskSelector``.  It
         # creates per-edge-type parameters based on the provided graph.
         selector._init_params(g)
+
+
+def drop_unselected_nodes(data: HeteroData, node_idx, view: str) -> HeteroData:
+    """Return subgraph retaining only ``node_idx`` for edge types matching ``view``.
+
+    Parameters
+    ----------
+    data : HeteroData
+        Input heterogeneous graph.
+    node_idx : Sequence[int] | Mapping[str, Sequence[int]]
+        Nodes to keep. When a mapping is provided the keys correspond to
+        node types.
+    view : str
+        Edge relation pattern (fnmatch) identifying node types.
+    """
+    from collections.abc import Mapping, Sequence
+    from src.graphs.transforms import GraphPruner
+
+    selected: dict[str, torch.Tensor] = {}
+
+    if isinstance(node_idx, Mapping):
+        for ntype in data.node_types:
+            idx = torch.as_tensor(node_idx.get(ntype, []), dtype=torch.long)
+            mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float)
+            if idx.numel() > 0:
+                mask[idx] = 1.0
+            selected[ntype] = mask
+    else:
+        # infer node type from view edge types
+        types = {et[0] for et in iter_edge_types(data, view)} | {et[2] for et in iter_edge_types(data, view)}
+        if len(types) != 1:
+            raise ValueError("Ambiguous node types; provide mapping per type")
+        ntype = next(iter(types))
+        mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float)
+        idx = torch.as_tensor(node_idx, dtype=torch.long)
+        if idx.numel() > 0:
+            mask[idx] = 1.0
+        selected = {ntype: mask}
+        for other in data.node_types:
+            if other != ntype:
+                selected.setdefault(other, torch.zeros(data[other].num_nodes, dtype=torch.float))
+
+    pruner = GraphPruner(selected, thresh=0.5)
+    out = pruner.apply(data)
+
+    if not isinstance(out, HeteroData):
+        builder = HeteroGraphBuilder()
+        builder.add_view(out, view)
+        out = builder.build()
+    return out

--- a/tests/test_drop_unselected_nodes.py
+++ b/tests/test_drop_unselected_nodes.py
@@ -1,0 +1,23 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.explain.utils.hetero import drop_unselected_nodes
+
+
+def build_graph():
+    g = HeteroData()
+    g["bb"].x = torch.zeros(3, 1)
+    g["bb"].num_nodes = 3
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0, 1, 2], [1, 2, 0]])
+    return g
+
+
+def test_drop_nodes():
+    g = build_graph()
+    out = drop_unselected_nodes(g, [0, 2], "cfg")
+    assert out["bb"].num_nodes == 2
+    assert out[("bb", "cfg", "bb")].edge_index.tolist() == [[1], [0]]

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -6,8 +6,29 @@ pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
 import torch
-from torch_geometric.data import Data
-from torch_geometric.data import HeteroData
+from torch_geometric.data import Data, HeteroData
+import types
+
+
+class DummyModel:
+    def __init__(self):
+        self.encoder = types.SimpleNamespace(target_node="bb", input_proj={})
+
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+    def __call__(self, *args, **kwargs):
+        return torch.tensor([0.0])
+
+
+class DummySelector:
+    def hard_selection(self, g):
+        key = next(iter(g.edge_types))
+        num = g[key].edge_index.size(1)
+        return {str(key): torch.arange(num)}
 
 
 def test_cli_invokes_train_selector(tmp_path, monkeypatch):
@@ -17,7 +38,7 @@ def test_cli_invokes_train_selector(tmp_path, monkeypatch):
     mpath = tmp_path / "model.pt"
     mpath.write_text("stub")
 
-    dummy_model = object()
+    dummy_model = DummyModel()
     orig_load = torch.load
 
     def fake_load(path, map_location=None):
@@ -34,7 +55,7 @@ def test_cli_invokes_train_selector(tmp_path, monkeypatch):
     def fake_train_selector(graph, model, **kw):
         captured["graph"] = graph
         captured["model"] = model
-        return "selector"
+        return DummySelector()
 
     monkeypatch.setattr("robust_malware_graph.explain.train_selector", fake_train_selector)
 
@@ -45,6 +66,7 @@ def test_cli_invokes_train_selector(tmp_path, monkeypatch):
     assert captured["graph"] is cfg
     assert captured["model"] is dummy_model
     assert out.exists()
+    assert out.with_suffix(".pred.json").exists()
 
 
 def test_cli_handles_heterodata(tmp_path, monkeypatch):
@@ -56,7 +78,7 @@ def test_cli_handles_heterodata(tmp_path, monkeypatch):
     mpath = tmp_path / "model.pt"
     mpath.write_text("stub")
 
-    dummy_model = object()
+    dummy_model = DummyModel()
     orig_load = torch.load
 
     def fake_load(path, map_location=None):
@@ -70,7 +92,7 @@ def test_cli_handles_heterodata(tmp_path, monkeypatch):
 
     monkeypatch.setattr(
         "robust_malware_graph.explain.train_selector",
-        lambda *a, **kw: "selector",
+        lambda *a, **kw: DummySelector(),
     )
 
     mod = importlib.import_module("src.cli.explainer_train")
@@ -78,6 +100,7 @@ def test_cli_handles_heterodata(tmp_path, monkeypatch):
     mod.main(["single", str(gpath), "--model", str(mpath), "--output", str(out), "--epochs", "1"])
 
     assert out.exists()
+    assert out.with_suffix(".pred.json").exists()
 
 
 def test_cli_dataset_mode(tmp_path, monkeypatch):
@@ -91,7 +114,7 @@ def test_cli_dataset_mode(tmp_path, monkeypatch):
     mpath = tmp_path / "model.pt"
     mpath.write_text("stub")
 
-    dummy_model = object()
+    dummy_model = DummyModel()
 
     def fake_load(path, weights_only=False, map_location=None):
         if Path(path) == gpath:
@@ -103,7 +126,7 @@ def test_cli_dataset_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(torch, "load", fake_load)
     monkeypatch.setattr(
         "robust_malware_graph.explain.train_selector",
-        lambda *a, **kw: "selector",
+        lambda *a, **kw: DummySelector(),
     )
 
     mod = importlib.import_module("src.cli.explainer_train")
@@ -123,6 +146,7 @@ def test_cli_dataset_mode(tmp_path, monkeypatch):
     ])
 
     assert (outdir / "a_selector.pt").exists()
+    assert (outdir / "a_pred.json").exists()
 
 
 def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
@@ -138,7 +162,7 @@ def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
     mpath = tmp_path / "model.pt"
     mpath.write_text("stub")
 
-    dummy_model = object()
+    dummy_model = DummyModel()
 
     orig_load = torch.load
 
@@ -153,7 +177,7 @@ def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
 
     def fake_train_selector(graph, model, **kw):
         captured["type"] = type(graph)
-        return "selector"
+        return DummySelector()
 
     monkeypatch.setattr("robust_malware_graph.explain.train_selector", fake_train_selector)
 
@@ -163,4 +187,5 @@ def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
     mod.main(["single", str(gpath), "--model", str(mpath), "--output", str(out), "--epochs", "1", "--ast", "--view", "ast"])
 
     assert out.exists()
+    assert out.with_suffix(".pred.json").exists()
     assert captured["type"].__name__ == "HeteroData"


### PR DESCRIPTION
## Summary
- add `drop_unselected_nodes` helper for hetero graphs
- export helper from utils
- compute predictions on pruned graphs when training selectors
- store prediction JSON next to selector outputs
- update CLI tests and add new test for node dropping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686770ce87b4832eb34b55d785720d0d