### PR TITLE
Add view-dir option for explainer training

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ python -m cli.explainer_train cfg.pt \
        --model models/gnn/res_gcl.pt \
        --output models/selector.pt \
        --epochs 500 \
-       --ast --view ast
+       --ast --view ast \
+       --view-dir data/views
 
 # 데이터셋 전체 학습 및 특징 추출 예시
 python -m cli.explainer_train \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -46,6 +46,12 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--beta", type=float, default=2e-2)
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
         pp.add_argument("--view", type=str, default="cfg", help="Edge relation view")
+        pp.add_argument(
+            "--view-dir",
+            type=Path,
+            default=Path("data/views"),
+            help="Directory containing view JSON graphs",
+        )
         flag = pp.add_mutually_exclusive_group()
         flag.add_argument("--ast", action="store_true", help="Load AST view graphs")
         flag.add_argument("--cfg", action="store_true", help="Load CFG view graphs")
@@ -153,7 +159,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")
         if not sha:
             raise ValueError("sha256 required to load view graph")
-        fp = Path("data") / "views" / view_flag / f"{sha}.json"
+        fp = args.view_dir / view_flag / f"{sha}.json"
         if not fp.is_file():
             gz = fp.with_suffix(fp.suffix + ".gz")
             if gz.is_file():

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -189,3 +189,59 @@ def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
     assert out.exists()
     assert out.with_suffix(".pred.json").exists()
     assert captured["type"].__name__ == "HeteroData"
+
+
+def test_cli_custom_view_dir(tmp_path, monkeypatch):
+    import json
+
+    view_root = tmp_path / "views"
+    view_dir = view_root / "cfg"
+    view_dir.mkdir(parents=True)
+    sha = "sample"
+    (view_dir / f"{sha}.json").write_text(json.dumps({"nodes": [{"id": 0, "kind": "file"}], "edges": []}))
+
+    gpath = tmp_path / f"{sha}.pt"
+    gpath.write_text("stub")
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    dummy_model = DummyModel()
+    orig_load = torch.load
+
+    def fake_load(path, map_location=None, weights_only=False):
+        if Path(path) == mpath:
+            return dummy_model
+        return orig_load(path, map_location=map_location)
+
+    monkeypatch.setattr(torch, "load", fake_load)
+
+    captured = {}
+
+    def fake_train_selector(graph, model, **kw):
+        captured["type"] = type(graph)
+        return DummySelector()
+
+    monkeypatch.setattr("robust_malware_graph.explain.train_selector", fake_train_selector)
+
+    mod = importlib.import_module("src.cli.explainer_train")
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "out.pt"
+    mod.main([
+        "single",
+        str(gpath),
+        "--model",
+        str(mpath),
+        "--output",
+        str(out),
+        "--epochs",
+        "1",
+        "--cfg",
+        "--view",
+        "cfg",
+        "--view-dir",
+        str(view_root),
+    ])
+
+    assert out.exists()
+    assert out.with_suffix(".pred.json").exists()
+    assert captured["type"].__name__ == "HeteroData"


### PR DESCRIPTION
## Summary
- add `--view-dir` argument with default `data/views`
- use `args.view_dir` when loading view graphs
- document the option in README
- test custom view directory support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867759db264832e83bfdb79002744a3