### PR TITLE
Add view flag validation to explainer train

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -148,6 +148,11 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         view_flag = "syscall"
 
     if view_flag:
+        if args.view != view_flag:
+            raise ValueError(
+                f"view flag mismatch: --{view_flag} requires --view {view_flag}"
+            )
+        args.view = view_flag
         sha = graph if isinstance(graph, str) else getattr(graph, "sha256", None)
         if sha is None and not isinstance(graph, str):
             sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -189,3 +189,34 @@ def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
     assert out.exists()
     assert out.with_suffix(".pred.json").exists()
     assert captured["type"].__name__ == "HeteroData"
+
+def test_cli_view_flag_mismatch(tmp_path, monkeypatch):
+    gpath = tmp_path / "cfg.pt"
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    dummy_model = DummyModel()
+    orig_load = torch.load
+
+    def fake_load(path, map_location=None, **kw):
+        if Path(path) == mpath:
+            return dummy_model
+        return orig_load(path, map_location=map_location, **kw)
+
+    monkeypatch.setattr(torch, "load", fake_load)
+    mod = importlib.import_module("src.cli.explainer_train")
+
+    with pytest.raises(ValueError):
+        mod.main([
+            "single",
+            str(gpath),
+            "--model",
+            str(mpath),
+            "--output",
+            str(tmp_path / "out.pt"),
+            "--epochs",
+            "1",
+            "--ast",
+            "--view",
+            "cfg",
+        ])


### PR DESCRIPTION
## Summary
- enforce consistency between `--ast`, `--cfg` etc flags and `--view`
- raise a `ValueError` when mismatched
- add regression test for mismatched view flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867759694a8832e9bcb757415cd24a8