### PR TITLE
Add view flag validation for explainer CLI

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -154,6 +154,11 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         view_flag = "syscall"
 
     if view_flag:
+        if args.view != view_flag:
+            raise ValueError(
+                f"view flag {view_flag} mismatches --view {args.view}"
+            )
+        args.view = view_flag
         sha = graph if isinstance(graph, str) else getattr(graph, "sha256", None)
         if sha is None and not isinstance(graph, str):
             sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -245,3 +245,47 @@ def test_cli_custom_view_dir(tmp_path, monkeypatch):
     assert out.exists()
     assert out.with_suffix(".pred.json").exists()
     assert captured["type"].__name__ == "HeteroData"
+
+
+def test_cli_view_flag_mismatch(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    dummy_model = DummyModel()
+    orig_load = torch.load
+
+    def fake_load(path, map_location=None, weights_only=False):
+        if Path(path) == gpath:
+            return g
+        if Path(path) == mpath:
+            return dummy_model
+        return orig_load(path, map_location=map_location)
+
+    monkeypatch.setattr(torch, "load", fake_load)
+    monkeypatch.setattr(
+        "robust_malware_graph.explain.train_selector",
+        lambda *a, **kw: DummySelector(),
+    )
+
+    mod = importlib.import_module("src.cli.explainer_train")
+    out = tmp_path / "out.pt"
+    with pytest.raises(ValueError, match="mismatches"):
+        mod.main([
+            "single",
+            str(gpath),
+            "--model",
+            str(mpath),
+            "--output",
+            str(out),
+            "--epochs",
+            "1",
+            "--ast",
+            "--view",
+            "cfg",
+        ])


### PR DESCRIPTION
## Summary
- validate view flags in `_train_selector_for_graph`
- test mismatched view flag handling in CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b45c8e98832e9d8139e4e56310d0