### PR TITLE
Fix pruned graph device

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -218,7 +218,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         builder.add_view(pruned, args.view)
         pruned_graph = builder.build()
         with torch.no_grad():
-            logits = model(pruned_graph, return_logits=True).squeeze()
+            logits = model(pruned_graph.to(device), return_logits=True).squeeze()
             prob = float(logits.sigmoid().cpu().item())
             pred = int(prob >= 0.5)
             pred_info = {"pred": pred, "prob": prob}

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -1,4 +1,5 @@
 import importlib
+import argparse
 import pytest
 from pathlib import Path
 
@@ -289,3 +290,50 @@ def test_cli_view_flag_mismatch(tmp_path, monkeypatch):
             "--view",
             "cfg",
         ])
+
+
+def test_pruned_graph_to_cuda(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+
+    captured = []
+
+    def fake_to(self, device):
+        captured.append(device)
+        return self
+
+    monkeypatch.setattr(HeteroData, "to", fake_to)
+
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    monkeypatch.setattr(
+        "robust_malware_graph.explain.train_selector",
+        lambda *a, **kw: DummySelector(),
+    )
+    monkeypatch.setattr(
+        "explain.utils.ensure_edgeaware_selector",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    mod = importlib.import_module("src.cli.explainer_train")
+    args = argparse.Namespace(
+        ast=False,
+        cfg=False,
+        fcg=False,
+        syscall=False,
+        view="cfg",
+        view_dir=tmp_path,
+        epochs=1,
+        lr=1e-3,
+        alpha=1.0,
+        beta=2e-2,
+        plot_path=None,
+        mine_features=None,
+    )
+
+    mod._train_selector_for_graph(g, DummyModel(), args, torch.device("cuda:0"))
+
+    assert torch.device("cuda:0") in captured


### PR DESCRIPTION
## Summary
- ensure pruned graphs are moved to the target device before inference
- validate `.to("cuda:0")` works via new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b7ddbb44832e9871b617b103fc74