### PR TITLE
Allow view flag to set view automatically

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -154,11 +154,12 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         view_flag = "syscall"
 
     if view_flag:
-        if args.view != view_flag:
+        if args.view == "cfg":
+            args.view = view_flag
+        elif args.view != view_flag:
             raise ValueError(
                 f"view flag {view_flag} mismatches --view {args.view}"
             )
-        args.view = view_flag
         sha = graph if isinstance(graph, str) else getattr(graph, "sha256", None)
         if sha is None and not isinstance(graph, str):
             sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -289,3 +289,60 @@ def test_cli_view_flag_mismatch(tmp_path, monkeypatch):
             "--view",
             "cfg",
         ])
+
+
+def test_cli_view_flag_sets_view(tmp_path, monkeypatch):
+    import json
+
+    view_dir = tmp_path / "data" / "views" / "ast"
+    view_dir.mkdir(parents=True)
+    sha = "sample"
+    (view_dir / f"{sha}.json").write_text(
+        json.dumps({"nodes": [{"id": 0, "kind": "file"}], "edges": []})
+    )
+
+    gpath = tmp_path / f"{sha}.pt"
+    gpath.write_text("stub")  # unused placeholder
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    dummy_model = DummyModel()
+
+    orig_load = torch.load
+
+    def fake_load(path, map_location=None, weights_only=False):
+        if Path(path) == mpath:
+            return dummy_model
+        return orig_load(path, map_location=map_location)
+
+    monkeypatch.setattr(torch, "load", fake_load)
+
+    captured = {}
+
+    def fake_train_selector(graph, model, **kw):
+        captured["type"] = type(graph)
+        return DummySelector()
+
+    monkeypatch.setattr(
+        "robust_malware_graph.explain.train_selector",
+        fake_train_selector,
+    )
+
+    mod = importlib.import_module("src.cli.explainer_train")
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "out.pt"
+    mod.main([
+        "single",
+        str(gpath),
+        "--model",
+        str(mpath),
+        "--output",
+        str(out),
+        "--epochs",
+        "1",
+        "--ast",
+    ])
+
+    assert out.exists()
+    assert out.with_suffix(".pred.json").exists()
+    assert captured["type"].__name__ == "HeteroData"


### PR DESCRIPTION
## Summary
- adjust `_train_selector_for_graph` to treat `--view`'s default as match when a view flag is provided
- test that a single flag like `--ast` works without explicitly setting `--view`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867bb354b84832eb04931c26102bd54