### PR TITLE
Align README examples with cli_workflow output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ python -m cli.rulegen_cli feature-mine \
 
 # 데이터셋 변환 예시
 python -m cli.rulegen_cli build-dataset \
-       --hetero-dir data/hetero \
+       --hetero-dir data/hetero_clean \
        --labels data/meta.csv \
        --out-dir data/rulegen_dataset
 
@@ -206,7 +206,7 @@ python -m cli.rulegen_cli ppo-train \
           --val-features val_features.json \
           --hint-features hints.json \
           --config configs/rulegen/ppo.yaml \
-          --checkpoint models/rulebank/ppo_agent.pt
+          --checkpoint models/rulegen/ppo_agent.pt
 # configs/rulegen/ppo.yaml 의 model.policy_net 으로
 # "gru"(기본값) 또는 "gpt2-small" 등의 GPT 모델을 선택할 수 있습니다.
 # RL
@@ -214,7 +214,7 @@ python -m cli.rulegen_cli ppo-train \
        --train-features features.json \
        --hint-features hints.json \
        --epochs 50000 \
-       --checkpoint models/rulebank/ppo_agent.pt \
+       --checkpoint models/rulegen/ppo_agent.pt \
        --plot-path runs/rulegen/ppo_train.png
 # 간단한 환경 생성 예시
 ```python
@@ -243,14 +243,14 @@ python -m cli.explainer_train cfg.pt \
 
 # 데이터셋 전체 학습 및 특징 추출 예시
 python -m cli.explainer_train \
-       --graph-dir data/train/graphs \
-       --meta-csv data/train/labels.csv \
-       --output-dir models/selectors \
+       --graph-dir data/splits/train/graphs \
+       --meta-csv data/meta.csv \
+       --output-dir models/explainers \
        --model models/gnn/res_gcl.pt \
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \
-       --dataset-path data/train/graphs \
+       --dataset-path data/splits/train/graphs \
        --output-path mined.json \
        --embed-dir data/embeds
 # 평가


### PR DESCRIPTION
## Summary
- update README example commands to use directories and files generated by `cli_workflow.ipynb`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867bf9b63fc832e95ca7eec6dc61366