### PR TITLE
Refactor explainer train CLI view handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,7 @@ python -m cli.explainer_train cfg.pt \
        --model models/gnn/res_gcl.pt \
        --output models/selector.pt \
        --epochs 500 \
-       --ast --view ast \
-       --view-dir data/views
+       --ast --view data/views
 
 # 데이터셋 전체 학습 및 특징 추출 예시
 python -m cli.explainer_train \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -45,12 +45,11 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--alpha", type=float, default=1.0)
         pp.add_argument("--beta", type=float, default=2e-2)
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
-        pp.add_argument("--view", type=str, default="cfg", help="Edge relation view")
         pp.add_argument(
-            "--view-dir",
+            "--view",
             type=Path,
-            default=Path("data/views"),
-            help="Directory containing view JSON graphs",
+            default=Path("data/views/cfg"),
+            help="Directory containing view JSON graphs or the view root",
         )
         flag = pp.add_mutually_exclusive_group()
         flag.add_argument("--ast", action="store_true", help="Load AST view graphs")
@@ -153,19 +152,18 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     elif args.syscall:
         view_flag = "syscall"
 
+    view_dir = args.view
+    view_name = args.view.name
     if view_flag:
-        if args.view == "cfg":
-            args.view = view_flag
-        elif args.view != view_flag:
-            raise ValueError(
-                f"view flag {view_flag} mismatches --view {args.view}"
-            )
+        # treat args.view as the root directory when a view flag is specified
+        view_dir = Path(args.view) / view_flag
+        view_name = view_flag
         sha = graph if isinstance(graph, str) else getattr(graph, "sha256", None)
         if sha is None and not isinstance(graph, str):
             sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")
         if not sha:
             raise ValueError("sha256 required to load view graph")
-        fp = args.view_dir / view_flag / f"{sha}.json"
+        fp = view_dir / f"{sha}.json"
         if not fp.is_file():
             gz = fp.with_suffix(fp.suffix + ".gz")
             if gz.is_file():
@@ -191,7 +189,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     selector = train_selector(
         graph,
         model,
-        view=args.view,
+        view=view_name,
         device=device,
         epochs=args.epochs,
         lr=args.lr,
@@ -206,7 +204,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     try:
         sel = selector.hard_selection(graph)
         keep: dict[str, set[int]] = {}
-        for et in iter_edge_types(graph, args.view):
+        for et in iter_edge_types(graph, view_name):
             idx = sel.get(str(et))
             if idx is None or len(idx) == 0:
                 continue
@@ -214,9 +212,9 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             keep.setdefault(et[0], set()).update(ei[0].tolist())
             keep.setdefault(et[2], set()).update(ei[1].tolist())
         keep_idx = {nt: sorted(v) for nt, v in keep.items()}
-        pruned = drop_unselected_nodes(graph, keep_idx, args.view)
+        pruned = drop_unselected_nodes(graph, keep_idx, view_name)
         builder = HeteroGraphBuilder()
-        builder.add_view(pruned, args.view)
+        builder.add_view(pruned, view_name)
         pruned_graph = builder.build()
         with torch.no_grad():
             logits = model(pruned_graph, return_logits=True).squeeze()

--- a/tests/test_explainer_train_cli.py
+++ b/tests/test_explainer_train_cli.py
@@ -152,7 +152,8 @@ def test_cli_dataset_mode(tmp_path, monkeypatch):
 def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
     import json
 
-    view_dir = tmp_path / "data" / "views" / "ast"
+    view_root = tmp_path / "data" / "views"
+    view_dir = view_root / "ast"
     view_dir.mkdir(parents=True)
     sha = "sample"
     (view_dir / f"{sha}.json").write_text(json.dumps({"nodes": [{"id": 0, "kind": "file"}], "edges": []}))
@@ -184,7 +185,19 @@ def test_cli_ast_flag_loads_view(tmp_path, monkeypatch):
     mod = importlib.import_module("src.cli.explainer_train")
     monkeypatch.chdir(tmp_path)
     out = tmp_path / "out.pt"
-    mod.main(["single", str(gpath), "--model", str(mpath), "--output", str(out), "--epochs", "1", "--ast", "--view", "ast"])
+    mod.main([
+        "single",
+        str(gpath),
+        "--model",
+        str(mpath),
+        "--output",
+        str(out),
+        "--epochs",
+        "1",
+        "--ast",
+        "--view",
+        str(view_root),
+    ])
 
     assert out.exists()
     assert out.with_suffix(".pred.json").exists()
@@ -237,8 +250,6 @@ def test_cli_custom_view_dir(tmp_path, monkeypatch):
         "1",
         "--cfg",
         "--view",
-        "cfg",
-        "--view-dir",
         str(view_root),
     ])
 
@@ -273,28 +284,35 @@ def test_cli_view_flag_mismatch(tmp_path, monkeypatch):
         lambda *a, **kw: DummySelector(),
     )
 
+    view_root = tmp_path / "views"
+    view_path = view_root / "cfg"
+    (view_path / "ast").mkdir(parents=True)
+    (view_path / "ast" / "graph.json").write_text("{}")
+
     mod = importlib.import_module("src.cli.explainer_train")
     out = tmp_path / "out.pt"
-    with pytest.raises(ValueError, match="mismatches"):
-        mod.main([
-            "single",
-            str(gpath),
-            "--model",
-            str(mpath),
-            "--output",
-            str(out),
-            "--epochs",
-            "1",
-            "--ast",
-            "--view",
-            "cfg",
-        ])
+    mod.main([
+        "single",
+        str(gpath),
+        "--model",
+        str(mpath),
+        "--output",
+        str(out),
+        "--epochs",
+        "1",
+        "--ast",
+        "--view",
+        str(view_path),
+    ])
+    assert out.exists()
+    assert out.with_suffix(".pred.json").exists()
 
 
 def test_cli_view_flag_sets_view(tmp_path, monkeypatch):
     import json
 
-    view_dir = tmp_path / "data" / "views" / "ast"
+    view_root = tmp_path / "data" / "views"
+    view_dir = view_root / "ast"
     view_dir.mkdir(parents=True)
     sha = "sample"
     (view_dir / f"{sha}.json").write_text(
@@ -341,6 +359,8 @@ def test_cli_view_flag_sets_view(tmp_path, monkeypatch):
         "--epochs",
         "1",
         "--ast",
+        "--view",
+        str(view_root),
     ])
 
     assert out.exists()


### PR DESCRIPTION
## Summary
- update `explainer_train` CLI to accept `--view` as a path and drop `--view-dir`
- adjust path building logic when loading additional view graphs
- pass view name derived from path when training
- update tests for new CLI
- refresh README examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c1f54f3c832e8b2e87c13c47cf34