### PR TITLE
Fix setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ Homepage = "https://example.com"
 rmg-cli = "robust_malware_graph.cli:main"
 
 [tool.setuptools]
-package-dir = {"robust_malware_graph" = ".", "robust_malware_graph.cli" = "src/robust_malware_graph/cli"}
+package-dir = {"" = "."}
 
 [tool.setuptools.packages.find]
-where = ["src", "."]
-include = ["robust_malware_graph*"]
+where = ["."]
+include = ["src*", "robust_malware_graph*"]


### PR DESCRIPTION
## Summary
- point `package-dir` to the project root
- search for packages only from the root and support both `src*` and `robust_malware_graph*`

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_68685fcc67c0832e9e40e3e2f1cabf98