### PR TITLE
Fix explainer view loader handling

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -22,6 +22,7 @@ from src.common.utils import get_logger
 from src.graphs.dataset.graph_dataset import collect_dataset_metadata
 from src.graphs.builders.hetero_builder import HeteroGraphBuilder
 from src.graphs.loaders.factory import get_loader
+from src.graphs.normalizers import get_normalizer
 
 LOGGER = get_logger(__name__)
 
@@ -170,9 +171,13 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                 fp = gz
         g = get_loader(view_flag).load(fp)
         if not isinstance(g, HeteroData):
-            builder = HeteroGraphBuilder()
-            builder.add_view(g, view_flag)
-            g = builder.build()
+            # Normalize single-view graph into HeteroData schema first
+            try:
+                g = get_normalizer(view_flag).normalize(g)
+            except Exception:  # pragma: no cover - best effort fallback
+                builder = HeteroGraphBuilder()
+                builder.add_view(g, view_flag)
+                g = builder.build()
         graph = g
     else:
         if isinstance(graph, str):


### PR DESCRIPTION
## Summary
- normalize single-view graphs using registered normalizers
- fall back to the previous builder approach if normalization fails

## Testing
- `pytest -k explainer_train_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_686881f71c44832ea4ef28da8a81690e