### PR TITLE
Freeze model params after loading

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -102,6 +102,10 @@ def _load_model(path: Path, device: torch.device):
         model.to(device)
     if hasattr(model, "eval"):
         model.eval()
+    # freeze model parameters to avoid accidental gradient computation
+    if hasattr(model, "parameters"):
+        for p in model.parameters():
+            p.requires_grad_(False)
     return model
 
 


### PR DESCRIPTION
## Summary
- ensure loaded models don't require gradients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869886399dc832eab08673e1aacfb8c