### PR TITLE
Add view filtering helper

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 
 from robust_malware_graph.explain import train_selector, explain_cfg
 from explain.utils import ensure_edgeaware_selector
-from explain.utils.hetero import iter_edge_types, drop_unselected_nodes
+from explain.utils.hetero import iter_edge_types, drop_unselected_nodes, filter_view
 from src.common.utils import get_logger
 from src.graphs.dataset.graph_dataset import collect_dataset_metadata
 from src.graphs.builders.hetero_builder import HeteroGraphBuilder
@@ -185,6 +185,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
     graph = GraphDataset._ensure_num_nodes(graph)
     graph = GraphDataset._ensure_x(graph)
+    graph = filter_view(graph, view_name)
     for nt in graph.node_types:
         graph[nt].batch = torch.zeros(graph[nt].num_nodes, dtype=torch.long)
 

--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -116,3 +116,24 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str) -> HeteroData:
         builder.add_view(out, view)
         out = builder.build()
     return out
+
+
+def filter_view(graph: HeteroData, view: str) -> HeteroData:
+    """Remove edges not matching ``view`` and drop disconnected node types."""
+
+    # remove unrelated edge stores
+    for et in list(graph.edge_types):
+        if not fnmatch(et[1], view):
+            del graph[et]
+
+    # gather node types still used by remaining edges
+    connected: set[str] = set()
+    for et in graph.edge_types:
+        connected.add(et[0])
+        connected.add(et[2])
+
+    for ntype in list(graph.node_types):
+        if ntype not in connected:
+            del graph[ntype]
+
+    return graph

--- a/tests/test_hetero_utils.py
+++ b/tests/test_hetero_utils.py
@@ -10,6 +10,7 @@ from src.explain.utils.hetero import (
     get_edge_store,
     edge_mask_to_global,
     iter_edge_types,
+    filter_view,
 )
 
 
@@ -47,3 +48,11 @@ def test_iter_edge_types_wildcard():
     assert set(etypes) == {("a", "rel", "a"), ("a", "rel2", "b")}
     etypes = list(iter_edge_types(g, "rel2"))
     assert etypes == [("a", "rel2", "b")]
+
+
+def test_filter_view_removes_edges_and_nodes():
+    g = _make_graph()
+    out = filter_view(g, "rel")
+    assert ("a", "rel", "a") in out.edge_types
+    assert ("a", "rel2", "b") not in out.edge_types
+    assert "b" not in out.node_types


### PR DESCRIPTION
## Summary
- add `filter_view` helper to remove unrelated edge types
- apply view filtering in explainer training after ensuring features
- test new `filter_view` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698866904c832eb3a743ba18b7cde4