### PR TITLE
Optimize selector memory usage

### DIFF
--- a/src/explain/cfg_explainer/selector.py
+++ b/src/explain/cfg_explainer/selector.py
@@ -195,7 +195,8 @@ class GumbelMaskSelector(nn.Module):
             masks[str(etype)] = gumbel_sigmoid(logits, τ, hard)
         m_prob = edge_mask_to_global(graph, masks, self.view)
 
-        masked_graph = graph.clone()
+        # Temporarily mask edge stores in-place to avoid cloning the graph
+        original: dict[str, dict[str, torch.Tensor]] = {}
         for etype_str, mask in masks.items():
             etype = eval(etype_str)
             keep = mask > 0.5
@@ -205,12 +206,22 @@ class GumbelMaskSelector(nn.Module):
                 else:
                     continue
 
-            store = masked_graph[etype]
+            store = graph[etype]
+            backup: dict[str, torch.Tensor] = {}
             for k, v in store.items():
                 if torch.is_tensor(v) and v.size(0) == mask.size(0):
+                    backup[k] = v
                     store[k] = v[keep]
+            original[etype_str] = backup
 
-        masked_score = score_fn(masked_graph)
+        masked_score = score_fn(graph)
+
+        # Restore original edge stores
+        for etype_str, backup in original.items():
+            etype = eval(etype_str)
+            store = graph[etype]
+            for k, v in backup.items():
+                store[k] = v
 
         loss = self.loss(full_score, masked_score, m_prob, alpha=alpha, beta=beta, loss_type=loss_type)
         loss.backward()
@@ -223,7 +234,7 @@ class GumbelMaskSelector(nn.Module):
             sparsity = m_prob.mean()
             deletion = torch.sigmoid(full_score) - torch.sigmoid(masked_score)
 
-        del masked_graph, masked_score, m_prob
+        del masked_score, m_prob
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 


### PR DESCRIPTION
## Summary
- avoid graph cloning in `GumbelMaskSelector.step`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698934fd88832eb8cfe467ef3f9b1c