### PR TITLE
Refactor selector masking to avoid cloning

### DIFF
--- a/src/explain/cfg_explainer/selector.py
+++ b/src/explain/cfg_explainer/selector.py
@@ -195,7 +195,10 @@ class GumbelMaskSelector(nn.Module):
             masks[str(etype)] = gumbel_sigmoid(logits, τ, hard)
         m_prob = edge_mask_to_global(graph, masks, self.view)
 
-        masked_graph = graph.clone()
+        masked_graph = HeteroData()
+        for ntype in graph.node_types:
+            masked_graph[ntype] = graph[ntype]
+
         for etype_str, mask in masks.items():
             etype = eval(etype_str)
             keep = mask > 0.5
@@ -205,10 +208,17 @@ class GumbelMaskSelector(nn.Module):
                 else:
                     continue
 
+            orig_store = graph[etype]
             store = masked_graph[etype]
-            for k, v in store.items():
+
+            store.edge_index = orig_store.edge_index[:, keep]
+            for k, v in orig_store.items():
+                if k == "edge_index":
+                    continue
                 if torch.is_tensor(v) and v.size(0) == mask.size(0):
                     store[k] = v[keep]
+                else:
+                    store[k] = v
 
         masked_score = score_fn(masked_graph)
 


### PR DESCRIPTION
## Summary
- update cfg explainer selector step to avoid cloning whole graphs

## Testing
- `pytest -k selector -q`

------
https://chatgpt.com/codex/tasks/task_e_6869899d9ce4832eaf862ff4936afee7