### PR TITLE
Enable AMP training option for selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ obs, _ = env.reset()  # `reset()` 호출 시 다른 힌트를 전달할 수도 �
 python -m cli.explainer_train single cfg.pt \
        --model models/gnn/res_gcl.pt \
        --output models/selector.pt \
-       --epochs 500
+       --epochs 500 \
+       --amp
 
 # AST 뷰 그래프 학습 예시
 python -m cli.explainer_train cfg.pt \
@@ -242,10 +243,11 @@ python -m cli.explainer_train cfg.pt \
 
 # 데이터셋 전체 학습 및 특징 추출 예시
 python -m cli.explainer_train batch \
-       --graph-dir data/splits/train/graphs \
-       --meta-csv data/meta.csv \
-       --output-dir models/explainers \
-       --model models/gnn/res_gcl.pt
+        --graph-dir data/splits/train/graphs \
+        --meta-csv data/meta.csv \
+        --output-dir models/explainers \
+        --model models/gnn/res_gcl.pt \
+        --amp
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import gc
 from pathlib import Path
+from contextlib import nullcontext
 
 import torch
 from torch_geometric.data import HeteroData
@@ -46,6 +47,7 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--alpha", type=float, default=1.0)
         pp.add_argument("--beta", type=float, default=2e-2)
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
+        pp.add_argument("--amp", action="store_true", help="Enable mixed precision (CUDA)")
         pp.add_argument(
             "--view",
             type=Path,
@@ -195,7 +197,12 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
     _reinit_input_proj(graph, model, device)
 
-    score_fn = lambda g: model(g, return_logits=True).squeeze()
+    if args.amp and device.type == "cuda":
+        def score_fn(g):
+            with torch.cuda.amp.autocast():
+                return model(g, return_logits=True).squeeze()
+    else:
+        score_fn = lambda g: model(g, return_logits=True).squeeze()
     selector = train_selector(
         graph,
         model,
@@ -206,6 +213,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         alpha=args.alpha,
         beta=args.beta,
         plot_path=args.plot_path,
+        amp=args.amp,
         score_fn=score_fn,
     )
     ensure_edgeaware_selector(selector, graph)
@@ -227,7 +235,9 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         builder.add_view(pruned, view_name)
         pruned_graph = builder.build()
         with torch.no_grad():
-            logits = model(pruned_graph, return_logits=True).squeeze()
+            ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+            with ctx():
+                logits = model(pruned_graph, return_logits=True).squeeze()
             prob = float(logits.sigmoid().cpu().item())
             pred = int(prob >= 0.5)
             pred_info = {"pred": pred, "prob": prob}

--- a/src/explain/cfg_explainer/__init__.py
+++ b/src/explain/cfg_explainer/__init__.py
@@ -68,6 +68,7 @@ def train_selector(
     beta: float = 2e-2,
     plot_path: Path | str | None = None,
     score_fn=None,
+    amp: bool = False,
     **selector_kwargs,
 ) -> GumbelMaskSelector:
     """
@@ -93,6 +94,8 @@ def train_selector(
         Custom graph scoring function. If ``None``, it is built from ``model``
         assuming ``Data`` inputs with ``x`` and ``edge_index`` or ``HeteroData``
         inputs for heterogeneous graphs.
+    amp : bool, default=False
+        Enable mixed precision (CUDA) via ``torch.cuda.amp.autocast``.
 
     Returns
     -------
@@ -103,6 +106,13 @@ def train_selector(
             score_fn = lambda g: model(g.to(device)).squeeze()
         else:
             score_fn = lambda g: model(g.x.to(device), g.edge_index.to(device)).squeeze()
+
+    if amp and torch.cuda.is_available():
+        base_fn = score_fn
+
+        def score_fn(graph):
+            with torch.cuda.amp.autocast():
+                return base_fn(graph)
 
     selector = GumbelMaskSelector(view=view, device=device, **selector_kwargs)
     ensure_edgeaware_selector(selector, cfg_graph)

--- a/src/explain/train_selector.py
+++ b/src/explain/train_selector.py
@@ -26,6 +26,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--num-neighbors", type=int, default=15, help="Neighbors to sample per hop")
     p.add_argument("--num-hops", type=int, default=2, help="K-hop neighborhood")
     p.add_argument("--view", type=str, default="cfg", help="Edge relation view")
+    p.add_argument("--amp", action="store_true", help="Enable mixed precision (CUDA)")
     return p
 
 def select_cfg_graph(dataset, model, selector_type) -> HeteroData:
@@ -148,6 +149,7 @@ def main():
         device=device,
         epochs=args.epochs,
         lr=args.lr,
+        amp=args.amp,
         score_fn=score_fn,
     )
     ensure_edgeaware_selector(selector, graph)


### PR DESCRIPTION
## Summary
- add optional `--amp` flag to CLI scripts
- support mixed precision in `train_selector`
- document new flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698a5d2ecc832e99e6e0103ca9970c