### PR TITLE
Fix explainer training commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ python -m cli.explainer_train single cfg.pt \
        --amp
 
 # AST 뷰 그래프 학습 예시
-python -m cli.explainer_train cfg.pt \
+python -m cli.explainer_train single cfg.pt \
        --model models/gnn/res_gcl.pt \
        --output models/selector.pt \
        --epochs 500 \

--- a/cli_workflow.ipynb
+++ b/cli_workflow.ipynb
@@ -686,12 +686,16 @@
     "\n",
     "예시 명령:\n",
     "```bash\n",
-    "# CFG 뷰 사용\n",
-    "!python -m cli.explainer_train batch   --graph-dir data/splits/train/graphs   --output-dir models/explainers   --model models/gnn/res_gcl.pt   --epochs 5 --cfg\n",
+    "# 단일 CFG 그래프 학습\n",
+    "!python -m cli.explainer_train single cfg.pt --model models/gnn/res_gcl.pt --output models/selector.pt --epochs 5 --cfg\n",
+    "\n",
+    "# 데이터셋 전체 학습 (CFG)\n",
+    "!python -m cli.explainer_train batch --graph-dir data/splits/train/graphs --output-dir models/explainers --model models/gnn/res_gcl.pt --epochs 5 --cfg\n",
     "\n",
     "# AST 뷰와 피처 추출 활성화\n",
-    "!python -m cli.explainer_train batch   --graph-dir data/splits/train/graphs   --output-dir models/explainers   --model models/gnn/res_gcl.pt   --epochs 5 --ast --mine-features features.json\n",
-    "```\n"
+    "!python -m cli.explainer_train batch --graph-dir data/splits/train/graphs --output-dir models/explainers --model models/gnn/res_gcl.pt --epochs 5 --ast --mine-features features.json\n",
+    "```\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- update README to show correct `single` subcommand for explainer training
- update notebook example commands for training explainer selectors

## Testing
- `pytest -k explainer_train_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_68698f69c478832ea5e72739d900f202