### PR TITLE
Wrap step_subgraph scoring with no_grad

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -257,7 +257,8 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                     store[k] = v[keep]
             original[str(et)] = backup
 
-        masked_score = score_fn(sub)
+        with torch.no_grad():
+            masked_score = score_fn(sub)
 
         for et_str, backup in original.items():
             etype = eval(et_str)
@@ -270,6 +271,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         loss.backward()
         optim.step()
         selector.tau.mul_(selector.tau_decay).clamp_(min=selector.tau_min)
+        del masked_score
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 


### PR DESCRIPTION
## Summary
- avoid accumulating gradients when scoring masked subgraphs
- explicitly free `masked_score` after use

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a0d1bec4832ebc0eeeba9eb75e39