### PR TITLE
Add CPU & mini-batch full score options

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ python -m cli.explainer_train single cfg.pt \
        --model models/gnn/res_gcl.pt \
        --output models/selector.pt \
        --epochs 500 \
-       --amp
+       --amp \
+       --full-mini-batch
 
 # AST 뷰 그래프 학습 예시
 python -m cli.explainer_train single cfg.pt \
@@ -247,13 +248,16 @@ python -m cli.explainer_train batch \
         --meta-csv data/meta.csv \
         --output-dir models/explainers \
         --model models/gnn/res_gcl.pt \
-        --amp
+        --amp \
+        --full-cpu
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \
        --dataset-path data/splits/train/graphs \
        --output-path mined.json \
        --embed-dir data/embeds
+# 큰 그래프에서 GPU 메모리 부족이 발생할 경우
+# `--full-cpu` 또는 `--full-mini-batch` 옵션을 활용해 전체 점수 계산을 조절할 수 있습니다.
 # 평가
 # 기존의 `temp_explainer_runner.py` 스크립트는 더 이상 제공되지 않습니다.
 # 위의 `feature-mine` 하위 명령을 사용해 동일한 기능을 수행할 수 있습니다.

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -29,6 +29,7 @@ from explain.utils.hetero import (
     get_edge_store,
 )
 from src.graphs.sampling import sample_subgraph
+from torch_geometric.loader import NeighborLoader
 from src.common.utils import get_logger
 from src.graphs.dataset.graph_dataset import collect_dataset_metadata
 from src.graphs.builders.hetero_builder import HeteroGraphBuilder
@@ -61,6 +62,12 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--num-hops", type=int, default=2)
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
         pp.add_argument("--amp", action="store_true", help="Enable mixed precision (CUDA)")
+        pp.add_argument("--full-cpu", action="store_true", help="Compute full graph score on CPU")
+        pp.add_argument(
+            "--full-mini-batch",
+            action="store_true",
+            help="Approximate full score via NeighborLoader mini-batches",
+        )
         pp.add_argument(
             "--view",
             type=Path,
@@ -230,9 +237,35 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     optim = torch.optim.Adam(selector.parameters(), lr=args.lr)
 
     with torch.no_grad():
-        ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
-        with ctx():
-            full_score = model(graph, return_logits=True).squeeze()
+        if args.full_cpu:
+            model_cpu = model.to("cpu") if device.type == "cuda" else model
+            ctx = nullcontext
+            with ctx():
+                full_score = model_cpu(graph.to("cpu"), return_logits=True).squeeze()
+            if device.type == "cuda":
+                model.to(device)
+        elif args.full_mini_batch:
+            num_neigh = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}
+            loader = NeighborLoader(
+                graph,
+                input_nodes=(model.encoder.target_node, torch.arange(graph[model.encoder.target_node].num_nodes)),
+                batch_size=args.batch_size,
+                num_neighbors=num_neigh,
+                shuffle=False,
+            )
+            preds = []
+            ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+            for batch in loader:
+                batch = batch.to(device)
+                with ctx():
+                    preds.append(model(batch, return_logits=True).squeeze())
+            full_score = torch.stack(preds).mean()
+        else:
+            ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+            g_dev = graph.to(device)
+            with ctx():
+                full_score = model(g_dev, return_logits=True).squeeze()
+            del g_dev
 
     def step_subgraph(sub):
         masks = []


### PR DESCRIPTION
## Summary
- allow explainer training to compute full scores on CPU
- support mini-batch approximation of the full score via `NeighborLoader`
- document the `--full-cpu` and `--full-mini-batch` CLI flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a19f250c832e9edf86ac8104c84e