### PR TITLE
Optimize mini-batch loader lifetime

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -28,7 +28,6 @@ from explain.utils.hetero import (
     filter_view,
     get_edge_store,
 )
-from src.graphs.sampling import sample_subgraph
 from torch_geometric.loader import NeighborLoader
 from src.common.utils import get_logger
 from src.graphs.dataset.graph_dataset import collect_dataset_metadata
@@ -308,18 +307,40 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-    for _ in range(args.epochs):
-        sub = sample_subgraph(
-            graph,
+    # prepare a NeighborLoader for repeated mini-batch sampling
+    neigh_args = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}
+    loader = NeighborLoader(
+        graph,
+        input_nodes=(
             model.encoder.target_node,
-            batch_size=args.batch_size,
-            num_neighbors=args.num_neighbors,
-            num_hops=args.num_hops,
-            device=device,
-        )
+            torch.arange(graph[model.encoder.target_node].num_nodes),
+        ),
+        batch_size=args.batch_size,
+        num_neighbors=neigh_args,
+        shuffle=True,
+    )
+
+    loader_iter = iter(loader)
+    for _ in range(args.epochs):
+        try:
+            sub = next(loader_iter)
+        except StopIteration:
+            loader_iter = iter(loader)
+            sub = next(loader_iter)
+
+        sub = sub.to(device)
+        for nt in sub.node_types:
+            if "batch" not in sub[nt]:
+                sub[nt].batch = torch.zeros(
+                    sub[nt].num_nodes, dtype=torch.long, device=device
+                )
         step_subgraph(sub)
         del sub
         gc.collect()
+
+    # release loader resources explicitly
+    del loader
+    gc.collect()
 
     pred_info = None
     try:


### PR DESCRIPTION
## Summary
- create a NeighborLoader once outside the epoch loop in `explainer_train.py`
- iterate sequentially across epochs using a persistent iterator
- release the loader explicitly to avoid memory leaks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a2db65e0832ea1bbdf187de21ef0