### PR TITLE
Manage CUDA memory during explainer training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -303,7 +303,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         loss.backward()
         optim.step()
         selector.tau.mul_(selector.tau_decay).clamp_(min=selector.tau_min)
-        del masked_score
+        del masked_score, m_prob, loss
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
@@ -337,6 +337,8 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         step_subgraph(sub)
         del sub
         gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     # release loader resources explicitly
     del loader


### PR DESCRIPTION
## Summary
- clear tensors in `step_subgraph` and empty CUDA cache
- empty CUDA cache in the training loop after each epoch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a4ad0020832e96c95a733beba737