### PR TITLE
Add ClusterLoader support to selector training

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ python -m cli.explainer_train feature-mine \
        --embed-dir data/embeds
 # 큰 그래프에서 GPU 메모리 부족이 발생할 경우
 # `--full-cpu` 또는 `--full-mini-batch` 옵션을 활용해 전체 점수 계산을 조절할 수 있습니다.
+# `--cluster-parts`와 `--cluster-batch-size` 옵션을 사용하면 ClusterLoader로 그래프를 분할해 처리할 수 있습니다.
 # 평가
 # 기존의 `temp_explainer_runner.py` 스크립트는 더 이상 제공되지 않습니다.
 # 위의 `feature-mine` 하위 명령을 사용해 동일한 기능을 수행할 수 있습니다.

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -67,6 +67,10 @@ def build_parser() -> argparse.ArgumentParser:
             action="store_true",
             help="Approximate full score via NeighborLoader mini-batches",
         )
+        pp.add_argument("--cluster-parts", type=int, default=0,
+                       help="Number of graph partitions for ClusterLoader (0=disable)")
+        pp.add_argument("--cluster-batch-size", type=int, default=1,
+                       help="Mini-batch size per partition")
         pp.add_argument(
             "--view",
             type=Path,
@@ -258,6 +262,17 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                 batch = batch.to(device)
                 with ctx():
                     preds.append(model(batch, return_logits=True).squeeze())
+            full_score = torch.stack(preds).mean()
+        elif args.cluster_parts > 0:
+            from src.graphs.builders.graph_sampler import cluster_loader
+            loader = cluster_loader(graph, num_parts=args.cluster_parts,
+                                   batch_size=args.cluster_batch_size, shuffle=False)
+            preds = []
+            ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+            for part in loader:
+                part = part.to(device)
+                with ctx():
+                    preds.append(model(part, return_logits=True).squeeze())
             full_score = torch.stack(preds).mean()
         else:
             ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext


### PR DESCRIPTION
## Summary
- add `--cluster-parts` and `--cluster-batch-size` options to CLI
- compute full score using ClusterLoader when partitions enabled
- document new options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c6149298832eb2c13441e886772b