### PR TITLE
Enable cluster-based selector training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -72,6 +72,11 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--cluster-batch-size", type=int, default=1,
                        help="Mini-batch size per partition")
         pp.add_argument(
+            "--cluster-train",
+            action="store_true",
+            help="Use ClusterLoader for training mini-batches",
+        )
+        pp.add_argument(
             "--view",
             type=Path,
             default=Path("data/views/cfg"),
@@ -322,18 +327,32 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-    # prepare a NeighborLoader for repeated mini-batch sampling
-    neigh_args = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}
-    loader = NeighborLoader(
-        graph,
-        input_nodes=(
-            model.encoder.target_node,
-            torch.arange(graph[model.encoder.target_node].num_nodes),
-        ),
-        batch_size=args.batch_size,
-        num_neighbors=neigh_args,
-        shuffle=True,
-    )
+    # prepare a mini-batch loader for repeated sampling
+    if args.cluster_train:
+        from src.graphs.builders.graph_sampler import cluster_loader
+
+        data_for_loader = graph
+        if isinstance(graph, HeteroData):
+            data_for_loader = graph.to_homogeneous()
+
+        loader = cluster_loader(
+            data_for_loader,
+            num_parts=args.cluster_parts,
+            batch_size=args.cluster_batch_size,
+            shuffle=True,
+        )
+    else:
+        neigh_args = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}
+        loader = NeighborLoader(
+            graph,
+            input_nodes=(
+                model.encoder.target_node,
+                torch.arange(graph[model.encoder.target_node].num_nodes),
+            ),
+            batch_size=args.batch_size,
+            num_neighbors=neigh_args,
+            shuffle=True,
+        )
 
     loader_iter = iter(loader)
     for _ in range(args.epochs):
@@ -343,6 +362,10 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             loader_iter = iter(loader)
             sub = next(loader_iter)
 
+        if args.cluster_train:
+            builder = HeteroGraphBuilder()
+            builder.add_view(sub, view_name)
+            sub = builder.build()
         sub = sub.to(device)
         for nt in sub.node_types:
             if "batch" not in sub[nt]:


### PR DESCRIPTION
## Summary
- add `--cluster-train` option to `explainer_train` CLI
- support ClusterLoader batches in `_train_selector_for_graph`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c6d6e890832e8e1f90fc79cc7ff3