### PR TITLE
Improve explainer GPU memory handling

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -496,6 +496,8 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+                clear_memory_cache()
+                LOGGER.debug("CUDA and feature caches cleared")
 
     if args.mine_features and features_out:
         with args.mine_features.open("w", encoding="utf-8") as fp:
@@ -611,7 +613,7 @@ def feature_mine(args: argparse.Namespace) -> None:
 
 
 from src.graphs.dataset import GraphDataset
-from src.graphs.features.cache import load_tensor
+from src.graphs.features.cache import load_tensor, clear_memory_cache
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- free feature cache after each CUDA cache clear in `_train_batch_impl`
- import the new helper from `src.graphs.features.cache`
- log when CUDA and feature caches are cleared

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c9074a04832ebc19f4d317dadab2