### PR TITLE
Refine explainer batch loader

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -58,6 +58,8 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--alpha", type=float, default=1.0)
         pp.add_argument("--beta", type=float, default=2e-2)
         pp.add_argument("--batch-size", type=int, default=2048)
+        pp.add_argument("--num-workers", type=int, default=0,
+                       help="DataLoader worker processes")
         pp.add_argument("--num-neighbors", type=int, default=15)
         pp.add_argument("--num-hops", type=int, default=2)
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
@@ -416,13 +418,12 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
 
 def _train_batch_impl(args, model, device: torch.device) -> None:
-    dataset_root = args.graph_dir.parent.parent
+    root = args.graph_dir.parent.parent
     split = args.graph_dir.parent.name
     ds = GraphDataset(
-        root=dataset_root,
+        root=root,
         split=split,
         load_embeds=True,
-        embed_dir=Path("data/embeds"),
     )
 
     if args.meta_csv:
@@ -441,7 +442,7 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
         ds,
         batch_size=1,
         shuffle=False,
-        num_workers=0,
+        num_workers=args.num_workers,
         collate_fn=lambda b: b[0],
     )
 


### PR DESCRIPTION
## Summary
- add `--num-workers` option for DataLoader
- instantiate GraphDataset using `graph_dir` to infer root and split
- configure DataLoader to respect the new workers option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c9e94204832e9336251f8f0c5ddc