### PR TITLE
Add no-embeds flag for explainer training

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ python -m cli.explainer_train single cfg.pt \
        --output models/selector.pt \
        --epochs 500 \
        --amp \
-       --full-mini-batch
+       --full-mini-batch \
+       [--no-embeds]
 
 # AST 뷰 그래프 학습 예시
 python -m cli.explainer_train single cfg.pt \
@@ -249,7 +250,8 @@ python -m cli.explainer_train batch \
         --output-dir models/explainers \
         --model models/gnn/res_gcl.pt \
         --amp \
-        --full-cpu
+        --full-cpu \
+        [--no-embeds]
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -53,6 +53,7 @@ def build_parser() -> argparse.ArgumentParser:
     def add_common(pp: argparse.ArgumentParser) -> None:
         pp.add_argument("--model", type=Path, required=True, help="Classifier checkpoint")
         pp.add_argument("--device", type=str, default="cpu")
+        pp.add_argument("--no-embeds", action="store_true", help="Skip loading token embeddings")
         pp.add_argument("--epochs", type=int, default=1000)
         pp.add_argument("--lr", type=float, default=2e-3)
         pp.add_argument("--alpha", type=float, default=1.0)
@@ -421,7 +422,7 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
     ds = GraphDataset(
         root=args.graph_dir.parent.parent,
         split=args.graph_dir.parent.name,
-        load_embeds=True,
+        load_embeds=not args.no_embeds,
         require_labels=False,
     )
 
@@ -532,7 +533,7 @@ def train_single(args: argparse.Namespace) -> None:
             raise ValueError("No valid graph with CFG edges found in the dataset.")
 
         sha = getattr(cfg_graph, "sha256", None)
-        if sha:
+        if sha and not args.no_embeds:
             _attach_embeddings(cfg_graph, sha, Path("data/embeds"))
         graph_input = cfg_graph
 

--- a/tests/test_explainer_train_no_embeds.py
+++ b/tests/test_explainer_train_no_embeds.py
@@ -1,0 +1,86 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from tests.test_explainer_train_cli import DummyModel, DummySelector
+from src.graphs.normalizers.schema import NodeType, EdgeRel
+from src.graphs.features.cache import save_tensor
+
+
+def _make_graph(path: Path, embed_dir: Path) -> None:
+    g = HeteroData()
+    g[NodeType.TOKEN.value].x = torch.randn(1, 2)
+    g[NodeType.TOKEN.value].num_nodes = 1
+    ei = torch.tensor([[0], [0]])
+    et = (NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.TOKEN.value)
+    g[et].edge_index = ei
+    g[et].edge_type = torch.zeros(1, dtype=torch.long)
+    torch.save(g, path)
+    save_tensor(path.stem, torch.randn(1, 2), embed_dir)
+
+
+def test_explainer_train_batch_no_embeds(tmp_path, monkeypatch):
+    data_root = tmp_path / "data"
+    embed_dir = data_root / "embeds"
+    gdir = data_root / "train" / "graphs"
+    gdir.mkdir(parents=True)
+    _make_graph(gdir / "a.pt", embed_dir)
+    (data_root / "train" / "labels.csv").write_text("sha256,label\na,1\n")
+
+    meta_csv = tmp_path / "meta.csv"
+    meta_csv.write_text("sha256,label\na,1\n")
+
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    dummy_model = DummyModel()
+    monkeypatch.setattr("src.cli.explainer_train._load_model", lambda p, d: dummy_model)
+    monkeypatch.setattr(
+        "src.cli.explainer_train._train_selector_for_graph",
+        lambda *a, **kw: (DummySelector(), HeteroData(), {"pred": 0, "prob": 0.0}),
+    )
+
+    importlib.invalidate_caches()
+    mod = importlib.import_module("src.cli.explainer_train")
+
+    calls = []
+    orig_init = mod.GraphDataset.__init__
+
+    def rec_init(self, *args, **kwargs):
+        calls.append(kwargs.get("load_embeds", True))
+        orig_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(mod.GraphDataset, "__init__", rec_init)
+
+    argv = [
+        "batch",
+        "--graph-dir",
+        str(gdir),
+        "--meta-csv",
+        str(meta_csv),
+        "--output-dir",
+        str(tmp_path / "out"),
+        "--model",
+        str(mpath),
+        "--epochs",
+        "1",
+        "--no-embeds",
+    ]
+
+    orig_argv = sys.argv
+    sys.argv = argv
+    try:
+        mod.main()
+    finally:
+        sys.argv = orig_argv
+
+    assert calls
+    assert all(c is False for c in calls)


### PR DESCRIPTION
## Summary
- support `--no-embeds` option for `explainer_train`
- load embeddings conditionally and update docs
- test that dataset loader honors the flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e7abc7d8832ea72b42d40c448098