### PR TITLE
Fix edge_id preservation in cluster training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -337,7 +337,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
         data_for_loader = graph
         if isinstance(graph, HeteroData):
-            data_for_loader = graph.to_homogeneous()
+            data_for_loader = graph.to_homogeneous(edge_attrs=["edge_id"])
 
         loader = cluster_loader(
             data_for_loader,


### PR DESCRIPTION
## Summary
- keep `edge_id` when converting graphs to homogeneous format for ClusterGCN

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a04801f84832e861d8dcd1d987a69