### PR TITLE
Fix CPU stacking for explainer_train

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -270,7 +270,8 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             for batch in loader:
                 batch = batch.to(device)
                 with ctx():
-                    preds.append(model(batch, return_logits=True).squeeze())
+                    preds.append(model(batch, return_logits=True).squeeze().cpu())
+            assert all(p.device.type == "cpu" for p in preds)
             full_score = torch.stack(preds).mean()
         elif args.cluster_parts > 0:
             from src.graphs.builders.graph_sampler import cluster_loader
@@ -281,7 +282,8 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             for part in loader:
                 part = part.to(device)
                 with ctx():
-                    preds.append(model(part, return_logits=True).squeeze())
+                    preds.append(model(part, return_logits=True).squeeze().cpu())
+            assert all(p.device.type == "cpu" for p in preds)
             full_score = torch.stack(preds).mean()
         else:
             ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext


### PR DESCRIPTION
## Summary
- force CPU transfer of mini-batch and cluster loop predictions in `explainer_train`
- assert CPU tensors prior to computing averaged score

## Testing
- `pytest -k 'dummy' -q`

------
https://chatgpt.com/codex/tasks/task_e_686a05bfdfac832e8fe99e94825d5007