### PR TITLE
Enable hetero ClusterLoader

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -274,9 +274,13 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             assert all(p.device.type == "cpu" for p in preds)
             full_score = torch.stack(preds).mean()
         elif args.cluster_parts > 0:
-            from src.graphs.builders.graph_sampler import cluster_loader
-            loader = cluster_loader(graph, num_parts=args.cluster_parts,
-                                   batch_size=args.cluster_batch_size, shuffle=False)
+            from src.graphs.builders.graph_sampler import cluster_loader_hetero
+            loader = cluster_loader_hetero(
+                graph,
+                batch_size=args.cluster_batch_size,
+                num_parts=args.cluster_parts,
+                shuffle=False,
+            )
             preds = []
             ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
             for part in loader:
@@ -335,16 +339,12 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
     # prepare a mini-batch loader for repeated sampling
     if args.cluster_train:
-        from src.graphs.builders.graph_sampler import cluster_loader
+        from src.graphs.builders.graph_sampler import cluster_loader_hetero
 
-        data_for_loader = graph
-        if isinstance(graph, HeteroData):
-            data_for_loader = graph.to_homogeneous(edge_attrs=["edge_id"])
-
-        loader = cluster_loader(
-            data_for_loader,
-            num_parts=args.cluster_parts,
+        loader = cluster_loader_hetero(
+            graph,
             batch_size=args.cluster_batch_size,
+            num_parts=args.cluster_parts,
             shuffle=True,
         )
     else:

--- a/src/graphs/builders/__init__.py
+++ b/src/graphs/builders/__init__.py
@@ -38,6 +38,7 @@ try:  # optional torch_geometric dependency
         sample_edge_drop,
         sainth_loader,
         cluster_loader,
+        cluster_loader_hetero,
     )
 except Exception:  # pragma: no cover - missing heavy deps
     HeteroGraphBuilder = ViewMerger = None  # type: ignore
@@ -60,6 +61,9 @@ except Exception:  # pragma: no cover - missing heavy deps
     def cluster_loader(*_a, **_k):  # type: ignore
         raise ImportError("torch_geometric is required")
 
+    def cluster_loader_hetero(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
 __all__: List[str] = [
     # builders
     "HeteroGraphBuilder",
@@ -72,5 +76,6 @@ __all__: List[str] = [
     "sample_edge_drop",
     "sainth_loader",
     "cluster_loader",
+    "cluster_loader_hetero",
     "OverLengthPolicy",
 ]

--- a/src/graphs/builders/graph_sampler.py
+++ b/src/graphs/builders/graph_sampler.py
@@ -160,3 +160,14 @@ def cluster_loader(
 ) -> ClusterLoader:
     data = ClusterData(g, num_parts=num_parts, recursive=False)
     return ClusterLoader(data, batch_size=batch_size, shuffle=shuffle)
+
+
+def cluster_loader_hetero(
+    g: HeteroData,
+    num_parts: int = 1500,
+    batch_size: int = 20,
+    shuffle: bool = True,
+) -> ClusterLoader:
+    """ClusterGCN loader for :class:`HeteroData` graphs."""
+    data = ClusterData(g, num_parts=num_parts, recursive=False)
+    return ClusterLoader(data, batch_size=batch_size, shuffle=shuffle)


### PR DESCRIPTION
## Summary
- enable ClusterLoader support for HeteroData graphs
- expose `cluster_loader_hetero`
- use the hetero loader in `explainer_train`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a0b2ae354832e90979eed9373604c