### PR TITLE
Add selector score caching

### DIFF
--- a/scripts/precompute_scores.py
+++ b/scripts/precompute_scores.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.models.gnn.res_wrapper import RESGCLClassifier
+from src.graphs.dataset import GraphDataset
+
+
+def load_graph(path: Path) -> HeteroData:
+    g = torch.load(path, weights_only=False)
+    return GraphDataset._ensure_x(GraphDataset._ensure_num_nodes(g))
+
+
+def compute_score(model: RESGCLClassifier, g: HeteroData, device: torch.device) -> float:
+    for nt in g.node_types:
+        g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
+    g = g.to(device)
+    with torch.no_grad():
+        logits = model(g, return_logits=True).squeeze()
+    return float(logits.cpu().item())
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Precompute full graph scores")
+    parser.add_argument("--model", type=Path, required=True, help="Classifier checkpoint")
+    parser.add_argument("--device", type=str, default="cpu")
+    parser.add_argument("--output", type=Path, required=True, help="Score cache JSON path")
+    parser.add_argument("graphs", nargs="+", type=Path, help="Graph files (*.pt)")
+    args = parser.parse_args(argv)
+
+    device = torch.device(args.device)
+    model = RESGCLClassifier.load_from_checkpoint(args.model, map_location=device)
+    model.to(device).eval()
+
+    scores: dict[str, float] = {}
+    for gp in args.graphs:
+        g = load_graph(gp)
+        sha = getattr(g, "sha256", gp.stem)
+        scores[sha] = compute_score(model, g, device)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as fp:
+        json.dump(scores, fp, indent=2)
+    print(f"[OK] scores saved -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -64,6 +64,7 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--num-neighbors", type=int, default=15)
         pp.add_argument("--num-hops", type=int, default=2)
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
+        pp.add_argument("--score-cache", type=Path, help="JSON file with precomputed full scores")
         pp.add_argument("--amp", action="store_true", help="Enable mixed precision (CUDA)")
         pp.add_argument("--full-cpu", action="store_true", help="Compute full graph score on CPU")
         pp.add_argument(
@@ -181,6 +182,14 @@ def _mine_tokens(graph: HeteroData, model, device: torch.device) -> list[str]:
 
 
 def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torch.device):
+    sha = None
+    if isinstance(graph, str):
+        sha = graph
+    else:
+        sha = getattr(graph, "sha256", None)
+        if sha is None:
+            sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")
+
     view_flag = None
     if args.ast:
         view_flag = "ast"
@@ -197,9 +206,6 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         # treat args.view as the root directory when a view flag is specified
         view_dir = Path(args.view) / view_flag
         view_name = view_flag
-        sha = graph if isinstance(graph, str) else getattr(graph, "sha256", None)
-        if sha is None and not isinstance(graph, str):
-            sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")
         if not sha:
             raise ValueError("sha256 required to load view graph")
         fp = view_dir / f"{sha}.json"
@@ -229,6 +235,14 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
     _reinit_input_proj(graph, model, device)
 
+    score_cache: dict[str, float] = {}
+    if args.score_cache and args.score_cache.is_file():
+        try:
+            with args.score_cache.open() as fp:
+                score_cache = json.load(fp)
+        except Exception as e:  # pragma: no cover - best effort
+            LOGGER.warning("Failed to load score cache %s: %s", args.score_cache, e)
+
     if args.amp and device.type == "cuda":
         def score_fn(g):
             with torch.cuda.amp.autocast():
@@ -248,53 +262,66 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
     optim = torch.optim.Adam(selector.parameters(), lr=args.lr)
 
-    with torch.no_grad():
-        if args.full_cpu:
-            model_cpu = model.to("cpu") if device.type == "cuda" else model
-            ctx = nullcontext
-            with ctx():
-                full_score = model_cpu(graph.to("cpu"), return_logits=True).squeeze()
-            if device.type == "cuda":
-                model.to(device)
-        elif args.full_mini_batch:
-            num_neigh = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}
-            loader = NeighborLoader(
-                graph,
-                input_nodes=(model.encoder.target_node, torch.arange(graph[model.encoder.target_node].num_nodes)),
-                batch_size=args.batch_size,
-                num_neighbors=num_neigh,
-                shuffle=False,
-            )
-            preds = []
-            ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
-            for batch in loader:
-                batch = batch.to(device)
+    full_score: torch.Tensor | None = None
+    if args.score_cache and sha and sha in score_cache:
+        full_score = torch.tensor(score_cache[sha], device=device)
+    else:
+        with torch.no_grad():
+            if args.full_cpu:
+                model_cpu = model.to("cpu") if device.type == "cuda" else model
+                ctx = nullcontext
                 with ctx():
-                    preds.append(model(batch, return_logits=True).squeeze().cpu())
-            assert all(p.device.type == "cpu" for p in preds)
-            full_score = torch.stack(preds).mean()
-        elif args.cluster_parts > 0:
-            from src.graphs.builders.graph_sampler import cluster_loader_hetero
-            loader = cluster_loader_hetero(
-                graph,
-                batch_size=args.cluster_batch_size,
-                num_parts=args.cluster_parts,
-                shuffle=False,
-            )
-            preds = []
-            ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
-            for part in loader:
-                part = part.to(device)
+                    full_score = model_cpu(graph.to("cpu"), return_logits=True).squeeze()
+                if device.type == "cuda":
+                    model.to(device)
+            elif args.full_mini_batch:
+                num_neigh = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}
+                loader = NeighborLoader(
+                    graph,
+                    input_nodes=(model.encoder.target_node, torch.arange(graph[model.encoder.target_node].num_nodes)),
+                    batch_size=args.batch_size,
+                    num_neighbors=num_neigh,
+                    shuffle=False,
+                )
+                preds = []
+                ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+                for batch in loader:
+                    batch = batch.to(device)
+                    with ctx():
+                        preds.append(model(batch, return_logits=True).squeeze().cpu())
+                assert all(p.device.type == "cpu" for p in preds)
+                full_score = torch.stack(preds).mean()
+            elif args.cluster_parts > 0:
+                from src.graphs.builders.graph_sampler import cluster_loader_hetero
+                loader = cluster_loader_hetero(
+                    graph,
+                    batch_size=args.cluster_batch_size,
+                    num_parts=args.cluster_parts,
+                    shuffle=False,
+                )
+                preds = []
+                ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+                for part in loader:
+                    part = part.to(device)
+                    with ctx():
+                        preds.append(model(part, return_logits=True).squeeze().cpu())
+                assert all(p.device.type == "cpu" for p in preds)
+                full_score = torch.stack(preds).mean()
+            else:
+                ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+                g_dev = graph.to(device)
                 with ctx():
-                    preds.append(model(part, return_logits=True).squeeze().cpu())
-            assert all(p.device.type == "cpu" for p in preds)
-            full_score = torch.stack(preds).mean()
-        else:
-            ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
-            g_dev = graph.to(device)
-            with ctx():
-                full_score = model(g_dev, return_logits=True).squeeze()
-            del g_dev
+                    full_score = model(g_dev, return_logits=True).squeeze()
+                del g_dev
+
+        if args.score_cache and sha:
+            score_cache[sha] = float(full_score.detach().cpu().item())
+            try:
+                args.score_cache.parent.mkdir(parents=True, exist_ok=True)
+                with args.score_cache.open("w", encoding="utf-8") as fp:
+                    json.dump(score_cache, fp, indent=2)
+            except Exception as e:  # pragma: no cover - best effort
+                LOGGER.warning("Failed to update score cache %s: %s", args.score_cache, e)
 
     def step_subgraph(sub):
         masks = []

--- a/tests/test_score_cache.py
+++ b/tests/test_score_cache.py
@@ -1,0 +1,84 @@
+import argparse
+import types
+import json
+from pathlib import Path
+
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.cli.explainer_train import _train_selector_for_graph
+
+
+class DummyModel:
+    def __init__(self):
+        self.encoder = types.SimpleNamespace(target_node="bb", input_proj={})
+        self.calls = 0
+
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        return torch.tensor([0.0])
+
+
+def build_graph():
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    ei = torch.tensor([[0], [0]])
+    g[("bb", "cfg", "bb")].edge_index = ei
+    g[("bb", "cfg", "bb")].edge_type = torch.zeros(1, dtype=torch.long)
+    g.sha256 = "abc"
+    return g
+
+
+def make_args(cache_path):
+    return argparse.Namespace(
+        ast=False,
+        cfg=False,
+        fcg=False,
+        syscall=False,
+        view=Path("data/views/cfg"),
+        full_cpu=False,
+        full_mini_batch=False,
+        cluster_parts=0,
+        cluster_batch_size=1,
+        cluster_train=False,
+        amp=False,
+        num_neighbors=1,
+        num_hops=1,
+        batch_size=1,
+        epochs=0,
+        lr=1e-3,
+        alpha=1.0,
+        beta=0.0,
+        plot_path=None,
+        score_cache=cache_path,
+    )
+
+
+def test_score_cache(tmp_path):
+    cache = tmp_path / "scores.json"
+    g = build_graph()
+    model = DummyModel()
+    args = make_args(cache)
+    device = torch.device("cpu")
+
+    _train_selector_for_graph(g, model, args, device)
+    assert cache.exists()
+    data = json.loads(cache.read_text())
+    assert data["abc"] == 0.0
+    first_calls = model.calls
+
+    model.calls = 0
+    _train_selector_for_graph(g, model, args, device)
+    # second call should skip full score computation
+    assert model.calls < first_calls


### PR DESCRIPTION
## Summary
- add `--score-cache` option to the explainer CLI
- look up precomputed full scores by sha in `_train_selector_for_graph`
- update score JSON when missing
- add script to precompute scores for many graphs
- test score caching logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a13a911a0832ea39d4d651480aec2