### PR TITLE
Add prepartition support using METIS

### DIFF
--- a/scripts/prepartition_graphs.py
+++ b/scripts/prepartition_graphs.py
@@ -1,0 +1,45 @@
+import argparse
+import sys
+from pathlib import Path
+import torch
+import numpy as np
+
+# add repo root for local imports when executed directly
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from torch_geometric.loader import ClusterData
+
+
+def load_graph(path: Path):
+    return torch.load(path, weights_only=False)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Pre-partition graphs with METIS")
+    p.add_argument("graph_dir", type=Path, help="Directory with *.pt graphs")
+    p.add_argument("--parts", type=int, default=1500, help="Number of partitions")
+    p.add_argument("--output-dir", type=Path, default=Path("cluster"), help="Directory to save *.npz files")
+    args = p.parse_args(argv)
+
+    out_dir = args.output_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    paths = sorted(args.graph_dir.glob("*.pt"))
+    for gp in paths:
+        g = load_graph(gp)
+        cd = ClusterData(g, num_parts=args.parts, recursive=False)
+        part = cd.partition
+        np.savez_compressed(
+            out_dir / f"{gp.stem}.npz",
+            indptr=part.indptr.cpu().numpy(),
+            index=part.index.cpu().numpy(),
+            partptr=part.partptr.cpu().numpy(),
+            node_perm=part.node_perm.cpu().numpy(),
+            edge_perm=part.edge_perm.cpu().numpy(),
+            sparse_format=part.sparse_format,
+        )
+        print(f"[OK] {gp.name} -> {gp.stem}.npz")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -76,11 +76,8 @@ def build_parser() -> argparse.ArgumentParser:
                        help="Number of graph partitions for ClusterLoader (0=disable)")
         pp.add_argument("--cluster-batch-size", type=int, default=1,
                        help="Mini-batch size per partition")
-        pp.add_argument(
-            "--cluster-train",
-            action="store_true",
-            help="Use ClusterLoader for training mini-batches",
-        )
+        pp.add_argument("--cluster-dir", type=Path,
+                       help="Directory with precomputed cluster *.npz files")
         pp.add_argument(
             "--view",
             type=Path,
@@ -190,6 +187,11 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         if sha is None:
             sha = getattr(getattr(graph, "metadata", {}), "get", lambda _x: None)("sha256")
 
+    cluster_file = None
+    if args.cluster_dir and sha:
+        cluster_file = Path(args.cluster_dir) / f"{sha}.npz"
+    has_cluster = cluster_file is not None and cluster_file.is_file()
+
     view_flag = None
     if args.ast:
         view_flag = "ast"
@@ -291,6 +293,14 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                         preds.append(model(batch, return_logits=True).squeeze().cpu())
                 assert all(p.device.type == "cpu" for p in preds)
                 full_score = torch.stack(preds).mean()
+            elif has_cluster:
+                from src.graphs.builders.graph_sampler import cluster_file_loader_hetero
+                loader = cluster_file_loader_hetero(
+                    graph,
+                    cluster_file,
+                    batch_size=args.cluster_batch_size,
+                    shuffle=False,
+                )
             elif args.cluster_parts > 0:
                 from src.graphs.builders.graph_sampler import cluster_loader_hetero
                 loader = cluster_loader_hetero(
@@ -365,13 +375,13 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             torch.cuda.empty_cache()
 
     # prepare a mini-batch loader for repeated sampling
-    if args.cluster_train:
-        from src.graphs.builders.graph_sampler import cluster_loader_hetero
+    if has_cluster:
+        from src.graphs.builders.graph_sampler import cluster_file_loader_hetero
 
-        loader = cluster_loader_hetero(
+        loader = cluster_file_loader_hetero(
             graph,
+            cluster_file,
             batch_size=args.cluster_batch_size,
-            num_parts=args.cluster_parts,
             shuffle=True,
         )
     else:
@@ -395,7 +405,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             loader_iter = iter(loader)
             sub = next(loader_iter)
 
-        if args.cluster_train:
+        if has_cluster:
             builder = HeteroGraphBuilder()
             builder.add_view(sub, view_name)
             sub = builder.build()

--- a/src/graphs/builders/graph_sampler.py
+++ b/src/graphs/builders/graph_sampler.py
@@ -28,9 +28,11 @@ PyG 내장 래퍼
 from __future__ import annotations
 
 import random
+from pathlib import Path
 from typing import Iterable, List, Tuple
 
 import torch
+import numpy as np
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.loader import (
     ClusterData,
@@ -38,6 +40,7 @@ from torch_geometric.loader import (
     GraphSAINTEdgeSampler,
     GraphSAINTNodeSampler,
 )
+from torch_geometric.loader.cluster import Partition
 from torch_geometric.utils import k_hop_subgraph, subgraph
 
 ###############################################################################
@@ -171,3 +174,39 @@ def cluster_loader_hetero(
     """ClusterGCN loader for :class:`HeteroData` graphs."""
     data = ClusterData(g, num_parts=num_parts, recursive=False)
     return ClusterLoader(data, batch_size=batch_size, shuffle=shuffle)
+
+
+def cluster_file_loader(
+    g: Data,
+    cluster_file: str | Path,
+    batch_size: int = 20,
+    shuffle: bool = True,
+) -> ClusterLoader:
+    """ClusterGCN loader from a saved ``*.npz`` partition file."""
+    arr = np.load(cluster_file)
+    part = Partition(
+        indptr=torch.from_numpy(arr["indptr"]),
+        index=torch.from_numpy(arr["index"]),
+        partptr=torch.from_numpy(arr["partptr"]),
+        node_perm=torch.from_numpy(arr["node_perm"]),
+        edge_perm=torch.from_numpy(arr["edge_perm"]),
+        sparse_format=str(arr.get("sparse_format", "csr")),
+    )
+    data_obj = ClusterData.__new__(ClusterData)
+    data_obj.num_parts = part.partptr.numel() - 1
+    data_obj.partition = part
+    data_obj.recursive = False
+    data_obj.keep_inter_cluster_edges = False
+    data_obj.sparse_format = part.sparse_format
+    data_obj.data = ClusterData._permute_data(data_obj, g, part)
+    return ClusterLoader(data_obj, batch_size=batch_size, shuffle=shuffle)
+
+
+def cluster_file_loader_hetero(
+    g: HeteroData,
+    cluster_file: str | Path,
+    batch_size: int = 20,
+    shuffle: bool = True,
+) -> ClusterLoader:
+    """ClusterGCN loader for :class:`HeteroData` from partition file."""
+    return cluster_file_loader(g, cluster_file, batch_size=batch_size, shuffle=shuffle)


### PR DESCRIPTION
## Summary
- add `scripts/prepartition_graphs.py` to save METIS partitions
- load cluster `.npz` files using new `cluster_file_loader[_hetero]`
- update `explainer_train.py` to use `--cluster-dir` and drop `--cluster-train`

## Testing
- `pytest -k explainer_train_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_686a155d19f8832e979311531f09406f