### PR TITLE
Add FP16 casting support to selector training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -11,6 +11,16 @@ import gc
 from pathlib import Path
 from contextlib import nullcontext
 
+
+def _cast_graph_dtype(g: HeteroData, dtype: torch.dtype) -> None:
+    """Cast floating-point attributes of ``g`` in-place to ``dtype``."""
+    if dtype == torch.float32:
+        return
+    for store in g.node_stores + g.edge_stores:
+        for key, val in list(store.items()):
+            if torch.is_tensor(val) and torch.is_floating_point(val) and val.dtype != dtype:
+                store[key] = val.to(dtype)
+
 import torch
 from torch.utils.data import DataLoader
 from torch_geometric.data import HeteroData
@@ -236,6 +246,8 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         graph[nt].batch = torch.zeros(graph[nt].num_nodes, dtype=torch.long)
 
     _reinit_input_proj(graph, model, device)
+    param_dtype = next(model.parameters()).dtype
+    _cast_graph_dtype(graph, param_dtype)
 
     score_cache: dict[str, float] = {}
     if args.score_cache and args.score_cache.is_file():
@@ -290,6 +302,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                 ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
                 for batch in loader:
                     batch = batch.to(device)
+                    _cast_graph_dtype(batch, param_dtype)
                     with ctx():
                         pred_sum += model(batch, return_logits=True).squeeze().cpu()
                     n += 1
@@ -315,6 +328,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                 ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
                 for part in loader:
                     part = part.to(device)
+                    _cast_graph_dtype(part, param_dtype)
                     with ctx():
                         pred_sum += model(part, return_logits=True).squeeze().cpu()
                     n += 1
@@ -322,6 +336,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             else:
                 ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
                 g_dev = graph.to(device)
+                _cast_graph_dtype(g_dev, param_dtype)
                 with ctx():
                     full_score = model(g_dev, return_logits=True).squeeze()
                 del g_dev
@@ -336,6 +351,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                 LOGGER.warning("Failed to update score cache %s: %s", args.score_cache, e)
 
     def step_subgraph(sub):
+        _cast_graph_dtype(sub, param_dtype)
         masks = []
         optim.zero_grad()
         τ = float(selector.tau)
@@ -443,6 +459,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         builder = HeteroGraphBuilder()
         builder.add_view(pruned, view_name)
         pruned_graph = builder.build()
+        _cast_graph_dtype(pruned_graph, param_dtype)
         with torch.no_grad():
             ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
             with ctx():

--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -54,6 +54,7 @@ class RESGCLClassifier(nn.Module):
         head: Union[str, nn.Module] = "binary_mlp",  # name or instance
         drop_prob: float = 0.2,
         n_samples_cert: int = 30,
+        dtype: torch.dtype | None = None,
     ):
         """
         Parameters
@@ -86,6 +87,9 @@ class RESGCLClassifier(nn.Module):
             self.classifier = nn.Linear(self.head.out_dim, 1)
         else:
             self.classifier = None
+
+        if dtype is not None:
+            self.to(dtype=dtype)
 
     # ------------------------------------------------------------------ #
     @staticmethod
@@ -160,7 +164,7 @@ class RESGCLClassifier(nn.Module):
 
     # ------------------------------------------------------------------ #
     @classmethod
-    def load_from_checkpoint(cls, path, *, map_location=None) -> "RESGCLClassifier":
+    def load_from_checkpoint(cls, path, *, map_location=None, dtype=None) -> "RESGCLClassifier":
         """Load classifier from ``torch.save`` checkpoint."""
         obj = torch.load(path, map_location=map_location, weights_only=False)
 
@@ -226,12 +230,12 @@ class RESGCLClassifier(nn.Module):
         else:
             encoder = RGCNEncoder._from_state_dict(enc_state, attr_names=attr_names)
 
-        model = cls(encoder=encoder)
+        model = cls(encoder=encoder, dtype=dtype)
         model.load_state_dict(state, strict=False)
         return model
 
     # ------------------------------------------------------------------ #
     @classmethod
-    def load_pretrained(cls, path, *, map_location=None) -> "RESGCLClassifier":
+    def load_pretrained(cls, path, *, map_location=None, dtype=None) -> "RESGCLClassifier":
         """Backward-compatible alias for :meth:`load_from_checkpoint`."""
-        return cls.load_from_checkpoint(path, map_location=map_location)
+        return cls.load_from_checkpoint(path, map_location=map_location, dtype=dtype)


### PR DESCRIPTION
## Summary
- cast graph tensors to model dtype in `_train_selector_for_graph`
- allow `RESGCLClassifier` initialization and loading with optional dtype for FP16 weights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1888b534832eb4442e99809dd059