### PR TITLE
Add GraphSAINT sampler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ python -m cli.explainer_train feature-mine \
 # 큰 그래프에서 GPU 메모리 부족이 발생할 경우
 # `--full-cpu` 또는 `--full-mini-batch` 옵션을 활용해 전체 점수 계산을 조절할 수 있습니다.
 # `--cluster-parts`와 `--cluster-batch-size` 옵션을 사용하면 ClusterLoader로 그래프를 분할해 처리할 수 있습니다.
+# `--saint {node,edge}` 옵션을 사용하면 GraphSAINT 샘플러로 서브그래프 단위 학습이 가능해 GPU 메모리를 절약할 수 있습니다.
 # 평가
 # 기존의 `temp_explainer_runner.py` 스크립트는 더 이상 제공되지 않습니다.
 # 위의 `feature-mine` 하위 명령을 사용해 동일한 기능을 수행할 수 있습니다.

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -73,6 +73,10 @@ def build_parser() -> argparse.ArgumentParser:
                        help="DataLoader worker processes")
         pp.add_argument("--num-neighbors", type=int, default=15)
         pp.add_argument("--num-hops", type=int, default=2)
+        pp.add_argument("--saint", choices=["node", "edge"], help="Use GraphSAINT loader")
+        pp.add_argument("--walk-length", type=int, default=2, help="GraphSAINT walk length")
+        pp.add_argument("--sample-coverage", type=int, default=0, help="GraphSAINT sample coverage")
+        pp.add_argument("--num-steps", type=int, default=1, help="GraphSAINT steps per epoch")
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
         pp.add_argument("--score-cache", type=Path, help="JSON file with precomputed full scores")
         pp.add_argument("--amp", action="store_true", help="Enable mixed precision (CUDA)")
@@ -333,6 +337,26 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                         pred_sum += model(part, return_logits=True).squeeze().cpu()
                     n += 1
                 full_score = pred_sum / n
+            elif args.saint:
+                from src.graphs.builders.graph_sampler import sainth_loader_hetero
+                loader = sainth_loader_hetero(
+                    graph,
+                    mode=args.saint,
+                    batch_size=args.batch_size,
+                    walk_length=args.walk_length,
+                    sample_coverage=args.sample_coverage,
+                    num_steps=args.num_steps,
+                )
+                pred_sum = torch.tensor(0.0)
+                n = 0
+                ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
+                for part in loader:
+                    part = part.to(device)
+                    _cast_graph_dtype(part, param_dtype)
+                    with ctx():
+                        pred_sum += model(part, return_logits=True).squeeze().cpu()
+                    n += 1
+                full_score = pred_sum / n
             else:
                 ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
                 g_dev = graph.to(device)
@@ -401,6 +425,17 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             cluster_file,
             batch_size=args.cluster_batch_size,
             shuffle=True,
+        )
+    elif args.saint:
+        from src.graphs.builders.graph_sampler import sainth_loader_hetero
+
+        loader = sainth_loader_hetero(
+            graph,
+            mode=args.saint,
+            batch_size=args.batch_size,
+            walk_length=args.walk_length,
+            sample_coverage=args.sample_coverage,
+            num_steps=args.num_steps,
         )
     else:
         neigh_args = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}

--- a/src/graphs/__init__.py
+++ b/src/graphs/__init__.py
@@ -62,6 +62,7 @@ from .builders import (
     sample_random_walk,
     sample_edge_drop,
     sainth_loader,
+    sainth_loader_hetero,
     cluster_loader,
 )
 
@@ -117,6 +118,7 @@ __all__: List[str] = [
     "sample_random_walk",
     "sample_edge_drop",
     "sainth_loader",
+    "sainth_loader_hetero",
     "cluster_loader",
     # dataset
     "GraphDataset",

--- a/src/graphs/builders/__init__.py
+++ b/src/graphs/builders/__init__.py
@@ -12,6 +12,7 @@ from graphs.builders import (
     sample_random_walk,   # random-walk 병합 서브그래프
     sample_edge_drop,     # 엣지-드롭 증강
     sainth_loader,        # GraphSAINT Node/Edge Loader
+    sainth_loader_hetero,
     cluster_loader,       # ClusterGCN Loader
 )
 
@@ -37,6 +38,7 @@ try:  # optional torch_geometric dependency
         sample_random_walk,
         sample_edge_drop,
         sainth_loader,
+        sainth_loader_hetero,
         cluster_loader,
         cluster_loader_hetero,
     )
@@ -58,6 +60,9 @@ except Exception:  # pragma: no cover - missing heavy deps
     def sainth_loader(*_a, **_k):  # type: ignore
         raise ImportError("torch_geometric is required")
 
+    def sainth_loader_hetero(*_a, **_k):  # type: ignore
+        raise ImportError("torch_geometric is required")
+
     def cluster_loader(*_a, **_k):  # type: ignore
         raise ImportError("torch_geometric is required")
 
@@ -75,6 +80,7 @@ __all__: List[str] = [
     "sample_random_walk",
     "sample_edge_drop",
     "sainth_loader",
+    "sainth_loader_hetero",
     "cluster_loader",
     "cluster_loader_hetero",
     "OverLengthPolicy",

--- a/src/graphs/builders/graph_sampler.py
+++ b/src/graphs/builders/graph_sampler.py
@@ -147,12 +147,66 @@ def sainth_loader(
     mode: str = "node",
     batch_size: int = 6000,
     walk_length: int = 2,
+    *,
+    num_steps: int = 1,
+    sample_coverage: int = 0,
+    save_dir: str | None = None,
+    log: bool = True,
+    num_workers: int = 0,
 ) -> GraphSAINTNodeSampler | GraphSAINTEdgeSampler:
+    common = dict(
+        batch_size=batch_size,
+        walk_length=walk_length,
+        num_steps=num_steps,
+        sample_coverage=sample_coverage,
+        save_dir=save_dir,
+        log=log,
+        num_workers=num_workers,
+    )
     if mode == "node":
-        return GraphSAINTNodeSampler(g, batch_size=batch_size, walk_length=walk_length)
+        return GraphSAINTNodeSampler(g, **common)
     if mode == "edge":
-        return GraphSAINTEdgeSampler(g, batch_size=batch_size, walk_length=walk_length)
+        return GraphSAINTEdgeSampler(g, **common)
     raise ValueError("mode must be 'node' or 'edge'")
+
+
+def sainth_loader_hetero(
+    g: HeteroData,
+    mode: str = "node",
+    batch_size: int = 6000,
+    walk_length: int = 2,
+    *,
+    num_steps: int = 1,
+    sample_coverage: int = 0,
+    save_dir: str | None = None,
+    log: bool = True,
+    num_workers: int = 0,
+) -> Iterable[HeteroData]:
+    """GraphSAINT sampler for :class:`HeteroData` graphs.
+
+    The heterogeneous graph is converted to a homogeneous view for sampling and
+    then reconstructed on the fly for each mini-batch.
+    """
+    from torch_geometric.utils import to_homogeneous, to_heterogeneous
+
+    homo, node_type, edge_type = to_homogeneous(
+        g, add_node_type=True, add_edge_type=True
+    )
+
+    loader = sainth_loader(
+        homo,
+        mode=mode,
+        batch_size=batch_size,
+        walk_length=walk_length,
+        num_steps=num_steps,
+        sample_coverage=sample_coverage,
+        save_dir=save_dir,
+        log=log,
+        num_workers=num_workers,
+    )
+
+    for sub in loader:
+        yield to_heterogeneous(sub, node_type=node_type, edge_type=edge_type)
 
 
 def cluster_loader(

--- a/tests/test_sainth_loader.py
+++ b/tests/test_sainth_loader.py
@@ -1,0 +1,26 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.graphs.builders.graph_sampler import sainth_loader_hetero
+
+
+def build_small_graph():
+    g = HeteroData()
+    g["n"].x = torch.randn(4, 3)
+    g["n"].num_nodes = 4
+    ei = torch.tensor([[0, 1, 2], [1, 2, 3]], dtype=torch.long)
+    g[("n", "rel", "n")].edge_index = ei
+    return g
+
+
+def test_sainth_loader_hetero_yields_graphs():
+    g = build_small_graph()
+    loader = sainth_loader_hetero(g, num_steps=1)
+    sub = next(iter(loader))
+    assert isinstance(sub, HeteroData)
+    assert sub.num_nodes > 0


### PR DESCRIPTION
## Summary
- add hetero-compatible `sainth_loader_hetero`
- use GraphSAINT loader when `--saint` option is given
- document GraphSAINT sampling in README
- test loader helper

## Testing
- `pytest -q` *(fails: missing heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_686a1b23d7c8832eae593b6685704b1c