### PR TITLE
Add checkpoint option for RESGCL forward

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -103,6 +103,7 @@ def build_parser() -> argparse.ArgumentParser:
         flag.add_argument("--cfg", action="store_true", help="Load CFG view graphs")
         flag.add_argument("--fcg", action="store_true", help="Load FCG view graphs")
         flag.add_argument("--syscall", action="store_true", help="Load SysCall view graphs")
+        pp.add_argument("--checkpoint", action="store_true", help="Enable gradient checkpointing")
 
     # --- single graph ---
     s = sub.add_parser("single", help="Train selector on a single graph")
@@ -264,9 +265,9 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     if args.amp and device.type == "cuda":
         def score_fn(g):
             with torch.cuda.amp.autocast():
-                return model(g, return_logits=True).squeeze()
+                return model(g, return_logits=True, checkpoint_layers=args.checkpoint).squeeze()
     else:
-        score_fn = lambda g: model(g, return_logits=True).squeeze()
+        score_fn = lambda g: model(g, return_logits=True, checkpoint_layers=args.checkpoint).squeeze()
     # attach global edge ids for subgraph sampling
     offset = 0
     for et in graph.edge_types:
@@ -289,7 +290,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                 model_cpu = model.to("cpu") if device.type == "cuda" else model
                 ctx = nullcontext
                 with ctx():
-                    full_score = model_cpu(graph.to("cpu"), return_logits=True).squeeze()
+                    full_score = model_cpu(graph.to("cpu"), return_logits=True, checkpoint_layers=args.checkpoint).squeeze()
                 if device.type == "cuda":
                     model.to(device)
             elif args.full_mini_batch:
@@ -308,7 +309,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                     batch = batch.to(device)
                     _cast_graph_dtype(batch, param_dtype)
                     with ctx():
-                        pred_sum += model(batch, return_logits=True).squeeze().cpu()
+                        pred_sum += model(batch, return_logits=True, checkpoint_layers=args.checkpoint).squeeze().cpu()
                     n += 1
                 full_score = pred_sum / n
             elif has_cluster:
@@ -334,7 +335,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                     part = part.to(device)
                     _cast_graph_dtype(part, param_dtype)
                     with ctx():
-                        pred_sum += model(part, return_logits=True).squeeze().cpu()
+                        pred_sum += model(part, return_logits=True, checkpoint_layers=args.checkpoint).squeeze().cpu()
                     n += 1
                 full_score = pred_sum / n
             elif args.saint:
@@ -354,7 +355,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                     part = part.to(device)
                     _cast_graph_dtype(part, param_dtype)
                     with ctx():
-                        pred_sum += model(part, return_logits=True).squeeze().cpu()
+                        pred_sum += model(part, return_logits=True, checkpoint_layers=args.checkpoint).squeeze().cpu()
                     n += 1
                 full_score = pred_sum / n
             else:
@@ -362,7 +363,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                 g_dev = graph.to(device)
                 _cast_graph_dtype(g_dev, param_dtype)
                 with ctx():
-                    full_score = model(g_dev, return_logits=True).squeeze()
+                    full_score = model(g_dev, return_logits=True, checkpoint_layers=args.checkpoint).squeeze()
                 del g_dev
 
         if args.score_cache and sha:
@@ -498,7 +499,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         with torch.no_grad():
             ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
             with ctx():
-                logits = model(pruned_graph, return_logits=True).squeeze()
+                logits = model(pruned_graph, return_logits=True, checkpoint_layers=args.checkpoint).squeeze()
             prob = float(logits.sigmoid().cpu().item())
             pred = int(prob >= 0.5)
             pred_info = {"pred": pred, "prob": prob}

--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -33,6 +33,7 @@ import logging
 
 import torch
 from torch import nn, Tensor
+from torch.utils.checkpoint import checkpoint
 
 from .layers.edge_smoothing import EdgeDropSmoothing
 from .heads import get_head, HEAD_REGISTRY  # registry helpers
@@ -103,7 +104,9 @@ class RESGCLClassifier(nn.Module):
         return head
 
     # ------------------------------------------------------------------ #
-    def forward(self, data, *, return_logits: bool = False) -> Tensor:
+    def forward(
+        self, data, *, return_logits: bool = False, checkpoint_layers: bool = False
+    ) -> Tensor:
         """Single forward pass with edge‑drop when in training mode."""
         # apply edge‑drop only during training
         if self.training:
@@ -115,7 +118,10 @@ class RESGCLClassifier(nn.Module):
                 if ea is not None:
                     data[etype].edge_attr = ea
 
-        emb = self.encoder(data)                      # (B, D)
+        if checkpoint_layers:
+            emb = checkpoint(self.encoder, data)      # (B, D)
+        else:
+            emb = self.encoder(data)                  # (B, D)
         if emb is None:
             return None
         


### PR DESCRIPTION
## Summary
- optionally checkpoint layers when calling `RESGCLClassifier.forward`
- expose `--checkpoint` flag in `explainer_train.py`
- pass checkpoint flag through training helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a213c5c28832eb3b5f1c0cd825c4b