### PR TITLE
Auto adjust explainer batch settings

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -11,6 +11,8 @@ import gc
 from pathlib import Path
 from contextlib import nullcontext
 
+import psutil
+
 
 def _cast_graph_dtype(g: HeteroData, dtype: torch.dtype) -> None:
     """Cast floating-point attributes of ``g`` in-place to ``dtype``."""
@@ -709,8 +711,39 @@ from src.graphs.dataset import GraphDataset
 from src.graphs.features.cache import load_tensor, clear_memory_cache
 
 
+def _available_memory_gb(device: torch.device) -> float:
+    """Return approximate available memory in GB for *device*."""
+    if device.type == "cuda" and torch.cuda.is_available():
+        free, _ = torch.cuda.mem_get_info(device)
+        return free / 1024 ** 3
+    return psutil.virtual_memory().available / 1024 ** 3
+
+
+def _auto_adjust_params(args: argparse.Namespace, device: torch.device) -> None:
+    """Auto-tune batch and neighbor parameters based on free memory."""
+    mem_gb = _available_memory_gb(device)
+    orig_bs = args.batch_size
+    orig_neigh = args.num_neighbors
+
+    if mem_gb < 4:
+        if args.batch_size > 1:
+            args.batch_size = max(1, args.batch_size // 2)
+        if args.num_neighbors > 1:
+            args.num_neighbors = max(1, args.num_neighbors // 2)
+
+    if args.batch_size != orig_bs or args.num_neighbors != orig_neigh:
+        LOGGER.info(
+            "Adjusted for %.1fGB free mem -> batch_size=%d num_neighbors=%d",
+            mem_gb,
+            args.batch_size,
+            args.num_neighbors,
+        )
+
+
 def main(argv: list[str] | None = None) -> None:
     args = build_parser().parse_args(argv)
+    device = torch.device(args.device)
+    _auto_adjust_params(args, device)
     try:
         args.func(args)  # type: ignore[misc]
     except Exception:  # pragma: no cover - pass through for visibility


### PR DESCRIPTION
## Summary
- check available memory before training explainer
- automatically reduce `batch_size` and `num_neighbors` if memory is low
- log the new parameters for visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a22988d60832ea7dd7d9d3db6900c