### PR TITLE
Reuse sainth_loader

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -256,6 +256,18 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     param_dtype = next(model.parameters()).dtype
     _cast_graph_dtype(graph, param_dtype)
 
+    sainth_loader = None
+    if args.saint:
+        from src.graphs.builders.graph_sampler import sainth_loader_hetero
+        sainth_loader = sainth_loader_hetero(
+            graph,
+            mode=args.saint,
+            batch_size=args.batch_size,
+            walk_length=args.walk_length,
+            sample_coverage=args.sample_coverage,
+            num_steps=args.num_steps,
+        )
+
     score_cache: dict[str, float] = {}
     if args.score_cache and args.score_cache.is_file():
         try:
@@ -341,19 +353,10 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                     n += 1
                 full_score = pred_sum / n
             elif args.saint:
-                from src.graphs.builders.graph_sampler import sainth_loader_hetero
-                loader = sainth_loader_hetero(
-                    graph,
-                    mode=args.saint,
-                    batch_size=args.batch_size,
-                    walk_length=args.walk_length,
-                    sample_coverage=args.sample_coverage,
-                    num_steps=args.num_steps,
-                )
                 pred_sum = torch.tensor(0.0)
                 n = 0
                 ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
-                for part in loader:
+                for part in sainth_loader:
                     part = part.to(device)
                     _cast_graph_dtype(part, param_dtype)
                     with ctx():
@@ -430,16 +433,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
             shuffle=True,
         )
     elif args.saint:
-        from src.graphs.builders.graph_sampler import sainth_loader_hetero
-
-        loader = sainth_loader_hetero(
-            graph,
-            mode=args.saint,
-            batch_size=args.batch_size,
-            walk_length=args.walk_length,
-            sample_coverage=args.sample_coverage,
-            num_steps=args.num_steps,
-        )
+        loader = sainth_loader
     else:
         neigh_args = {et: [args.num_neighbors] * args.num_hops for et in graph.edge_types}
         loader = NeighborLoader(
@@ -479,6 +473,8 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
     # release loader resources explicitly
     del loader
+    if sainth_loader is not None:
+        del sainth_loader
     gc.collect()
 
     pred_info = None


### PR DESCRIPTION
## Summary
- reuse GraphSAINT loader across full-score and training loops
- clear loader resources at exit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a35911964832eb97b366c40faf175