### PR TITLE
Support float16 graph features with AMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ python -m cli.explainer_train single cfg.pt \
        --output models/selector.pt \
        --epochs 500 \
        --amp \
+       # halves feature precision when enabled
        --full-mini-batch \
        [--no-embeds]
 
@@ -250,6 +251,7 @@ python -m cli.explainer_train batch \
         --output-dir models/explainers \
         --model models/gnn/res_gcl.pt \
         --amp \
+        # halves feature precision when enabled
         --full-cpu \
         [--no-embeds]
 # 특징 추출만 별도로 실행할 경우

--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -141,7 +141,12 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument("--threshold", type=float, default=0.5, help="Positive class threshold")
     p.add_argument("--outfile", type=Path, default=Path("predictions.csv"))
     p.add_argument("--explain", action="store_true", help="Dump per‑sample JSON stub for XAI")
-    p.add_argument("--amp", action="store_true", default=False, help="Enable mixed‑precision (CUDA)")
+    p.add_argument(
+        "--amp",
+        action="store_true",
+        default=False,
+        help="Enable mixed‑precision (CUDA) and halve feature precision",
+    )
     return p
 
 

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -81,7 +81,11 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--num-steps", type=int, default=1, help="GraphSAINT steps per epoch")
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
         pp.add_argument("--score-cache", type=Path, help="JSON file with precomputed full scores")
-        pp.add_argument("--amp", action="store_true", help="Enable mixed precision (CUDA)")
+        pp.add_argument(
+            "--amp",
+            action="store_true",
+            help="Enable mixed precision (CUDA) and halve feature precision",
+        )
         pp.add_argument("--full-cpu", action="store_true", help="Compute full graph score on CPU")
         pp.add_argument(
             "--full-mini-batch",
@@ -253,7 +257,11 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         graph[nt].batch = torch.zeros(graph[nt].num_nodes, dtype=torch.long)
 
     _reinit_input_proj(graph, model, device)
-    param_dtype = next(model.parameters()).dtype
+    param_dtype = (
+        torch.float16
+        if args.amp and device.type == "cuda"
+        else next(model.parameters()).dtype
+    )
     _cast_graph_dtype(graph, param_dtype)
 
     score_cache: dict[str, float] = {}

--- a/src/explain/cfg_explainer/__init__.py
+++ b/src/explain/cfg_explainer/__init__.py
@@ -95,7 +95,8 @@ def train_selector(
         assuming ``Data`` inputs with ``x`` and ``edge_index`` or ``HeteroData``
         inputs for heterogeneous graphs.
     amp : bool, default=False
-        Enable mixed precision (CUDA) via ``torch.cuda.amp.autocast``.
+        Enable mixed precision (CUDA) via ``torch.cuda.amp.autocast`` and
+        halve feature precision.
 
     Returns
     -------

--- a/src/explain/train_selector.py
+++ b/src/explain/train_selector.py
@@ -26,7 +26,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--num-neighbors", type=int, default=15, help="Neighbors to sample per hop")
     p.add_argument("--num-hops", type=int, default=2, help="K-hop neighborhood")
     p.add_argument("--view", type=str, default="cfg", help="Edge relation view")
-    p.add_argument("--amp", action="store_true", help="Enable mixed precision (CUDA)")
+    p.add_argument(
+        "--amp",
+        action="store_true",
+        help="Enable mixed precision (CUDA) and halve feature precision",
+    )
     return p
 
 def select_cfg_graph(dataset, model, selector_type) -> HeteroData:


### PR DESCRIPTION
## Summary
- cast graph inputs to half precision when AMP is enabled
- document AMP flag casts features to float16
- clarify CLI help messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a35be61d8832e9cda871483abea15