### PR TITLE
Add no-full-score option to explainer training

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ python -m cli.explainer_train single cfg.pt \
        --amp \
        # halves feature precision when enabled
        --full-mini-batch \
-       [--no-embeds]
+       [--no-embeds] [--no-full-score]
 
 # AST 뷰 그래프 학습 예시
 python -m cli.explainer_train single cfg.pt \
@@ -253,7 +253,7 @@ python -m cli.explainer_train batch \
         --amp \
         # halves feature precision when enabled
         --full-cpu \
-        [--no-embeds]
+        [--no-embeds] [--no-full-score]
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \
@@ -264,6 +264,8 @@ python -m cli.explainer_train feature-mine \
 # `--full-cpu` 또는 `--full-mini-batch` 옵션을 활용해 전체 점수 계산을 조절할 수 있습니다.
 # `--cluster-parts`와 `--cluster-batch-size` 옵션을 사용하면 ClusterLoader로 그래프를 분할해 처리할 수 있습니다.
 # `--saint {node,edge}` 옵션을 사용하면 GraphSAINT 샘플러로 서브그래프 단위 학습이 가능해 GPU 메모리를 절약할 수 있습니다.
+# 캐시된 점수만 사용할 경우 `--no-full-score` 옵션을 지정합니다.
+# 필요한 점수는 `scripts/precompute_scores.py` 스크립트로 미리 계산할 수 있습니다.
 # 평가
 # 기존의 `temp_explainer_runner.py` 스크립트는 더 이상 제공되지 않습니다.
 # 위의 `feature-mine` 하위 명령을 사용해 동일한 기능을 수행할 수 있습니다.

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -82,6 +82,11 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--plot-path", type=Path, help="Where to save training curve (.png)")
         pp.add_argument("--score-cache", type=Path, help="JSON file with precomputed full scores")
         pp.add_argument(
+            "--no-full-score",
+            action="store_true",
+            help="Skip full score computation when cache is missing",
+        )
+        pp.add_argument(
             "--amp",
             action="store_true",
             help="Enable mixed precision (CUDA) and halve feature precision",
@@ -284,6 +289,10 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         except Exception as e:  # pragma: no cover - best effort
             LOGGER.warning("Failed to load score cache %s: %s", args.score_cache, e)
 
+    skip_full = args.no_full_score and not (
+        args.score_cache and sha and sha in score_cache
+    )
+
     if args.amp and device.type == "cuda":
         def score_fn(g):
             with torch.cuda.amp.autocast():
@@ -306,7 +315,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     full_score: torch.Tensor | None = None
     if args.score_cache and sha and sha in score_cache:
         full_score = torch.tensor(score_cache[sha], device=device)
-    else:
+    elif not skip_full:
         with torch.no_grad():
             if args.full_cpu:
                 model_cpu = model.to("cpu") if device.type == "cuda" else model
@@ -372,12 +381,27 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
                     n += 1
                 full_score = pred_sum / n
             else:
+                num_neigh = {et: [3] * args.num_hops for et in graph.edge_types}
+                loader = NeighborLoader(
+                    graph,
+                    input_nodes=(
+                        model.encoder.target_node,
+                        torch.arange(graph[model.encoder.target_node].num_nodes),
+                    ),
+                    batch_size=256,
+                    num_neighbors=num_neigh,
+                    shuffle=False,
+                )
+                pred_sum = torch.tensor(0.0)
+                n = 0
                 ctx = torch.cuda.amp.autocast if (device.type == "cuda" and args.amp) else nullcontext
-                g_dev = graph.to(device)
-                _cast_graph_dtype(g_dev, param_dtype)
-                with ctx():
-                    full_score = model(g_dev, return_logits=True, checkpoint_layers=args.checkpoint).squeeze()
-                del g_dev
+                for batch in loader:
+                    batch = batch.to(device)
+                    _cast_graph_dtype(batch, param_dtype)
+                    with ctx():
+                        pred_sum += model(batch, return_logits=True, checkpoint_layers=args.checkpoint).squeeze().cpu()
+                    n += 1
+                full_score = pred_sum / n
 
         if args.score_cache and sha:
             score_cache[sha] = float(full_score.detach().cpu().item())

--- a/tests/test_score_cache.py
+++ b/tests/test_score_cache.py
@@ -62,6 +62,7 @@ def make_args(cache_path):
         beta=0.0,
         plot_path=None,
         score_cache=cache_path,
+        no_full_score=False,
     )
 
 
@@ -82,3 +83,16 @@ def test_score_cache(tmp_path):
     _train_selector_for_graph(g, model, args, device)
     # second call should skip full score computation
     assert model.calls < first_calls
+
+
+def test_no_full_score_option(tmp_path):
+    cache = tmp_path / "scores.json"
+    g = build_graph()
+    model = DummyModel()
+    args = make_args(cache)
+    args.no_full_score = True
+    device = torch.device("cpu")
+
+    _train_selector_for_graph(g, model, args, device)
+    assert not cache.exists()
+    assert model.calls == 0


### PR DESCRIPTION
## Summary
- support `--no-full-score` flag in explainer CLI
- skip full score computation when cache miss and flag used
- fallback to small NeighborLoader when computing full score
- document workflow for precomputing scores
- test new option behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a36e96604832e9cd357c46714f4e3