### PR TITLE
Add fp16 mode for explainer training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -86,6 +86,11 @@ def build_parser() -> argparse.ArgumentParser:
             action="store_true",
             help="Enable mixed precision (CUDA) and halve feature precision",
         )
+        pp.add_argument(
+            "--fp16",
+            action="store_true",
+            help="Cast features and model parameters to float16",
+        )
         pp.add_argument("--full-cpu", action="store_true", help="Compute full graph score on CPU")
         pp.add_argument(
             "--full-mini-batch",
@@ -149,7 +154,7 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _load_model(path: Path, device: torch.device):
+def _load_model(path: Path, device: torch.device, *, fp16: bool = False):
     model = RESGCLClassifier.load_from_checkpoint(path, map_location=device)
     if hasattr(model, "to"):
         model.to(device)
@@ -159,6 +164,8 @@ def _load_model(path: Path, device: torch.device):
     if hasattr(model, "parameters"):
         for p in model.parameters():
             p.requires_grad_(False)
+    if fp16:
+        model.half()
     return model
 
 
@@ -257,11 +264,13 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         graph[nt].batch = torch.zeros(graph[nt].num_nodes, dtype=torch.long)
 
     _reinit_input_proj(graph, model, device)
-    param_dtype = (
-        torch.float16
-        if args.amp and device.type == "cuda"
-        else next(model.parameters()).dtype
-    )
+    if getattr(args, "fp16", False):
+        param_dtype = torch.float16
+        model.half()
+    else:
+        param_dtype = (
+            torch.float16 if args.amp and device.type == "cuda" else next(model.parameters()).dtype
+        )
     _cast_graph_dtype(graph, param_dtype)
 
     sainth_loader = None
@@ -606,13 +615,13 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
 
 def train_batch(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
-    model = _load_model(args.model, device)
+    model = _load_model(args.model, device, fp16=getattr(args, "fp16", False))
     _train_batch_impl(args, model, device)
 
 
 def train_single(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
-    model = _load_model(args.model, device)
+    model = _load_model(args.model, device, fp16=getattr(args, "fp16", False))
 
     if args.ast or args.cfg or args.fcg or args.syscall:
         sha = args.cfg_graph.stem

--- a/tests/test_explainer_train_no_embeds.py
+++ b/tests/test_explainer_train_no_embeds.py
@@ -42,7 +42,9 @@ def test_explainer_train_batch_no_embeds(tmp_path, monkeypatch):
     mpath.write_text("stub")
 
     dummy_model = DummyModel()
-    monkeypatch.setattr("src.cli.explainer_train._load_model", lambda p, d: dummy_model)
+    monkeypatch.setattr(
+        "src.cli.explainer_train._load_model", lambda p, d, fp16=False: dummy_model
+    )
     monkeypatch.setattr(
         "src.cli.explainer_train._train_selector_for_graph",
         lambda *a, **kw: (DummySelector(), HeteroData(), {"pred": 0, "prob": 0.0}),

--- a/tests/test_score_cache.py
+++ b/tests/test_score_cache.py
@@ -53,6 +53,7 @@ def make_args(cache_path):
         cluster_batch_size=1,
         cluster_train=False,
         amp=False,
+        fp16=False,
         num_neighbors=1,
         num_hops=1,
         batch_size=1,
@@ -82,3 +83,25 @@ def test_score_cache(tmp_path):
     _train_selector_for_graph(g, model, args, device)
     # second call should skip full score computation
     assert model.calls < first_calls
+
+
+class DummyFP16Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.encoder = types.SimpleNamespace(target_node="bb", input_proj={})
+        self.lin = torch.nn.Linear(1, 1)
+
+    def forward(self, *args, **kwargs):
+        return torch.tensor([0.0])
+
+
+def test_fp16_casts_dtype(tmp_path):
+    g = build_graph()
+    model = DummyFP16Model()
+    args = make_args(None)
+    args.fp16 = True
+    device = torch.device("cpu")
+
+    _train_selector_for_graph(g, model, args, device)
+    assert g["bb"].x.dtype == torch.float16
+    assert next(model.parameters()).dtype == torch.float16


### PR DESCRIPTION
## Summary
- add `--fp16` option to CLI parser for explainer training
- support fp16 in `_load_model` and `_train_selector_for_graph`
- pass fp16 flag in train batch/single helpers
- test fp16 graph/model casting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a370c8ea4832eb100f6b8a71cdabb