### PR TITLE
Use int32 for edge IDs in explainer training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -295,7 +295,9 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
     for et in graph.edge_types:
         if "edge_id" not in graph[et]:
             num_e = graph[et].edge_index.size(1)
-            graph[et].edge_id = torch.arange(offset, offset + num_e)
+            graph[et].edge_id = torch.arange(
+                offset, offset + num_e, dtype=torch.int32
+            )
             offset += num_e
 
     selector = GumbelMaskSelector(view=view_name, device=device)


### PR DESCRIPTION
## Summary
- assign edge_id tensors with `dtype=torch.int32`
- check other edge_id usage and note that indexing functions expect long tensors

## Testing
- `pytest -q` *(fails: tests require missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a37022534832ea75fb8dd565849df