### PR TITLE
Add float16 option to explainer training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -91,6 +91,11 @@ def build_parser() -> argparse.ArgumentParser:
             action="store_true",
             help="Enable mixed precision (CUDA) and halve feature precision",
         )
+        pp.add_argument(
+            "--fp16",
+            action="store_true",
+            help="Cast graph features and model parameters to float16",
+        )
         pp.add_argument("--full-cpu", action="store_true", help="Compute full graph score on CPU")
         pp.add_argument(
             "--full-mini-batch",
@@ -262,9 +267,11 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
         graph[nt].batch = torch.zeros(graph[nt].num_nodes, dtype=torch.long)
 
     _reinit_input_proj(graph, model, device)
+    if args.fp16:
+        model.half()
     param_dtype = (
         torch.float16
-        if args.amp and device.type == "cuda"
+        if args.fp16 or (args.amp and device.type == "cuda")
         else next(model.parameters()).dtype
     )
     _cast_graph_dtype(graph, param_dtype)

--- a/tests/test_score_cache.py
+++ b/tests/test_score_cache.py
@@ -96,3 +96,35 @@ def test_no_full_score_option(tmp_path):
     _train_selector_for_graph(g, model, args, device)
     assert not cache.exists()
     assert model.calls == 0
+
+
+class ParamModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.encoder = types.SimpleNamespace(target_node="bb", input_proj={})
+        self.w = torch.nn.Parameter(torch.zeros(1, 1))
+
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+    def forward(self, *args, **kwargs):
+        return self.w.sum().unsqueeze(0)
+
+
+def test_fp16_cast(tmp_path):
+    g = build_graph()
+    model = ParamModel()
+    args = make_args(tmp_path / "scores.json")
+    args.fp16 = True
+    device = torch.device("cpu")
+
+    _, out, _ = _train_selector_for_graph(g, model, args, device)
+
+    assert next(model.parameters()).dtype == torch.float16
+    for store in out.node_stores + out.edge_stores:
+        for val in store.values():
+            if torch.is_tensor(val) and torch.is_floating_point(val):
+                assert val.dtype == torch.float16


### PR DESCRIPTION
## Summary
- add `--fp16` option to explainer training CLI
- support half precision casting inside `_train_selector_for_graph`
- test dtype casting behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a38bd6c80832e8df455c764ff1e47