### PR TITLE
Add graph collate helper to detect CLI

### DIFF
--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -39,8 +39,10 @@ from typing import Iterator, Tuple
 import torch
 from torch import nn
 from torch.utils.data import DataLoader
-from torch_geometric.data import HeteroData, InMemoryDataset
+from torch_geometric.data import Batch, HeteroData, InMemoryDataset
 from torch_geometric.loader import DataLoader as GeoDataLoader
+
+from src.graphs.dataset import GraphDataset
 
 # ---------------------------------------------------------------------------
 #  Utilities
@@ -70,6 +72,23 @@ class GraphFileDataset(InMemoryDataset):
         data = load_graph(self.file_paths[idx])
         data.sha256 = self.file_paths[idx].stem  # attach ID for later
         return data
+
+
+def collate_graphs(
+    graphs: list[HeteroData],
+    *,
+    attr_names: dict[str, list[str]] | None = None,
+) -> Batch:
+    """Collate a list of graphs into a :class:`~torch_geometric.data.Batch`."""
+
+    fixed = [GraphDataset._ensure_num_nodes(g) for g in graphs]
+    fixed = [GraphDataset._ensure_x(g) for g in fixed]
+    if attr_names is not None:
+        fixed = [GraphDataset._ensure_meta_ids(g, attr_names) for g in fixed]
+
+    batch = Batch.from_data_list(fixed)
+    batch.sha256 = [g.sha256 for g in graphs]
+    return batch
 
 
 # ---------------------------------------------------------------------------
@@ -159,11 +178,18 @@ def main(argv: list[str] | None = None) -> None:
         print(f"[ERR] No *.pt graphs found under {args.graph_dir}", file=sys.stderr)
         sys.exit(1)
 
-    ds = GraphFileDataset(graph_files)
-    loader: DataLoader = GeoDataLoader(ds, batch_size=args.batch_size, shuffle=False,
-                                       num_workers=args.num_workers, pin_memory=device.type == "cuda")
-
     model = load_model(args.ckpt, device)
+    attr_names = getattr(getattr(model, "encoder", None), "attr_names", None)
+
+    ds = GraphFileDataset(graph_files)
+    loader: DataLoader = GeoDataLoader(
+        ds,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+        collate_fn=lambda batch: collate_graphs(batch, attr_names=attr_names),
+    )
 
     # ------------------------------------------------------------------
     # Inference loop


### PR DESCRIPTION
## Summary
- ensure graphs loaded in the detect CLI have `num_nodes`, `x`, and metadata
- batch graphs with a custom `collate_graphs` that also stores sha256 IDs
- construct dataloader using this collate function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a41b68eb0832eb468e049474e7140