### PR TITLE
Ensure meta IDs for graphs before inference

### DIFF
--- a/scripts/precompute_scores.py
+++ b/scripts/precompute_scores.py
@@ -42,6 +42,7 @@ def main(argv: list[str] | None = None) -> None:
     scores: dict[str, float] = {}
     for gp in args.graphs:
         g = load_graph(gp)
+        g = GraphDataset._ensure_meta_ids(g, model.encoder.attr_names)
         sha = getattr(g, "sha256", gp.stem)
         scores[sha] = compute_score(model, g, device)
 

--- a/src/cli/explain_refine.py
+++ b/src/cli/explain_refine.py
@@ -22,7 +22,7 @@ from src.models.gnn.res_wrapper import RESGCLClassifier
 LOGGER = get_logger(__name__)
 
 
-def _load_graph(path: Path, view: str) -> HeteroData:
+def _load_graph(path: Path, view: str, attr_names: dict[str, list[str]]) -> HeteroData:
     if path.suffix in {".pt", ".pkl", ".pyg.pkl"}:
         g = torch.load(path, weights_only=False)
     else:
@@ -33,6 +33,7 @@ def _load_graph(path: Path, view: str) -> HeteroData:
         g = builder.build()
     g = GraphDataset._ensure_num_nodes(g)
     g = GraphDataset._ensure_x(g)
+    g = GraphDataset._ensure_meta_ids(g, attr_names)
     for nt in g.node_types:
         g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
     return g
@@ -59,7 +60,11 @@ def main(argv: list[str] | None = None) -> None:
     selector = torch.load(args.selector, map_location="cpu")
     LOGGER.info("Selector loaded: %s", args.selector)
 
-    graph = _load_graph(args.graph, args.view)
+    device = torch.device(args.device)
+    model = RESGCLClassifier.load_from_checkpoint(args.model, map_location=device)
+    model.to(device).eval()
+
+    graph = _load_graph(args.graph, args.view, model.encoder.attr_names)
     LOGGER.info("Graph loaded: %s", args.graph)
 
     ensure_edgeaware_selector(selector, graph)
@@ -75,9 +80,6 @@ def main(argv: list[str] | None = None) -> None:
         torch.save(pruned, args.save_path)
         LOGGER.info("Pruned graph saved → %s", args.save_path)
 
-    device = torch.device(args.device)
-    model = RESGCLClassifier.load_from_checkpoint(args.model, map_location=device)
-    model.to(device).eval()
     with torch.no_grad():
         prob = model(pruned.to(device)).sigmoid().item()
     print(f"probability={prob:.6f}")

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -262,6 +262,7 @@ def _train_selector_for_graph(graph: HeteroData | str, model, args, device: torc
 
     graph = GraphDataset._ensure_num_nodes(graph)
     graph = GraphDataset._ensure_x(graph)
+    graph = GraphDataset._ensure_meta_ids(graph, model.encoder.attr_names)
     graph = filter_view(graph, view_name)
     for nt in graph.node_types:
         graph[nt].batch = torch.zeros(graph[nt].num_nodes, dtype=torch.long)

--- a/src/explain/train_selector.py
+++ b/src/explain/train_selector.py
@@ -118,6 +118,7 @@ def main():
 
     graph = GraphDataset._ensure_num_nodes(graph)
     graph = GraphDataset._ensure_x(graph)
+    graph = GraphDataset._ensure_meta_ids(graph, model.encoder.attr_names)
     for nt in graph.node_types:
         graph[nt].batch = torch.zeros(graph[nt].num_nodes, dtype=torch.long)
 


### PR DESCRIPTION
## Summary
- maintain meta id attributes when loading graphs for explainers and score computations
- update refine CLI to load the model earlier so meta IDs can be added

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a42f8cb28832ebd9f4a64dfe1bbb2