### PR TITLE
Use HeteroData methods in SAINT sampler

### DIFF
--- a/src/graphs/builders/graph_sampler.py
+++ b/src/graphs/builders/graph_sampler.py
@@ -214,15 +214,15 @@ def sainth_loader_hetero(
     The heterogeneous graph is converted to a homogeneous view for sampling and
     then reconstructed on the fly for each mini-batch.
     """
-    from torch_geometric.utils.convert import to_homogeneous, to_heterogeneous
+
 
     _log_memory("sainth_loader_hetero: Start")
     
     logging.info("Converting HeteroData to homogeneous graph...")
     _log_memory("sainth_loader_hetero: Before to_homogeneous")
-    homo, node_type, edge_type = to_homogeneous(
-        g, add_node_type=True, add_edge_type=True
-    )
+    homo = g.to_homogeneous(add_node_type=True, add_edge_type=True)
+    node_type = homo.node_type
+    edge_type = homo.edge_type
     _log_memory("sainth_loader_hetero: After to_homogeneous")
     logging.info("Homogeneous graph created.")
 
@@ -244,7 +244,7 @@ def sainth_loader_hetero(
 
     for i, sub in enumerate(loader):
         _log_memory(f"sainth_loader_hetero: Start of iteration {i}")
-        yield to_heterogeneous(sub, node_type=node_type, edge_type=edge_type)
+        yield sub.to_heterogeneous(node_type=node_type, edge_type=edge_type)
         _log_memory(f"sainth_loader_hetero: End of iteration {i}")
 
 


### PR DESCRIPTION
## Summary
- remove unused convert import
- use `HeteroData.to_homogeneous()` and `Data.to_heterogeneous()` in SAINT loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b85351f1c832e892f70611b1f2a5e