### PR TITLE
Fix GraphSAINT heterogeneous loader

### DIFF
--- a/src/graphs/builders/graph_sampler.py
+++ b/src/graphs/builders/graph_sampler.py
@@ -226,8 +226,6 @@ def sainth_loader_hetero(
     logging.info("Converting HeteroData to homogeneous graph...")
     _log_memory("sainth_loader_hetero: Before to_homogeneous")
     homo = g.to_homogeneous(add_node_type=True, add_edge_type=True)
-    node_type = homo.node_type
-    edge_type = homo.edge_type
     _log_memory("sainth_loader_hetero: After to_homogeneous")
     logging.info("Homogeneous graph created.")
 
@@ -249,7 +247,7 @@ def sainth_loader_hetero(
 
     for i, sub in enumerate(loader):
         _log_memory(f"sainth_loader_hetero: Start of iteration {i}")
-        yield sub.to_heterogeneous(node_type=node_type)
+        yield sub.to_heterogeneous()
         _log_memory(f"sainth_loader_hetero: End of iteration {i}")
 
 


### PR DESCRIPTION
## Summary
- ensure GraphSAINT subgraphs are converted back to hetero graphs using the subgraph's own node/edge mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb68c523c832e86d19e6d7ef49b11