### PR TITLE
Fix GraphSAINT hetero metadata usage

### DIFF
--- a/src/graphs/builders/graph_sampler.py
+++ b/src/graphs/builders/graph_sampler.py
@@ -247,7 +247,12 @@ def sainth_loader_hetero(
 
     for i, sub in enumerate(loader):
         _log_memory(f"sainth_loader_hetero: Start of iteration {i}")
-        yield sub.to_heterogeneous()
+        yield sub.to_heterogeneous(
+            node_type=sub.node_type,
+            edge_type=sub.edge_type,
+            node_type_names=list(g.node_types),
+            edge_type_names=list(g.edge_types),
+        )
         _log_memory(f"sainth_loader_hetero: End of iteration {i}")
 
 

--- a/tests/test_sainth_loader.py
+++ b/tests/test_sainth_loader.py
@@ -24,3 +24,5 @@ def test_sainth_loader_hetero_yields_graphs():
     sub = next(iter(loader))
     assert isinstance(sub, HeteroData)
     assert sub.num_nodes > 0
+    assert sub.node_types == g.node_types
+    assert sub.edge_types == g.edge_types


### PR DESCRIPTION
## Summary
- ensure `sainth_loader_hetero` preserves node and edge type names
- verify sampler output retains graph metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbb850aa0832ea3adf43545cd52da