### PR TITLE
Add reverse token child edges in CFGNormalizer

### DIFF
--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -115,6 +115,19 @@ class CFGNormalizer(NormalizerBase):
                 dtype=torch.long,
             )
 
+            # Create reverse edges: token -> bb
+            rev_edges = [[dst, src] for [src, dst] in child_edges]
+            rev_rel_key = (NodeType.TOKEN.value, EdgeRel.CHILD.value, NodeType.BB.value)
+            rev_edge_store = new_g[rev_rel_key]
+            rev_edge_store.edge_index = (
+                torch.tensor(rev_edges, dtype=torch.long).t().contiguous()
+            )
+            rev_edge_store.edge_type = torch.full(
+                (rev_edge_store.edge_index.size(1),),
+                EDGE_REL_ID[EdgeRel.CHILD.value],
+                dtype=torch.long,
+            )
+
         # ────────────────────────────────────────────────────────────
         # 4) 그래프-레벨 메타
         # ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make CFG normalizer also create token->bb child edges

## Testing
- `pytest -k normalizer -q`

------
https://chatgpt.com/codex/tasks/task_e_686bef3add2c832ea3237bb34f38118b