### PR TITLE
Handle missing addr/inst_cnt

### DIFF
--- a/src/graphs/normalizers/ast_norm.py
+++ b/src/graphs/normalizers/ast_norm.py
@@ -47,7 +47,10 @@ class ASTNormalizer(NormalizerBase):
         tok_store.num_nodes = n  # set first to avoid PyG warnings
 
         tok_store.tok_id = g.kind_id.clone()
-        tok_store.addr = torch.zeros(n, dtype=torch.long)
+        # address 정보가 제공되는 경우에만 보존
+        addr = getattr(g, "addr", None)
+        if addr is not None:
+            tok_store.addr = torch.as_tensor(addr).clone()
 
         # 위치(pos) : 0 … N-1
         tok_store.pos = torch.arange(n, dtype=torch.long)

--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -63,10 +63,11 @@ class CFGNormalizer(NormalizerBase):
 
         if hasattr(g, "addr"):
             bb_store.addr = [g.addr[i] for i in bb_idx]
-        if hasattr(g, "inst_cnt"):
-            bb_store.inst_cnt = torch.as_tensor(g.inst_cnt)[bb_idx]
+        inst_cnt = getattr(g, "inst_cnt", None)
+        if inst_cnt is not None:
+            bb_store.inst_cnt = torch.as_tensor(inst_cnt)[bb_idx]
         else:
-            bb_store.inst_cnt = torch.zeros(n_nodes, dtype=torch.long)
+            bb_store.inst_cnt = torch.full((n_nodes,), -1, dtype=torch.long)
 
         # ────────────────────────────────────────────────────────────
         # 2) 토큰 노드 (선택)


### PR DESCRIPTION
## Summary
- only store AST token addresses when provided
- fill missing CFG inst_cnt with -1

## Testing
- `pytest tests/test_normalizer.py -q`
- `pytest tests/test_hetero_builder.py -k builder_num_nodes_inferred -q`
- `pytest tests/test_hetero_builder.py tests/test_normalizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686befee7590832e8f2140656335440c