### PR TITLE
Support string nodes in CFG normalizer

### DIFF
--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -46,9 +46,11 @@ class CFGNormalizer(NormalizerBase):
 
         bb_idx = [i for i, k in enumerate(kinds) if k == "bb"] if kinds else list(range(g.num_nodes))
         tok_idx = [i for i, k in enumerate(kinds) if k == "token"] if kinds else []
+        str_idx = [i for i, k in enumerate(kinds) if k == "string"] if kinds else []
 
         bb_map = {old: i for i, old in enumerate(bb_idx)}
         tok_map = {old: i for i, old in enumerate(tok_idx)}
+        str_map = {old: i for i, old in enumerate(str_idx)}
 
         # ────────────────────────────────────────────────────────────
         # 1) 노드 - BasicBlock
@@ -79,18 +81,31 @@ class CFGNormalizer(NormalizerBase):
                 tok_store.text = [texts[i] for i in tok_idx]
 
         # ────────────────────────────────────────────────────────────
-        # 3) 엣지 – ('bb', 'cfg', 'bb') + ('bb','child','token')
+        # 3) 문자열 노드 (선택)
+        # ────────────────────────────────────────────────────────────
+        if str_idx:
+            str_store = new_g[NodeType.STRING.value]
+            str_store.num_nodes = len(str_idx)
+            if texts:
+                slen = [len(texts[i]) if texts[i] is not None else 0 for i in str_idx]
+                str_store.slen = torch.tensor(slen, dtype=torch.long)
+
+        # ────────────────────────────────────────────────────────────
+        # 4) 엣지 – ('bb', 'cfg', 'bb') + ('bb','child','token') + ('bb','ref','string')
         # ────────────────────────────────────────────────────────────
         rel_key = (NodeType.BB.value, EdgeRel.CFG.value, NodeType.BB.value)
         edge_store = new_g[rel_key]
 
         cfg_edges = []
         child_edges = []
+        ref_edges = []
         for src, dst in g.edge_index.t().tolist():
             if src in bb_map and dst in bb_map:
                 cfg_edges.append([bb_map[src], bb_map[dst]])
             elif src in bb_map and dst in tok_map:
                 child_edges.append([bb_map[src], tok_map[dst]])
+            elif src in bb_map and dst in str_map:
+                ref_edges.append([bb_map[src], str_map[dst]])
 
         if cfg_edges:
             edge_store.edge_index = torch.tensor(cfg_edges, dtype=torch.long).t().contiguous()
@@ -129,8 +144,24 @@ class CFGNormalizer(NormalizerBase):
                 dtype=torch.long,
             )
 
+        if ref_edges:
+            ref_rel_key = (
+                NodeType.BB.value,
+                EdgeRel.REF.value,
+                NodeType.STRING.value,
+            )
+            ref_edge_store = new_g[ref_rel_key]
+            ref_edge_store.edge_index = (
+                torch.tensor(ref_edges, dtype=torch.long).t().contiguous()
+            )
+            ref_edge_store.edge_type = torch.full(
+                (ref_edge_store.edge_index.size(1),),
+                EDGE_REL_ID[EdgeRel.REF.value],
+                dtype=torch.long,
+            )
+
         # ────────────────────────────────────────────────────────────
-        # 4) 그래프-레벨 메타
+        # 5) 그래프-레벨 메타
         # ────────────────────────────────────────────────────────────
         if hasattr(g, "entry_id") and int(g.entry_id[0]) in bb_map:
             new_g.entry_bb = torch.tensor([bb_map[int(g.entry_id[0])]], dtype=torch.long)


### PR DESCRIPTION
## Summary
- extend CFG normalizer with string node handling
- create `string` node stores with a `slen` attribute
- extract references from basic blocks to string nodes

## Testing
- `pytest -k normalizer -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf0d96ec0832e96aec7273c38d133