### PR TITLE
Fix None kinds handling in CFGNormalizer

### DIFF
--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -42,6 +42,8 @@ class CFGNormalizer(NormalizerBase):
         new_g = HeteroData()
 
         kinds = getattr(g, "kind_str", None)
+        if kinds:
+            kinds = ["bb" if (k is None or k == "") else k for k in kinds]
         texts = getattr(g, "text", None)
 
         bb_idx = [i for i, k in enumerate(kinds) if k == "bb"] if kinds else list(range(g.num_nodes))


### PR DESCRIPTION
## Summary
- guard against empty or missing kind strings in CFGNormalizer

## Testing
- `pytest -k normalizer -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf1e0f424832e97b2e87eeda371b9