### PR TITLE
Add bidirectional edge mapping in AST loader

### DIFF
--- a/src/graphs/loaders/ast_loader.py
+++ b/src/graphs/loaders/ast_loader.py
@@ -94,8 +94,11 @@ class ASTLoader(GraphLoaderBase):
         # ---- edge_index ---------------------------------------- #
         raw_edges = js.get("edges", [])
         if raw_edges:
+            mapped = []
             try:
-                mapped = [[id2idx[src], id2idx[tgt]] for src, tgt in raw_edges]
+                for src, tgt in raw_edges:
+                    mapped.append([id2idx[src], id2idx[tgt]])
+                    mapped.append([id2idx[tgt], id2idx[src]])
             except KeyError as e:
                 raise ValueError(f"edge references unknown node id: {e}") from None
             edge_index = torch.tensor(mapped, dtype=torch.long).t().contiguous()


### PR DESCRIPTION
## Summary
- update AST edge mapping to store edges in both directions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf63c36c8832e8d5e59fa1f3cd7bc