### PR TITLE
Handle text property in AST normalizer

### DIFF
--- a/src/graphs/normalizers/ast_norm.py
+++ b/src/graphs/normalizers/ast_norm.py
@@ -46,6 +46,9 @@ class ASTNormalizer(NormalizerBase):
         tok_store = new_g[NodeType.TOKEN.value]
         tok_store.num_nodes = n  # set first to avoid PyG warnings
 
+        if hasattr(g, "text"):
+            tok_store.text = list(g.text)
+
         tok_store.tok_id = g.kind_id.clone()
         # address 정보가 제공되는 경우에만 보존
         addr = getattr(g, "addr", None)

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -6,6 +6,8 @@ pytest.importorskip("torch_geometric")
 
 import torch
 from torch_geometric.data import Data
+import json
+from src.graphs.loaders.ast_loader import ASTLoader
 
 from src.graphs.normalizers.ast_norm import ASTNormalizer
 from src.graphs.normalizers.fcg_norm import FCGNormalizer
@@ -54,3 +56,23 @@ def test_syscall_normalizer_num_nodes():
     out = SysCallNormalizer().normalize(g)
     sc_store = out[NodeType.SYSCALL.value]
     assert sc_store.num_nodes == 3
+
+
+def test_ast_loader_normalizer_token_texts(tmp_path):
+    sample = {
+        "nodes": [
+            {"id": 0, "kind": "file"},
+            {"id": 1, "kind": "token", "text": "foo"},
+        ],
+        "edges": [[0, 1]],
+    }
+    path = tmp_path / "ast.json"
+    path.write_text(json.dumps(sample))
+
+    loader = ASTLoader()
+    data = loader._parse(path)
+    g_norm = ASTNormalizer().normalize(data)
+
+    tok_store = g_norm[NodeType.TOKEN.value]
+    assert hasattr(tok_store, "text")
+    assert len(tok_store.text) == tok_store.num_nodes


### PR DESCRIPTION
## Summary
- copy raw `text` attribute from AST loader output when normalizing
- add regression test ensuring `tok_store.text` is preserved via `ASTLoader` + `ASTNormalizer`

## Testing
- `pytest tests/test_normalizer.py tests/test_hetero_builder.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686bfedb1c30832eb722f8fde02cfa2d