### PR TITLE
Add reverse child edges for FCG normalizer

### DIFF
--- a/src/graphs/normalizers/fcg_norm.py
+++ b/src/graphs/normalizers/fcg_norm.py
@@ -120,6 +120,23 @@ class FCGNormalizer(NormalizerBase):
                 dtype=torch.long,
             )
 
+            # reverse edges: token -> function
+            rev_edges = [[dst, src] for src, dst in child_edges]
+            rel_key_rev = (
+                NodeType.TOKEN.value,
+                EdgeRel.CHILD.value,
+                NodeType.FUNCTION.value,
+            )
+            rev_edge_store = new_g[rel_key_rev]
+            rev_edge_store.edge_index = (
+                torch.tensor(rev_edges, dtype=torch.long).t().contiguous()
+            )
+            rev_edge_store.edge_type = torch.full(
+                (rev_edge_store.edge_index.size(1),),
+                EDGE_REL_ID[EdgeRel.CHILD.value],
+                dtype=torch.long,
+            )
+
         # ──────────────────────────────────────────────────────────
         # 4) 그래프-레벨 메타
         # ──────────────────────────────────────────────────────────

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -12,7 +12,7 @@ from src.graphs.loaders.ast_loader import ASTLoader
 from src.graphs.normalizers.ast_norm import ASTNormalizer
 from src.graphs.normalizers.fcg_norm import FCGNormalizer
 from src.graphs.normalizers.syscall_norm import SysCallNormalizer
-from src.graphs.normalizers.schema import NodeType
+from src.graphs.normalizers.schema import NodeType, EdgeRel
 
 
 def test_fcg_normalizer_name_list():
@@ -31,6 +31,26 @@ def test_fcg_normalizer_name_list():
     fn_store = out[NodeType.FUNCTION.value]
     assert fn_store.name == ["main", "foo", "bar"]
     assert fn_store.num_nodes == 3
+
+
+def test_fcg_normalizer_rev_child_edges():
+    g = Data(
+        kind_str=["function", "function", "token"],
+        edge_index=torch.tensor([[0, 0], [1, 2]], dtype=torch.long),
+        num_nodes=3,
+    )
+
+    out = FCGNormalizer().normalize(g)
+
+    rel_key = (
+        NodeType.TOKEN.value,
+        EdgeRel.CHILD.value,
+        NodeType.FUNCTION.value,
+    )
+
+    assert rel_key in out.edge_types
+    rev_store = out[rel_key]
+    assert rev_store.edge_index.tolist() == [[0], [0]]
 
 
 def test_ast_normalizer_num_nodes():


### PR DESCRIPTION
## Summary
- support reverse ('token','child','function') edges in `FCGNormalizer`
- test for new reverse edge generation

## Testing
- `pytest -k normalizer -q`

------
https://chatgpt.com/codex/tasks/task_e_686c005a1a84832e8af8933a581c1ec2