### PR TITLE
Fix LLM embed text handling and add tests

### DIFF
--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -289,7 +289,7 @@ def embed_corpus(
             input_ids = store["input_ids"]
             attn_mask = store.get("attention_mask")
         else:
-            texts = store.get("kind_str") or store.get("text")
+            texts = store.get("text") or store.get("kind_str")
             if texts is None:
                 skipped += 1
                 continue
@@ -300,10 +300,7 @@ def embed_corpus(
                     texts = list(texts)
                 except TypeError:
                     texts = [texts]
-            texts = [str(t) for t in texts if t is not None]
-            if not texts:
-                skipped += 1
-                continue
+            texts = ["[UNK]" if t is None else str(t) for t in texts]
 
             from transformers import AutoTokenizer
 

--- a/tests/test_embed_stage.py
+++ b/tests/test_embed_stage.py
@@ -123,4 +123,39 @@ def test_embed_corpus_text_coercion(tmp_path, monkeypatch):
     feat2 = load_tensor("two", out_dir)
 
     assert feat1.tolist() == [[5]]
-    assert feat2.tolist() == [[1], [3]]
+    assert feat2.tolist() == [[1], [5], [3]]
+
+
+def test_embed_corpus_text_priority(tmp_path, monkeypatch):
+    hetero_dir = tmp_path / "hetero"
+    hetero_dir.mkdir()
+
+    g = HeteroData()
+    g["token"].text = ["abc"]
+    g["token"].kind_str = ["should_not_use"]
+    g["token"].num_nodes = 1
+    torch.save(g, hetero_dir / "both.pt")
+
+    out_dir = tmp_path / "embeds"
+
+    class DummyTok:
+        def __call__(self, texts, *args, **kwargs):
+            ids = torch.tensor([[len(t)] for t in texts], dtype=torch.long)
+            mask = torch.ones_like(ids)
+            return {"input_ids": ids, "attention_mask": mask}
+
+    class DummyAutoTok:
+        @staticmethod
+        def from_pretrained(name):
+            return DummyTok()
+
+    import src.models.llm_embed as llm_embed
+
+    monkeypatch.setattr(llm_embed, "AutoTokenizer", DummyAutoTok)
+
+    encoder = DummyEncoder()
+    embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+
+    feat = load_tensor("both", out_dir)
+
+    assert feat.tolist() == [[3]]


### PR DESCRIPTION
## Summary
- prioritize `text` over `kind_str` when collecting node texts
- replace `None` texts with `[UNK]` to keep node/embedding counts aligned
- expand tests for embed stage to cover new logic

## Testing
- `pytest -q tests/test_embed_stage.py` *(fails: skipped because torch & others not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c004b512c832ea889e51458816cc9