### PR TITLE
Preserve node order for empty texts in embed_corpus

### DIFF
--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -284,6 +284,7 @@ def embed_corpus(
             continue
 
         store = g["token"]
+        none_idx: list[int] = []
 
         if "input_ids" in store:
             input_ids = store["input_ids"]
@@ -300,7 +301,15 @@ def embed_corpus(
                     texts = list(texts)
                 except TypeError:
                     texts = [texts]
-            texts = ["[UNK]" if t is None else str(t) for t in texts]
+
+            clean_texts = []
+            for idx, t in enumerate(texts):
+                if t is None:
+                    none_idx.append(idx)
+                    clean_texts.append("")
+                else:
+                    clean_texts.append(str(t))
+            texts = clean_texts
 
             from transformers import AutoTokenizer
 
@@ -335,6 +344,8 @@ def embed_corpus(
             embeddings.append(emb)
 
         feat = torch.cat(embeddings, dim=0)
+        if none_idx:
+            feat[none_idx] = 0
         save_tensor(out_name, feat, out_dir, overwrite=overwrite)
         processed += 1
 

--- a/tests/test_embed_stage.py
+++ b/tests/test_embed_stage.py
@@ -123,7 +123,7 @@ def test_embed_corpus_text_coercion(tmp_path, monkeypatch):
     feat2 = load_tensor("two", out_dir)
 
     assert feat1.tolist() == [[5]]
-    assert feat2.tolist() == [[1], [5], [3]]
+    assert feat2.tolist() == [[1], [0], [3]]
 
 
 def test_embed_corpus_text_priority(tmp_path, monkeypatch):
@@ -159,3 +159,37 @@ def test_embed_corpus_text_priority(tmp_path, monkeypatch):
     feat = load_tensor("both", out_dir)
 
     assert feat.tolist() == [[3]]
+
+
+def test_embed_corpus_none_zero(tmp_path, monkeypatch):
+    hetero_dir = tmp_path / "hetero"
+    hetero_dir.mkdir()
+
+    g = HeteroData()
+    g["token"].text = [None, "x", None]
+    g["token"].num_nodes = 3
+    torch.save(g, hetero_dir / "mix.pt")
+
+    out_dir = tmp_path / "embeds"
+
+    class DummyTok:
+        def __call__(self, texts, *args, **kwargs):
+            ids = torch.tensor([[len(t)] for t in texts], dtype=torch.long)
+            mask = torch.ones_like(ids)
+            return {"input_ids": ids, "attention_mask": mask}
+
+    class DummyAutoTok:
+        @staticmethod
+        def from_pretrained(name):
+            return DummyTok()
+
+    import src.models.llm_embed as llm_embed
+
+    monkeypatch.setattr(llm_embed, "AutoTokenizer", DummyAutoTok)
+
+    encoder = DummyEncoder()
+    embed_corpus(encoder, hetero_dir=hetero_dir, out_dir=out_dir)
+
+    feat = load_tensor("mix", out_dir)
+
+    assert feat.tolist() == [[0], [1], [0]]


### PR DESCRIPTION
## Summary
- preserve node order when embedding token nodes by keeping empty strings
- zero out embeddings produced for empty strings
- adapt embed stage tests and add a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c01775820832eb5d9cfa8a979043e