### PR TITLE
Add saliency bonus support to RuleGenEnv

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -89,6 +89,7 @@ class RuleGenEnv(gym.Env):
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         seed: int = 2024,
         hint_features: List[str] | None = None,
+        token_saliency: Dict[str, float] | None = None,
     ):
         """
         Parameters
@@ -102,6 +103,7 @@ class RuleGenEnv(gym.Env):
         device           : 모델/데이터 평가 디바이스
         seed             : reproducibility
         hint_features    : 초기 관측에 포함할 토큰 문자열 시퀀스
+        token_saliency   : 토큰별 중요도 가중치 딕셔너리
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -135,6 +137,9 @@ class RuleGenEnv(gym.Env):
 
         self.vocab_size = len(self.token2id)
         self.max_len = max_len
+
+        # token saliency weights
+        self.token_saliency = token_saliency or {}
 
         # Hint features / tokens
         self.hint_features = hint_features or []
@@ -314,11 +319,19 @@ class RuleGenEnv(gym.Env):
             - 0.05 * rule_len
             + (0.05 if certified_r >= 2 else 0.0)
         )
+
+        used_tokens = self._rule_tokenize(rule_text)
+        if used_tokens:
+            bonus = 0.02 * np.mean([self.token_saliency.get(t, 0.0) for t in used_tokens])
+        else:
+            bonus = 0.0
+        reward += bonus
         metrics = dict(
             f1_clean=f1_clean,
             f1_dummy=f1_dummy,
             rule_len=rule_len,
             certified_r=certified_r,
+            saliency_bonus=bonus,
             reward=reward,
         )
         return reward, metrics


### PR DESCRIPTION
## Summary
- extend `RuleGenEnv` to accept `token_saliency`
- grant reward bonus based on token saliency
- log the saliency bonus metric

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6bcfa130832eafc23dc665715d1b