### PR TITLE
Initialize GRU policy embeddings from classifier

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -245,6 +245,31 @@ class PPORuleAgent:
                 hidden_size=256,
                 use_hint=use_hint,
             ).to(self.device)
+            # --------------------------------------------------------------
+            # Optional: initialise embeddings from classifier encoder
+            enc = getattr(env, "classifier", None)
+            meta = getattr(getattr(enc, "encoder", None), "meta_embed", None)
+            if meta is not None:
+                attr_vocab = getattr(enc.encoder, "attr_vocab", None)
+                if isinstance(attr_vocab, dict):
+                    src_dim = meta.weight.size(1)
+                    dst_dim = self.policy.embed.weight.size(1)
+                    for tok, tid in env.token2id.items():
+                        aid = attr_vocab.get(tok)
+                        if aid is None:
+                            continue
+                        vec = meta.weight[aid].detach()
+                        if src_dim == dst_dim:
+                            new_vec = vec
+                        elif src_dim < dst_dim:
+                            new_vec = torch.zeros(dst_dim, device=vec.device, dtype=vec.dtype)
+                            new_vec[:src_dim] = vec
+                        else:  # src_dim > dst_dim
+                            proj_w = torch.empty(dst_dim, src_dim, device=vec.device, dtype=vec.dtype)
+                            nn.init.xavier_uniform_(proj_w)
+                            new_vec = torch.matmul(proj_w, vec)
+                        with torch.no_grad():
+                            self.policy.embed.weight[tid] = new_vec
         else:
             _LOG.info("Using GPT policy: %s", policy_net)
             self.policy = GPTPolicy(policy_net, env.action_space.n, use_hint).to(self.device)


### PR DESCRIPTION
## Summary
- seed GRU policy embeddings using the classifier encoder when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6bd9ca8c832e9e7f3ce9a65a1bdd