### PR TITLE
Add dynamic node selection and chain token mining

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -69,6 +69,8 @@ class FeatureMiner:
         self,
         *,
         top_k: int = 50,
+        top_k_percent: float | None = None,
+        dynamic_k: bool = False,
         min_saliency: float = 1e-3,
         keep_per_type: int = 20,
     ) -> None:
@@ -76,10 +78,14 @@ class FeatureMiner:
         Args
         ----
         top_k         : 전체 노드 중 saliency 기준으로 상위 k개를 기본 타깃으로 삼는다.
+        top_k_percent : 그래프 노드 수 비율 기반 자동 k 산출 (0~1 사이). 지정 시 ``top_k``보다 우선.
+        dynamic_k     : 노드 saliency 분포(평균+표준편차)에 따라 k를 자동 조정한다.
         min_saliency  : 절대 saliency 임계값 (둘 중 하나라도 통과하면 선택).
         keep_per_type : 노드 타입마다 너무 편중되지 않도록 선정 상한.
         """
         self.top_k = top_k
+        self.top_k_percent = top_k_percent
+        self.dynamic_k = dynamic_k
         self.min_saliency = min_saliency
         self.keep_per_type = keep_per_type
 
@@ -89,13 +95,15 @@ class FeatureMiner:
         self,
         data: HeteroData,
         saliency: torch.Tensor | Dict[str, torch.Tensor],
+        sal_stats: Dict[str, Tuple[float, float]] | None = None,
     ) -> List[str]:
-        return self.mine(data, saliency)
+        return self.mine(data, saliency, sal_stats)
 
     def mine(
         self,
         data: HeteroData,
         saliency: torch.Tensor | Dict[str, torch.Tensor],
+        sal_stats: Dict[str, Tuple[float, float]] | None = None,
     ) -> List[str]:
         """
         핵심 메서드: saliency 벡터와 그래프를 분석해 문자열 패턴 리스트 반환
@@ -108,15 +116,23 @@ class FeatureMiner:
 
         # 1) saliency 상위 노드 선택
         selected_indices = self._select_nodes(flat_sal)
+        selected_set = set(selected_indices.tolist())
+
         # 2) 노드별 메타 추출
         raw_features: List[str] = []
         for global_idx in selected_indices:
             ntype, local_idx = self._map_global_to_local(global_idx, node_offsets)
             meta = data[ntype]
-            raw_features.extend(self._extract_candidates(ntype, local_idx, meta))
+            raw_features.extend(
+                self._extract_candidates(
+                    data, ntype, local_idx, meta, node_offsets, selected_set
+                )
+            )
 
         # 3) 정규화 & dedup 정렬
         cleaned = self._normalize_and_rank(raw_features)
+        if sal_stats is not None:
+            cleaned = self._filter_by_saliency_stats(cleaned, sal_stats)
         _LOG.info("FeatureMiner: mined %d distinct candidates", len(cleaned))
         return cleaned
 
@@ -165,9 +181,21 @@ class FeatureMiner:
         flat_sal = flat_sal.detach().cpu()
         # 조건 1) 절대 threshold
         mask = flat_sal >= self.min_saliency
-        # 조건 2) top‑k
-        if flat_sal.numel() > self.top_k:
-            topk_idx = torch.topk(flat_sal, self.top_k).indices
+
+        k = self.top_k
+        n_nodes = flat_sal.numel()
+        if self.top_k_percent is not None:
+            k = max(int(n_nodes * self.top_k_percent), 1)
+
+        if self.dynamic_k:
+            thresh = float((flat_sal.mean() + flat_sal.std()).item())
+            dyn_mask = flat_sal >= max(thresh, self.min_saliency)
+            if dyn_mask.any():
+                mask |= dyn_mask
+                k = max(k, int(dyn_mask.sum().item()))
+
+        if n_nodes > k:
+            topk_idx = torch.topk(flat_sal, k).indices
             mask[topk_idx] = True
         return mask.nonzero(as_tuple=False).squeeze(1)
 
@@ -184,13 +212,23 @@ class FeatureMiner:
                 return ntype, global_idx - start
         raise IndexError("global_idx out of range")
 
+    def _map_local_to_global(
+        self, ntype: str, local_idx: int, offsets: Dict[str, Tuple[int, int]]
+    ) -> int:
+        """(node_type, local_idx) → global index"""
+        start, _ = offsets[ntype]
+        return start + local_idx
+
     # ───────────────────────────────────────── helpers (extract) ―─
 
     def _extract_candidates(
         self,
+        data: HeteroData,
         ntype: str,
         local_idx: int,
         meta: torch_geometric.data.Data,
+        offsets: Dict[str, Tuple[int, int]],
+        selected_set: set[int] | None = None,
     ) -> List[str]:
         """한 노드에서 YARA·CAPA 후보 문자열을 추출한다.
 
@@ -246,8 +284,10 @@ class FeatureMiner:
 
         # 1) API / 함수명
         name = _get("name") or _get("api")
+        chain_label = None
         if isinstance(name, str) and self._API_RX.fullmatch(name):
             candidates.append(f"call:{name}")
+            chain_label = name
 
         # 2) 문자열 리터럴
         string_val = _get("value") or _get("string")
@@ -278,6 +318,45 @@ class FeatureMiner:
         if isinstance(syscall, str):
             candidates.append(f"syscall:{syscall}")
 
+        # 이웃 노드 동시 선택 시 chain 토큰 생성
+        if selected_set is not None and chain_label is not None:
+            for etype in data.edge_types:
+                src, _, dst = etype
+                if src != ntype:
+                    continue
+                edges = data[etype].edge_index
+                rows = (edges[0] == local_idx).nonzero(as_tuple=False).view(-1)
+                for r in rows.tolist():
+                    nbr_local = int(edges[1, r])
+                    nbr_global = self._map_local_to_global(dst, nbr_local, offsets)
+                    if nbr_global not in selected_set:
+                        continue
+                    nbr_meta = data[dst]
+                    nbr_name = None
+                    for key in ["name", "api"]:
+                        val = nbr_meta.get(key)
+                        if val is None:
+                            continue
+                        if isinstance(val, (list, tuple)) and nbr_local < len(val):
+                            nbr_name = val[nbr_local]
+                        elif torch.is_tensor(val):
+                            try:
+                                arr = val[nbr_local]
+                                if arr.ndim == 0:
+                                    nbr_name = str(arr.item())
+                                else:
+                                    nbr_name = bytes(arr.tolist()).decode(errors="ignore")
+                            except Exception:
+                                continue
+                        else:
+                            try:
+                                nbr_name = val[nbr_local] if hasattr(val, "__getitem__") else val
+                            except Exception:
+                                continue
+                        if isinstance(nbr_name, str) and self._API_RX.fullmatch(nbr_name):
+                            candidates.append(f"chain:{chain_label}→{nbr_name}")
+                        break
+
         return candidates
 
     # ───────────────────────────────────────── helpers (post) ―─
@@ -292,6 +371,21 @@ class FeatureMiner:
         ranked = sorted(cnt.items(), key=lambda kv: (-kv[1], kv[0]))
         # 타입 편중 완화를 위해 같은 prefix 그룹별 한도를 둘 수도 있음 (TODO)
         return [feat for feat, _ in ranked]
+
+    def _filter_by_saliency_stats(
+        self, feats: Sequence[str], stats: Dict[str, Tuple[float, float]]
+    ) -> List[str]:
+        """악성/정상 saliency 통계 기반 필터링"""
+        filtered: List[str] = []
+        for f in feats:
+            val = stats.get(f)
+            if val is None:
+                filtered.append(f)
+                continue
+            mal_score, ben_score = val
+            if mal_score > self.min_saliency and mal_score > ben_score:
+                filtered.append(f)
+        return filtered
 
     # ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- enhance `FeatureMiner` with `top_k_percent` and `dynamic_k`
- generate `chain:` tokens when neighbouring nodes are also selected
- support optional saliency-based filtering of mined tokens

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6bcc7b10832eb840e21039c3fda2