### PR TITLE
Extend selector training options

### DIFF
--- a/src/explain/cfg_explainer/__init__.py
+++ b/src/explain/cfg_explainer/__init__.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Sequence
 
+from torch_geometric.loader import DataLoader
+
 import torch
 from torch_geometric.data import Data, HeteroData
 from pathlib import Path
@@ -57,7 +59,7 @@ __version__: str = "0.1.0"
 #                       High-level convenience wrappers                       #
 # --------------------------------------------------------------------------- #
 def train_selector(
-    cfg_graph: Data,
+    cfg_graph: Data | Sequence[Data] | Sequence[HeteroData],
     model,
     *,
     view: str = "cfg",
@@ -69,6 +71,9 @@ def train_selector(
     plot_path: Path | str | None = None,
     score_fn=None,
     amp: bool = False,
+    selector: GumbelMaskSelector | None = None,
+    batch: bool = False,
+    batch_size: int = 1,
     **selector_kwargs,
 ) -> GumbelMaskSelector:
     """
@@ -76,8 +81,8 @@ def train_selector(
 
     Parameters
     ----------
-    cfg_graph : Data
-        Full CFG graph.
+    cfg_graph : Data | Sequence[Data]
+        Single CFG graph or sequence of graphs.
     model : nn.Module or callable
         Frozen classifier that returns a single logit/score.
     view : str
@@ -88,8 +93,15 @@ def train_selector(
         Hyper-parameters forwarded to `selector.train_loop`.
     plot_path : Path | str | None
         If given, save training curves (fidelity/sparsity/deletion) as PNG.
+    selector
+        Pre-initialized selector. When provided, its ``_init_params``
+        method is invoked for each graph before training instead of
+        creating a new instance.
+    batch, batch_size
+        If ``batch`` is ``True`` a ``DataLoader`` is used with the given
+        ``batch_size`` to train on multiple graphs per step.
     selector_kwargs
-        Extra args → `GumbelMaskSelector` (e.g., init_bias, tau_start …).
+        Extra args → ``GumbelMaskSelector`` (e.g., init_bias, tau_start …).
     score_fn : callable, optional
         Custom graph scoring function. If ``None``, it is built from ``model``
         assuming ``Data`` inputs with ``x`` and ``edge_index`` or ``HeteroData``
@@ -117,19 +129,46 @@ def train_selector(
             with torch.amp.autocast(device_type="cuda"):
                 return base_fn(graph)
 
-    selector = GumbelMaskSelector(view=view, device=device, **selector_kwargs)
-    ensure_edgeaware_selector(selector, cfg_graph)
+    if not isinstance(cfg_graph, Sequence) or isinstance(cfg_graph, (Data, HeteroData)):
+        graphs = [cfg_graph]
+    else:
+        graphs = list(cfg_graph)
+
+    if selector is None:
+        selector = GumbelMaskSelector(view=view, device=device, **selector_kwargs)
     selector.to(device)
-    selector.train_loop(
-        cfg_graph.to(device),
-        score_fn,
-        epochs=epochs,
-        lr=lr,
-        alpha=alpha,
-        beta=beta,
-        show_progress=True,
-        plot_path=plot_path,
-    )
+
+    def train_on_graph(g):
+        ensure_edgeaware_selector(selector, g)
+        selector.train_loop(
+            g.to(device),
+            score_fn,
+            epochs=epochs,
+            lr=lr,
+            alpha=alpha,
+            beta=beta,
+            show_progress=len(graphs) == 1,
+            plot_path=plot_path if len(graphs) == 1 else None,
+        )
+
+    if batch and len(graphs) > 1:
+        loader = DataLoader(graphs, batch_size=batch_size, shuffle=False)
+        for epoch in range(epochs):
+            for batch_graph in loader:
+                ensure_edgeaware_selector(selector, batch_graph)
+                selector.train_loop(
+                    batch_graph.to(device),
+                    score_fn,
+                    epochs=1,
+                    lr=lr,
+                    alpha=alpha,
+                    beta=beta,
+                    show_progress=False,
+                )
+    else:
+        for g in graphs:
+            train_on_graph(g)
+
     return selector
 
 


### PR DESCRIPTION
## Summary
- support providing an existing selector instance to `train_selector`
- allow passing multiple graphs and optional batch training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6d43b294832eb96bab2958b46b4b