### PR TITLE
Update ensure_num_nodes with policies

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -306,7 +306,11 @@ def _ensure_num_nodes_any(g: Data | HeteroData) -> Data | HeteroData:
     return g
 
 
-def ensure_num_nodes(hetero: HeteroData) -> None:
+def ensure_num_nodes(
+    hetero: HeteroData,
+    *,
+    policy: OverLengthPolicy = OverLengthPolicy.TRIM,
+) -> None:
     """Infer and set ``num_nodes`` for every node store in ``hetero``.
 
     Parameters
@@ -315,9 +319,57 @@ def ensure_num_nodes(hetero: HeteroData) -> None:
         Graph whose node stores may lack ``num_nodes`` metadata.  The value is
         guessed from attributes such as ``x``, ``feat``, ``addr`` or
         ``inst_cnt`` with ``edge_index`` used as a fallback.
+    policy : OverLengthPolicy, default ``TRIM``
+        How to handle cases where feature or attribute lengths exceed
+        ``num_nodes``.
     """
-    for _, store in hetero.node_items():
-        store.num_nodes = _guess_num_nodes(store)
+
+    if isinstance(policy, str):
+        policy = OverLengthPolicy[policy]
+
+    for node_type, store in hetero.node_items():
+        current = getattr(store, "num_nodes", None)
+
+        # gather candidate lengths ignoring ``num_nodes``
+        candidates = []
+
+        for attr in ("x", "feat"):
+            val = getattr(store, attr, None)
+            if isinstance(val, torch.Tensor):
+                candidates.append(int(val.size(0)))
+
+        for attr in ("addr", "inst_cnt", "name", "api_name"):
+            val = getattr(store, attr, None)
+            if val is not None:
+                try:
+                    candidates.append(len(val))
+                except TypeError:
+                    if isinstance(val, torch.Tensor):
+                        candidates.append(int(val.size(0)))
+
+        ei = getattr(store, "edge_index", None)
+        if isinstance(ei, torch.Tensor) and ei.numel() > 0:
+            candidates.append(int(ei.max()) + 1)
+
+        guess = max(candidates) if candidates else 0
+
+        if current is None:
+            store.num_nodes = guess
+            continue
+
+        if guess > current:
+            if policy is OverLengthPolicy.ERROR:
+                raise ValueError(
+                    f"{guess} > num_nodes({current}) for node type; policy=ERROR"
+                )
+            if policy is OverLengthPolicy.EXPAND:
+                store.num_nodes = guess
+            elif policy is OverLengthPolicy.MASKPAD:
+                mask = torch.zeros(guess, dtype=torch.bool)
+                mask[:current] = True
+                store.mask = mask
+                store.num_nodes = guess
+
 
 
 def fill_missing_node_feats(

--- a/tests/test_hetero_builder.py
+++ b/tests/test_hetero_builder.py
@@ -86,7 +86,6 @@ def test_ensure_num_nodes_no_warning():
     assert not record
 
 
-@pytest.mark.xfail(reason="policy not implemented")
 def test_num_nodes_error_policy():
     g = HeteroData()
     g["n"].x = torch.randn(2, 1)
@@ -95,7 +94,6 @@ def test_num_nodes_error_policy():
         ensure_num_nodes(g, policy="ERROR")
 
 
-@pytest.mark.xfail(reason="policy not implemented")
 def test_num_nodes_expand_policy():
     g = HeteroData()
     g["n"].x = torch.randn(3, 1)
@@ -104,7 +102,6 @@ def test_num_nodes_expand_policy():
     assert g["n"].num_nodes == 3
 
 
-@pytest.mark.xfail(reason="policy not implemented")
 def test_num_nodes_maskpad_policy():
     g = HeteroData()
     g["n"].x = torch.randn(3, 1)


### PR DESCRIPTION
## Summary
- extend `ensure_num_nodes` with a `policy` argument
- implement `ERROR`, `EXPAND` and `MASKPAD` policies
- remove xfail from tests for these behaviours

## Testing
- `pytest tests/test_hetero_builder.py -k num_nodes --maxfail=1 -vv` *(fails: collected 0 items / 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c6d74f20c832e86cc1ea92d4c5b12