### PR TITLE
Improve checkpoint load failure message in feature mining CLI

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -155,12 +155,15 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
     if args.selector_checkpoint:
         try:
             selector = torch.load(args.selector_checkpoint, map_location="cpu")
-            if hasattr(selector, "eval"):
-                selector.eval()
-            logger.info("Loaded selector from %s", args.selector_checkpoint)
         except FileNotFoundError:
             logger.error("Selector checkpoint not found at %s", args.selector_checkpoint)
             raise SystemExit(1)
+        except Exception as exc:  # e.g. file corrupted or incompatible
+            logger.error("Failed to load selector checkpoint %s: %s", args.selector_checkpoint, exc)
+            raise SystemExit(1)
+        if hasattr(selector, "eval"):
+            selector.eval()
+        logger.info("Loaded selector from %s", args.selector_checkpoint)
 
     # GraphDataset does not support caching; simple on‑demand loading is fine
     dataset = GraphDataset(graph_dir, split='train')


### PR DESCRIPTION
## Summary
- better error handling when loading selector checkpoint in `cmd_feature_mine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7356fd10832ea2d9a70842aec7c4