### PR TITLE
Add global PGExplainer training command

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -54,6 +54,7 @@ from tqdm import tqdm
 from robust_malware_graph.explain import (
     explain_cfg,
     GumbelMaskSelector,
+    PGExplainer,
 )
 from src.explain.cfg_explainer.selector import gumbel_sigmoid
 from src.explain.utils import ensure_edgeaware_selector
@@ -207,6 +208,18 @@ def build_parser() -> argparse.ArgumentParser:
     b.add_argument("--mine-features", type=Path, help="Save mined features as JSON")
     add_common(b)
     b.set_defaults(func=train_batch)
+
+    # --- global PGExplainer ---
+    g = sub.add_parser("global", help="Train PGExplainer on multiple graphs")
+    g.add_argument(
+        "--graph-dir", type=Path, required=True, help="Directory containing *.pt graphs"
+    )
+    g.add_argument("--output", type=Path, required=True, help="Output explainer path")
+    g.add_argument("--view", type=str, default="cfg", help="Graph view relation name")
+    g.add_argument("--tau-decay", type=float, default=0.995, help="Temperature decay")
+    g.add_argument("--tau-min", type=float, default=0.5, help="Minimum temperature")
+    add_common(g)
+    g.set_defaults(func=train_global)
 
     # --- feature mining only ---
     m = sub.add_parser("mine-features", help="Extract discriminative tokens")
@@ -1236,6 +1249,110 @@ def train_single(args: argparse.Namespace) -> None:
                 indent=2,
             )
         LOGGER.info("Saved mined features → %s", args.mine_features)
+
+
+def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tensor]:
+    x_dict: dict[str, torch.Tensor] = {}
+    for nt in graph.node_types:
+        if not hasattr(graph[nt], "x"):
+            continue
+        feats = [graph[nt].x]
+        if getattr(encoder, "meta_embed", None):
+            for name in encoder.attr_names.get(nt, []):
+                attr = getattr(graph[nt], f"{name}_id", None)
+                if attr is not None:
+                    feats.append(encoder.meta_embed(attr))
+        node_feat = torch.cat(feats, dim=-1) if len(feats) > 1 else feats[0]
+        x_dict[nt] = encoder.input_proj[nt](node_feat)
+    for conv in encoder.convs:
+        x_dict = conv(x_dict, graph.edge_index_dict)
+        x_dict = {k: encoder.drop(encoder.act(v)) for k, v in x_dict.items()}
+    return x_dict
+
+
+def _masked_score(graph: HeteroData, mask_prob: torch.Tensor, view: str, model) -> torch.Tensor:
+    ptr = 0
+    original: dict[str, dict[str, torch.Tensor]] = {}
+    for et in iter_edge_types(graph, view):
+        store = graph[et]
+        num_e = store.edge_index.size(1)
+        mask = mask_prob[ptr : ptr + num_e]
+        ptr += num_e
+        keep = mask > 0.5
+        if keep.sum() == 0:
+            if len(mask) > 0:
+                keep[mask.argmax()] = True
+            else:
+                continue
+        backup = {}
+        for k, v in store.items():
+            if torch.is_tensor(v) and v.size(0) == mask.size(0):
+                backup[k] = v
+                store[k] = v[keep]
+        original[str(et)] = backup
+
+    with torch.no_grad():
+        out = model(graph, return_logits=True).squeeze()
+
+    for et_str, backup in original.items():
+        etype = eval(et_str)
+        store = graph[etype]
+        for k, v in backup.items():
+            store[k] = v
+
+    return out
+
+
+def train_global(args: argparse.Namespace) -> None:
+    device = torch.device(args.device)
+    model = _load_model(args, device)
+
+    graph_paths = sorted(Path(args.graph_dir).glob("*.pt"))
+    if not graph_paths:
+        raise ValueError(f"No graphs found in {args.graph_dir}")
+
+    explainer = PGExplainer(
+        model=model,
+        embed_dim=model.encoder.out_dim,
+        view=args.view,
+        device=device,
+    )
+    optim = torch.optim.Adam(explainer.parameters(), lr=args.lr)
+
+    param_dtype = next(model.parameters()).dtype
+    for epoch in range(args.epochs):
+        for gp in graph_paths:
+            g = torch.load(gp, map_location="cpu", weights_only=False)
+            if not isinstance(g, HeteroData):
+                continue
+            sha = getattr(g, "sha256", gp.stem)
+            if not args.no_embeds:
+                _attach_embeddings(g, sha, args.embed_dir)
+            g = GraphDataset._ensure_num_nodes(g)
+            g = GraphDataset._ensure_x(g)
+            g = GraphDataset._ensure_meta_ids(g, model.encoder.attr_names)
+            for nt in g.node_types:
+                g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
+            _reinit_input_proj(g, model, device)
+            _cast_graph_dtype(g, param_dtype)
+            g = g.to(device)
+
+            embeds = _compute_node_embeddings(g, model.encoder)
+            with torch.no_grad():
+                full_score = model(g, return_logits=True).squeeze()
+
+            mask_prob = explainer(g, embeddings=embeds)
+            masked = _masked_score(g, mask_prob, args.view, model)
+            loss = explainer.loss(full_score, masked, mask_prob, alpha=args.alpha, beta=args.beta)
+
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+            explainer.tau.mul_(args.tau_decay).clamp_(min=args.tau_min)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(explainer, args.output)
+    LOGGER.info("Saved explainer → %s", args.output)
 
 
 def mine_features(args: argparse.Namespace) -> None:

--- a/tests/test_explainer_train_global_cli.py
+++ b/tests/test_explainer_train_global_cli.py
@@ -1,0 +1,47 @@
+import importlib
+from pathlib import Path
+import types
+import pytest
+
+pytest.importorskip("torch")
+
+class DummyModel:
+    def __init__(self):
+        self.encoder = types.SimpleNamespace(target_node="bb", input_proj={})
+
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+
+def test_global_cli_invokes(tmp_path, monkeypatch):
+    gdir = tmp_path / "graphs"
+    gdir.mkdir()
+    (gdir / "a.pt").write_text("stub")
+    mpath = tmp_path / "model.pt"
+    mpath.write_text("stub")
+
+    captured = {}
+
+    def fake_train(args):
+        captured["graph_dir"] = args.graph_dir
+        captured["output"] = args.output
+
+    monkeypatch.setattr("src.cli.explainer_train.train_global", fake_train)
+    mod = importlib.import_module("src.cli.explainer_train")
+
+    out = tmp_path / "out.pt"
+    mod.main([
+        "global",
+        "--graph-dir",
+        str(gdir),
+        "--model",
+        str(mpath),
+        "--output",
+        str(out),
+    ])
+
+    assert captured["graph_dir"] == gdir
+    assert captured["output"] == out


### PR DESCRIPTION
## Summary
- add `global` subcommand in `explainer_train` CLI
- implement `train_global` to train a PGExplainer across graphs
- provide basic CLI test for the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7345169c832eaa304789e76c43b1