### PR TITLE
Add pretrained explainer support

### DIFF
--- a/src/explain/cfg_explainer/__init__.py
+++ b/src/explain/cfg_explainer/__init__.py
@@ -30,10 +30,11 @@ from typing import Dict, List, Sequence
 from torch_geometric.loader import DataLoader
 
 import torch
+import torch.nn as nn
 from torch_geometric.data import Data, HeteroData
 from pathlib import Path
 
-from .aggregator import CFGPathAggregator, aggregate_paths
+from .aggregator import CFGPathAggregator, aggregate_paths, iter_edge_types
 from .mapper import CFGASTMapper
 from .ranker import ShapleyNodeRanker, quick_rank
 from .selector import GumbelMaskSelector
@@ -182,6 +183,7 @@ def explain_cfg(
     selector_kwargs: Dict | None = None,
     ranker_kwargs: Dict | None = None,
     top_k: int | None = 20,
+    pretrained_explainer: nn.Module | None = None,
     score_fn=None,
 ) -> Dict[str, object]:
     """
@@ -193,6 +195,13 @@ def explain_cfg(
     2. **Aggregator**: group selected nodes into ordered paths.
     3. **Ranker**    : estimate Shapley importance & rank.
     4. **Mapper**    : convert CFG nodes → AST token indices.
+
+    Parameters
+    ----------
+    pretrained_explainer : nn.Module, optional
+        Pre-trained explainer providing ``get_node_saliency`` or ``hard_selection``.
+        When set, selector training is skipped and this explainer is used
+        to obtain ``sel_nodes`` via thresholding or top-k ranking.
 
     Returns
     -------
@@ -217,18 +226,72 @@ def explain_cfg(
                 g.x.to(device), g.edge_index.to(device)
             ).squeeze()
 
-    # ── 1. Selector
-    selector = train_selector(
-        cfg_graph,
-        model,
-        view=view,
-        device=device,
-        score_fn=score_fn,
-        **selector_kwargs,
-    )
+    # ── 1. Selector / Pretrained Explainer
+    if pretrained_explainer is None:
+        selector = train_selector(
+            cfg_graph,
+            model,
+            view=view,
+            device=device,
+            score_fn=score_fn,
+            **selector_kwargs,
+        )
+    else:
+        selector = pretrained_explainer
+
     ensure_edgeaware_selector(selector, cfg_graph)
     selector.to(device)
-    sel_nodes = selector.hard_selection(cfg_graph).tolist()
+
+    if pretrained_explainer is None:
+        sel_nodes = selector.hard_selection(cfg_graph).tolist()
+    else:
+        if hasattr(selector, "get_node_saliency"):
+            try:
+                mask_prob = selector(cfg_graph)
+                node_sal = selector.get_node_saliency(cfg_graph, mask_prob)
+            except TypeError:
+                node_sal = selector.get_node_saliency(cfg_graph)
+
+            if isinstance(node_sal, dict):
+                scores = []
+                for ntype in getattr(cfg_graph, "node_types", ["node"]):
+                    if ntype in node_sal:
+                        scores.append(node_sal[ntype])
+                    else:
+                        scores.append(torch.zeros(cfg_graph[ntype].num_nodes))
+                node_score = torch.cat(scores)
+            else:
+                node_score = node_sal
+
+            if top_k is not None:
+                sel_nodes = torch.topk(node_score, top_k).indices.tolist()
+            else:
+                sel_nodes = (node_score > 0.5).nonzero(as_tuple=False).view(-1).tolist()
+        elif hasattr(selector, "hard_selection"):
+            hs = selector.hard_selection(cfg_graph)
+            if isinstance(hs, dict):
+                nodes = set()
+                if isinstance(cfg_graph, HeteroData):
+                    for etype, store in iter_edge_types(cfg_graph, view):
+                        idx = hs.get(str(etype))
+                        if idx is None or len(idx) == 0:
+                            continue
+                        idx = torch.as_tensor(idx, dtype=torch.long)
+                        ei = store.edge_index[:, idx]
+                        nodes.update(ei[0].tolist())
+                        nodes.update(ei[1].tolist())
+                else:
+                    idx = torch.as_tensor(hs, dtype=torch.long)
+                    ei = cfg_graph.edge_index[:, idx]
+                    nodes.update(ei[0].tolist())
+                    nodes.update(ei[1].tolist())
+                sel_nodes = sorted(nodes)
+            else:
+                sel_nodes = torch.as_tensor(hs, dtype=torch.long).tolist()
+        else:
+            raise ValueError(
+                "pretrained_explainer must implement get_node_saliency or hard_selection"
+            )
 
     # ── 2. Aggregator
     paths = aggregate_paths(cfg_graph, sel_nodes)


### PR DESCRIPTION
## Summary
- allow `explain_cfg` to accept a pretrained explainer
- skip `train_selector` when an explainer is provided and compute selected nodes from it

## Testing
- `pytest -k explain_cfg_runs -vv`

------
https://chatgpt.com/codex/tasks/task_e_686c751bd5ec832ea56861c18252af3d