### PR TITLE
Add step penalty and token saliency bonus

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -90,6 +90,8 @@ class RuleGenEnv(gym.Env):
         seed: int = 2024,
         hint_features: List[str] | None = None,
         token_saliency: Dict[str, float] | None = None,
+        step_penalty: float = -0.01,
+        per_token_saliency: float = 0.02,
     ):
         """
         Parameters
@@ -104,6 +106,8 @@ class RuleGenEnv(gym.Env):
         seed             : reproducibility
         hint_features    : 초기 관측에 포함할 토큰 문자열 시퀀스
         token_saliency   : 토큰별 중요도 가중치 딕셔너리
+        step_penalty     : 매 스텝 적용할 패널티 (e.g. ``-0.01``)
+        per_token_saliency : 선택한 토큰 saliency 가중치 배율
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -140,6 +144,8 @@ class RuleGenEnv(gym.Env):
 
         # token saliency weights
         self.token_saliency = token_saliency or {}
+        self.step_penalty = step_penalty
+        self.per_token_saliency = per_token_saliency
 
         # Hint features / tokens
         self.hint_features = hint_features or []
@@ -217,6 +223,9 @@ class RuleGenEnv(gym.Env):
 
         # 1) 토큰 append
         self._tokens.append(action)
+        tok_str = self.id2token[action]
+        reward += self.step_penalty
+        reward += self.per_token_saliency * self.token_saliency.get(tok_str, 0.0)
 
         # 2) 종료 조건
         max_tokens = self.observation_space.shape[0]
@@ -224,7 +233,8 @@ class RuleGenEnv(gym.Env):
             done = True
             truncated = len(self._tokens) >= max_tokens
             rule_text = self._tokens_to_rule(self._tokens)
-            reward, metrics = self._compute_reward(rule_text)
+            final_r, metrics = self._compute_reward(rule_text)
+            reward += final_r
             info["metrics"] = metrics
 
         obs = self._pad_obs(self._tokens)


### PR DESCRIPTION
## Summary
- extend `RuleGenEnv.__init__` with `step_penalty` and `per_token_saliency`
- apply per-step penalty and saliency bonus in `step`
- accumulate episode reward with final reward from `_compute_reward`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7e674cdc832ea23755a4e429b1db