### PR TITLE
Refactor GRU policy with packed sequences

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -17,8 +17,8 @@ PPORuleAgent
 
     2. ***시퀀스 관측 처리***
        관측값(obs)은 길이 `max_len`의 토큰 ID 배열.
-       ‑ PAD 토큰을 제외한 임베딩의 **mean pooling**을 상태 표현으로 사용
-       (간단·경량, GPU 메모리 절약).
+       ‑ 전체 시퀀스를 GRU에 통과시켜 마지막 hidden state를
+         상태 표현으로 사용한다.
 
     3. ***정책 네트워크***
        `Embedding` → `LayerNorm` → `GRU`(1 layer, hidden=256) →
@@ -135,34 +135,36 @@ class GRUPolicy(nn.Module):
         x = self.embed(obs)  # (B,L,E)
         x = self.ln(x)
         lengths = mask.sum(dim=1).clamp(min=1)
-        pooled = (x * mask.unsqueeze(-1)).sum(dim=1) / lengths.unsqueeze(-1)
 
         if self.use_hint:
             if self.hint_size is None:
-                # Backward compatible: hint is a sequence of token IDs
                 if hint is None:
-                    hint_vec = torch.zeros_like(pooled)
+                    hint_vec = torch.zeros(x.size(0), x.size(2), device=x.device, dtype=x.dtype)
                 else:
                     hint_vec = self.embed(hint.long()).mean(dim=1)
             else:
                 if hint is None:
                     hint_input = torch.zeros(
-                        (pooled.size(0), self.hint_size),
-                        device=pooled.device,
-                        dtype=pooled.dtype,
+                        (x.size(0), self.hint_size),
+                        device=x.device,
+                        dtype=x.dtype,
                     )
                 else:
                     if hint.ndim == 1:
                         hint_input = hint.unsqueeze(0)
                     else:
                         hint_input = hint
-                    hint_input = hint_input.to(pooled.dtype)
+                    hint_input = hint_input.to(x.dtype)
                 hint_vec = self.hint_proj(hint_input)
 
-            pooled = torch.cat([pooled, hint_vec], dim=1)
+            hint_seq = hint_vec.unsqueeze(1).expand(-1, x.size(1), -1)
+            x = torch.cat([x, hint_seq], dim=2)
 
-        gru_out, _ = self.gru(pooled.unsqueeze(1))
-        h = gru_out[:, -1]  # (B,H)
+        x_packed = nn.utils.rnn.pack_padded_sequence(
+            x, lengths.cpu(), batch_first=True, enforce_sorted=False
+        )
+        _, h_n = self.gru(x_packed)
+        h = h_n[-1]  # (B,H)
         logits = self.pi_head(h)
         value = self.v_head(h).squeeze(-1)
         return logits, value


### PR DESCRIPTION
## Summary
- process entire token sequence with GRU instead of mean pooling
- update policy docs for new GRU usage
- support hints by concatenating per-step vectors

## Testing
- `pytest -k gru_policy_hint -q`
- `pytest tests/test_ppo_train_cli.py::test_ppo_train_checks_dataset -q`


------
https://chatgpt.com/codex/tasks/task_e_686c7f249284832ea3f66a0bf463c462