### PR TITLE
Support hint observations in PPO rule generator

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -335,8 +335,8 @@ class PPORuleAgent:
         -------
         List of ``(step, avg_return)`` logged at each ``log_interval``.
         """
-        obs, _ = self.env.reset()
-        hint = None
+        obs, info = self.env.reset()
+        hint = info.get("hint")
         global_step = 0
         episode_returns: List[float] = []
         interval_returns: List[float] = []
@@ -371,8 +371,8 @@ class PPORuleAgent:
                     episode_returns.append(ep_return)
                     interval_returns.append(ep_return)
                     ep_return = 0.0
-                    obs, _ = self.env.reset()
-                    hint = None
+                    obs, info = self.env.reset()
+                    hint = info.get("hint")
 
             # ── PPO Update
             self._update()
@@ -509,8 +509,8 @@ class PPORuleAgent:
         rules: List[List[str]] = []
 
         for _ in range(n):
-            obs, _ = self.env.reset()
-            hint = None
+            obs, info = self.env.reset()
+            hint = info.get("hint")
             toks: List[int] = []
             done = False
             steps = 0

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -155,6 +155,7 @@ class RuleGenEnv(gym.Env):
                 tok_id = self.token2id.get(tok)
                 if tok_id is not None:
                     self._default_hint_tokens.append(tok_id)
+        self._hint_tokens: List[int] = []
 
         # Gym spaces
         self.action_space = gym.spaces.Discrete(self.vocab_size)
@@ -200,16 +201,17 @@ class RuleGenEnv(gym.Env):
                 if tok_id is not None:
                     hint_tokens.append(tok_id)
 
-        self._tokens = list(hint_tokens)
+        self._hint_tokens = list(hint_tokens)
+        self._tokens = []
         # adjust observation space for current hint length
         self.observation_space = gym.spaces.Box(
             low=0,
             high=self.vocab_size,
-            shape=(self.max_len + len(self._tokens),),
+            shape=(self.max_len + len(self._hint_tokens),),
             dtype=np.int32,
         )
         obs = self._pad_obs(self._tokens)
-        info = {}
+        info = {"hint": np.array(self._hint_tokens, dtype=np.int32)}
         return obs, info
 
     def step(
@@ -229,9 +231,10 @@ class RuleGenEnv(gym.Env):
 
         # 2) 종료 조건
         max_tokens = self.observation_space.shape[0]
-        if action == self.token2id[self.END] or len(self._tokens) >= max_tokens:
+        total_len = len(self._tokens) + len(self._hint_tokens)
+        if action == self.token2id[self.END] or total_len >= max_tokens:
             done = True
-            truncated = len(self._tokens) >= max_tokens
+            truncated = total_len >= max_tokens
             rule_text = self._tokens_to_rule(self._tokens)
             final_r, metrics = self._compute_reward(rule_text)
             reward += final_r
@@ -301,7 +304,12 @@ class RuleGenEnv(gym.Env):
 
     # token → string → rule
     def _tokens_to_rule(self, toks: Sequence[int]) -> str:
-        raw_tokens = [self.id2token[i] for i in toks if i not in {self.token2id[self.END], self.token2id[self.PAD]}]
+        all_toks = list(self._hint_tokens) + list(toks)
+        raw_tokens = [
+            self.id2token[i]
+            for i in all_toks
+            if i not in {self.token2id[self.END], self.token2id[self.PAD]}
+        ]
         if self.rule_type == "yara":
             from .yara_builder import tokens_to_yara  # type: ignore
 


### PR DESCRIPTION
## Summary
- keep hint tokens separate from generated tokens in `RuleGenEnv`
- expose hint tokens via the `reset()` info dict
- include hint tokens when converting token sequences to rule text
- forward hint arrays to the policy in `PPORuleAgent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7ff76db4832e957d3d3c83bd1994