### PR TITLE
Add LR scheduler to PPO training

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -264,12 +264,19 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         hint_features=hint_feats,
         classifier_ckpt=args.classifier_ckpt,
     )
+    sched_cfg = cfg.get("scheduler", {})
+    sched_name = sched_cfg.get("name")
+    total_steps = int(sched_cfg.get("total_updates", args.epochs))
     try:
-        agent = rulegen.load_agent(env=env, policy_net=policy_net)
+        agent = rulegen.load_agent(
+            env=env,
+            policy_net=policy_net,
+            schedule_type=sched_name,
+            total_updates=total_steps,
+        )
     except TypeError:
         # backward compatibility with older API in tests
         agent = rulegen.load_agent(env=env)
-    total_steps = int(cfg.get("scheduler", {}).get("total_updates", args.epochs))
     log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))
     history = agent.train(
         total_timesteps=total_steps,

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -171,6 +171,8 @@ def load_agent(
     ckpt_path: str | None = None,
     env: Optional[RuleGenEnv] = None,
     policy_net: str = "gru",
+    schedule_type: str | None = None,
+    total_updates: int | None = None,
     **env_kwargs: Any,
 ) -> PPORuleAgent:
     """
@@ -181,6 +183,8 @@ def load_agent(
     ckpt_path  : `.pt` 파일 경로; None 이면 *새 에이전트* 초기화
     env        : 미리 생성한 RuleGenEnv; 없으면 자동 `make_env()`
     policy_net : "gru" 또는 사용할 GPT 모델명
+    schedule_type : 학습률 스케줄러 종류 (예: "linear", "cosine")
+    total_updates : 스케줄 총 스텝 수
     env_kwargs : env 미생성 시 전달할 파라미터
 
     Returns
@@ -189,7 +193,12 @@ def load_agent(
     """
     if env is None:
         env = make_env(**env_kwargs)
-    agent = PPORuleAgent(env, policy_net=policy_net)
+    agent = PPORuleAgent(
+        env,
+        policy_net=policy_net,
+        schedule_type=schedule_type,
+        total_updates=total_updates,
+    )
     if ckpt_path:
         agent.load(ckpt_path)
         _LOG.info("Loaded PPO agent weights from '%s'", ckpt_path)

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -213,6 +213,8 @@ class PPORuleAgent:
         gae_lambda: float = 0.95,
         clip_eps: float = 0.2,
         lr: float = 3e-4,
+        schedule_type: str | None = None,
+        total_updates: int | None = None,
         vf_coef: float = 0.5,
         entropy_coef: float = 0.01,
         max_grad_norm: float = 0.5,
@@ -277,6 +279,20 @@ class PPORuleAgent:
             self.policy = GPTPolicy(policy_net, env.action_space.n, use_hint).to(self.device)
 
         self.optimizer = torch.optim.Adam(self.policy.parameters(), lr=lr)
+
+        self.scheduler: torch.optim.lr_scheduler.LRScheduler | None = None
+        if schedule_type:
+            if total_updates is None:
+                raise ValueError("total_updates must be provided when using a scheduler")
+            if schedule_type == "linear":
+                lr_lambda = lambda step: 1 - min(step, total_updates) / float(total_updates)
+                self.scheduler = torch.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda)
+            elif schedule_type == "cosine":
+                self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+                    self.optimizer, T_max=total_updates
+                )
+            else:
+                raise ValueError(f"Unknown schedule_type '{schedule_type}'")
 
         # rollout storage
         self.reset_rollout_buffers()
@@ -484,6 +500,8 @@ class PPORuleAgent:
                 loss.backward()
                 nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
                 self.optimizer.step()
+                if self.scheduler is not None:
+                    self.scheduler.step()
 
         self.reset_rollout_buffers()
 


### PR DESCRIPTION
## Summary
- add `schedule_type` and `total_updates` options to `PPORuleAgent`
- create scheduler in agent init and step it after each update
- expose scheduler parameters through `rulegen.load_agent`
- pass scheduler config from CLI to agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c82d2b6d4832e8cc91b2158500334