### PR TITLE
Remove no_grad from masked_score

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1290,8 +1290,7 @@ def _masked_score(graph: HeteroData, mask_prob: torch.Tensor, view: str, model) 
                 store[k] = v[keep]
         original[str(et)] = backup
 
-    with torch.no_grad():
-        out = model(graph, return_logits=True).squeeze()
+    out = model(graph, return_logits=True).squeeze()
 
     for et_str, backup in original.items():
         etype = eval(et_str)


### PR DESCRIPTION
## Summary
- allow gradient tracking in `_masked_score`

## Testing
- `pylint $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c914a25d8832ea874c0cda7255af7