### PR TITLE
Add guard for empty masks

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1341,6 +1341,8 @@ def train_global(args: argparse.Namespace) -> None:
                 full_score = model(g, return_logits=True).squeeze()
 
             mask_prob = explainer(g, embeddings=embeds)
+            if mask_prob.numel() == 0:
+                continue  # no edges to explain
             masked = _masked_score(g, mask_prob, args.view, model)
             loss = explainer.loss(full_score, masked, mask_prob, alpha=args.alpha, beta=args.beta)
 


### PR DESCRIPTION
## Summary
- skip training steps when the explainer returns an empty edge mask

## Testing
- `ruff check src/cli/explainer_train.py` *(fails: E402 Module level import not at top of file)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c91754010832eb714a7ff583f13cc