### PR TITLE
Fix explainer call to use hard masks

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1340,7 +1340,7 @@ def train_global(args: argparse.Namespace) -> None:
             with torch.no_grad():
                 full_score = model(g, return_logits=True).squeeze()
 
-            mask_prob = explainer(g, embeddings=embeds)
+            mask_prob = explainer(g, embeddings=embeds, hard=True)
             masked = _masked_score(g, mask_prob, args.view, model)
             loss = explainer.loss(full_score, masked, mask_prob, alpha=args.alpha, beta=args.beta)
 


### PR DESCRIPTION
## Summary
- call the explainer in hard mode when training the selector

## Testing
- `ruff check .` *(fails: Found 454 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c916dbb50832eb7473ff350875a8c