### PR TITLE
Fix explainer invocation

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1339,7 +1339,7 @@ def train_global(args: argparse.Namespace) -> None:
             with torch.no_grad():
                 full_score = model(g, return_logits=True).squeeze()
 
-            mask_prob = explainer(g, embeddings=embeds)
+            mask_prob = explainer(g, embeddings=embeds, hard=True)
             if mask_prob.numel() == 0:
                 continue  # no edges to explain
             masked = _masked_score(g, mask_prob, args.view, model)


### PR DESCRIPTION
## Summary
- pass `hard=True` flag when calling the explainer in `explainer_train.py`

## Testing
- `ruff check src/cli/explainer_train.py` *(fails: E402)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c92d969d0832ea981fcf47618abd7