### PR TITLE
Add optional view parameter to iter_edge_types

### DIFF
--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -45,8 +45,13 @@ def edge_mask_to_global(
     return out
 
 
-def iter_edge_types(g: HeteroData, view: str) -> Iterable[EdgeType]:
+def iter_edge_types(g: HeteroData, view: str | None = None) -> Iterable[EdgeType]:
     """Yield edge types whose relation matches ``view`` (supports ``fnmatch``)."""
+
+    if view is None:
+        yield from g.edge_types
+        return
+
     for key in g.edge_types:
         if fnmatch(key[1], view):
             yield key

--- a/tests/test_hetero_utils.py
+++ b/tests/test_hetero_utils.py
@@ -50,6 +50,13 @@ def test_iter_edge_types_wildcard():
     assert etypes == [("a", "rel2", "b")]
 
 
+def test_iter_edge_types_none_returns_all():
+    g = _make_graph()
+    assert list(iter_edge_types(g, None)) == list(g.edge_types)
+    # also test default argument
+    assert list(iter_edge_types(g)) == list(g.edge_types)
+
+
 def test_filter_view_removes_edges_and_nodes():
     g = _make_graph()
     out = filter_view(g, "rel")


### PR DESCRIPTION
## Summary
- extend `iter_edge_types` to accept `view: str | None = None`
- return all edge types when view is `None`
- add tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb8061d3c832eac3c388f2b993b4a