### PR TITLE
Allow None view for filter_view

### DIFF
--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -123,8 +123,14 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str) -> HeteroData:
     return out
 
 
-def filter_view(graph: HeteroData, view: str) -> HeteroData:
-    """Remove edges not matching ``view`` and drop disconnected node types."""
+def filter_view(graph: HeteroData, view: str | None) -> HeteroData:
+    """Remove edges not matching ``view`` and drop disconnected node types.
+
+    If ``view`` is ``None`` the graph is returned unchanged.
+    """
+
+    if view is None:
+        return graph
 
     # remove unrelated edge stores
     for et in list(graph.edge_types):

--- a/tests/test_hetero_utils.py
+++ b/tests/test_hetero_utils.py
@@ -63,3 +63,10 @@ def test_filter_view_removes_edges_and_nodes():
     assert ("a", "rel", "a") in out.edge_types
     assert ("a", "rel2", "b") not in out.edge_types
     assert "b" not in out.node_types
+
+
+def test_filter_view_none_returns_graph():
+    g = _make_graph()
+    out = filter_view(g, None)
+    assert list(out.edge_types) == list(g.edge_types)
+    assert list(out.node_types) == list(g.node_types)


### PR DESCRIPTION
## Summary
- allow `filter_view` to accept `None` and return graph unchanged
- test that passing `None` keeps graph intact

## Testing
- `pytest tests/test_hetero_utils.py -k test_filter_view_none_returns_graph -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb8cce544832ebf1c7745ef0603d4