### PR TITLE
Fix selector iter_edge_types view optional

### DIFF
--- a/src/explain/cfg_explainer/selector.py
+++ b/src/explain/cfg_explainer/selector.py
@@ -72,10 +72,13 @@ def gumbel_sigmoid(logits: torch.Tensor, tau: float, hard: bool) -> torch.Tensor
 # --------------------------------------------------------------------------- #
 #                        Hetero graph edge helpers                            #
 # --------------------------------------------------------------------------- #
-def iter_edge_types(g: HeteroData, view: str):
-    """Yield edge types in ``g`` whose relation matches ``view``."""
+def iter_edge_types(g: HeteroData, view: str | None = None):
+    """Yield edge types in ``g`` whose relation matches ``view``.
+
+    When ``view`` is ``None`` all edge types are yielded.
+    """
     for etype in g.edge_types:
-        if etype[1] == view:
+        if view is None or etype[1] == view:
             yield etype
 
 


### PR DESCRIPTION
## Summary
- make `iter_edge_types` from selector accept `None` for view
- iterate all edge types when view is `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cba00e1d8832e9343490d2817fa61