### PR TITLE
Update PGExplainer to allow None view

### DIFF
--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -19,7 +19,10 @@ from .cfg_explainer.selector import gumbel_sigmoid, iter_edge_types, edge_mask_t
 
 
 class PGExplainer(nn.Module):
-    """Simple PGExplainer for heterogeneous graphs."""
+    """Simple PGExplainer for heterogeneous graphs.
+
+    ``view`` may be ``None`` to operate on the full graph.
+    """
 
     def __init__(
         self,
@@ -28,9 +31,26 @@ class PGExplainer(nn.Module):
         *,
         hidden_dim: int = 64,
         num_layers: int = 2,
-        view: str = "cfg",
+        view: str | None = "cfg",
         device: str | torch.device | None = None,
     ) -> None:
+        """Initialize the explainer.
+
+        Parameters
+        ----------
+        model : nn.Module
+            GNN model being explained.
+        embed_dim : int
+            Dimension of node embeddings provided to ``forward``.
+        hidden_dim : int, optional
+            Hidden size for the edge scoring MLP.
+        num_layers : int, optional
+            Number of MLP layers.
+        view : str | None, optional
+            Edge relation to explain. ``None`` uses all edge types.
+        device : str | torch.device | None, optional
+            Device for parameters and buffers.
+        """
         super().__init__()
         self.model = model
         self.view = view
@@ -56,7 +76,10 @@ class PGExplainer(nn.Module):
         tau: float | None = None,
         hard: bool = False,
     ) -> torch.Tensor:
-        """Return probabilistic edge mask for ``self.view``."""
+        """Return probabilistic edge mask for ``self.view``.
+
+        When ``self.view`` is ``None`` a mask for all edge types is returned.
+        """
         τ = float(self.tau if tau is None else tau)
 
         if isinstance(graph, Data):
@@ -111,7 +134,10 @@ class PGExplainer(nn.Module):
         graph: Data | HeteroData,
         mask_prob: torch.Tensor | Dict[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
-        """Aggregate edge importance into node scores."""
+        """Aggregate edge importance into node scores.
+
+        If ``self.view`` is ``None`` saliency is aggregated over all edge types.
+        """
         if isinstance(graph, Data):
             mask = mask_prob if isinstance(mask_prob, torch.Tensor) else next(iter(mask_prob.values()))
             score = torch.zeros(graph.num_nodes, device=mask.device)


### PR DESCRIPTION
## Summary
- document that PGExplainer can operate on the whole graph when `view=None`
- allow optional `view` argument
- clarify behaviour of `forward` and `get_node_saliency`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbaaa8cac832e92f44448e466d3dd