### PR TITLE
Support optional view in node pruning utilities

### DIFF
--- a/src/explain/cfg_explainer/selector.py
+++ b/src/explain/cfg_explainer/selector.py
@@ -82,8 +82,13 @@ def iter_edge_types(g: HeteroData, view: str | None = None):
             yield etype
 
 
-def edge_mask_to_global(g: HeteroData, masks: dict[str, torch.Tensor], view: str) -> torch.Tensor:
-    """Concatenate per-edge-type masks following ``iter_edge_types`` order."""
+def edge_mask_to_global(
+    g: HeteroData, masks: dict[str, torch.Tensor], view: str | None
+) -> torch.Tensor:
+    """Concatenate per-edge-type masks following ``iter_edge_types`` order.
+
+    ``None`` concatenates masks for all edge types.
+    """
     outs = []
     for et in iter_edge_types(g, view):
         outs.append(masks[str(et)])

--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -73,7 +73,7 @@ def ensure_edgeaware_selector(selector, g: HeteroData) -> None:
         selector._init_params(g)
 
 
-def drop_unselected_nodes(data: HeteroData, node_idx, view: str) -> HeteroData:
+def drop_unselected_nodes(data: HeteroData, node_idx, view: str | None) -> HeteroData:
     """Return subgraph retaining only ``node_idx`` for edge types matching ``view``.
 
     Parameters
@@ -83,8 +83,9 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str) -> HeteroData:
     node_idx : Sequence[int] | Mapping[str, Sequence[int]]
         Nodes to keep. When a mapping is provided the keys correspond to
         node types.
-    view : str
-        Edge relation pattern (fnmatch) identifying node types.
+    view : str | None
+        Edge relation pattern (fnmatch) identifying node types.  ``None``
+        targets all edge types.
     """
     from collections.abc import Mapping, Sequence
     from src.graphs.transforms import GraphPruner
@@ -126,20 +127,19 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str) -> HeteroData:
 def filter_view(graph: HeteroData, view: str | None) -> HeteroData:
     """Remove edges not matching ``view`` and drop disconnected node types.
 
-    If ``view`` is ``None`` the graph is returned unchanged.
+    ``None`` keeps all edge types.
     """
 
-    if view is None:
-        return graph
+    keep = set(iter_edge_types(graph, view))
 
     # remove unrelated edge stores
     for et in list(graph.edge_types):
-        if not fnmatch(et[1], view):
+        if et not in keep:
             del graph[et]
 
     # gather node types still used by remaining edges
     connected: set[str] = set()
-    for et in graph.edge_types:
+    for et in keep:
         connected.add(et[0])
         connected.add(et[2])
 

--- a/tests/test_drop_unselected_nodes.py
+++ b/tests/test_drop_unselected_nodes.py
@@ -21,3 +21,11 @@ def test_drop_nodes():
     out = drop_unselected_nodes(g, [0, 2], "cfg")
     assert out["bb"].num_nodes == 2
     assert out[("bb", "cfg", "bb")].edge_index.tolist() == [[1], [0]]
+
+
+def test_drop_nodes_none_view():
+    g = build_graph()
+    out = drop_unselected_nodes(g, [0, 2], None)
+    assert out["bb"].num_nodes == 2
+    assert out[("bb", "cfg", "bb")].edge_index.tolist() == [[1], [0]]
+


### PR DESCRIPTION
## Summary
- update `drop_unselected_nodes` to accept `None` for view
- refine `filter_view` to use `iter_edge_types`
- allow `edge_mask_to_global` to accept optional view
- test dropping nodes with `None` view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbb880f14832eab50fb2bcd084f71