### PR TITLE
Support optional view for global explainer

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -173,9 +173,9 @@ def build_parser() -> argparse.ArgumentParser:
         )
         pp.add_argument(
             "--view",
-            type=Path,
-            default=Path("data/views/cfg"),
-            help="Directory containing view JSON graphs or the view root",
+            type=str,
+            default=None,
+            help="Optional view name or directory containing view graphs",
         )
         flag = pp.add_mutually_exclusive_group()
         flag.add_argument("--ast", action="store_true", help="Load AST view graphs")
@@ -391,7 +391,7 @@ def _train_selector_for_graph(
         view_flag = "syscall"
 
     view_dir = args.view
-    view_name = args.view.name
+    view_name = Path(args.view).name if args.view is not None else None
     if view_flag:
         # LOGGER.info("Loading view graph '%s' for %s", view_flag, sha)
         _log_memory_usage(device, f"Before loading view graph for {sha}")
@@ -447,9 +447,10 @@ def _train_selector_for_graph(
     graph = GraphDataset._ensure_meta_ids(graph, model.encoder.attr_names)
     _log_memory_usage(device, f"After GraphDataset._ensure_meta_ids for {sha}")
 
-    _log_memory_usage(device, f"Before filter_view for {sha}")
-    graph = filter_view(graph, view_name)
-    _log_memory_usage(device, f"After filter_view for {sha}")
+    if view_name is not None:
+        _log_memory_usage(device, f"Before filter_view for {sha}")
+        graph = filter_view(graph, view_name)
+        _log_memory_usage(device, f"After filter_view for {sha}")
 
     # Re-initialize model's input layers to match the actual feature dimensions of the graph.
     # This is crucial because the explainer might be using graphs with different features
@@ -1269,7 +1270,9 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
     return x_dict
 
 
-def _masked_score(graph: HeteroData, mask_prob: torch.Tensor, view: str, model) -> torch.Tensor:
+def _masked_score(
+    graph: HeteroData, mask_prob: torch.Tensor, view: str | None, model
+) -> torch.Tensor:
     ptr = 0
     original: dict[str, dict[str, torch.Tensor]] = {}
     for et in iter_edge_types(graph, view):
@@ -1335,6 +1338,11 @@ def train_global(args: argparse.Namespace) -> None:
                 g = GraphDataset._ensure_num_nodes(g)
                 g = GraphDataset._ensure_x(g)
                 g = GraphDataset._ensure_meta_ids(g, model.encoder.attr_names)
+                view_name = (
+                    Path(args.view).name if args.view is not None else None
+                )
+                if view_name is not None:
+                    g = filter_view(g, view_name)
                 for nt in g.node_types:
                     g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
                 _reinit_input_proj(g, model, device)
@@ -1348,8 +1356,9 @@ def train_global(args: argparse.Namespace) -> None:
                 mask_prob = explainer(g, embeddings=embeds, hard=True)
                 if mask_prob.numel() == 0:
                     skipped_count += 1
+                    view_desc = args.view if args.view is not None else "all edges"
                     LOGGER.debug(
-                        f"Skipping graph {sha}: No edges found for view '{args.view}'. "
+                        f"Skipping graph {sha}: No edges found for view '{view_desc}'. "
                         f"Available edge types: {g.edge_types}"
                     )
                     continue  # no edges to explain


### PR DESCRIPTION
## Summary
- allow `--view` to be omitted and accept plain strings or paths
- skip `filter_view` for global explanations when no view is provided
- propagate optional view to PGExplainer and masked scoring
- improve logging message when no view is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbd305978832e80c7b16eb83d5612