### PR TITLE
Fix addr defaults in normalizers

### DIFF
--- a/src/graphs/normalizers/cfg_norm.py
+++ b/src/graphs/normalizers/cfg_norm.py
@@ -67,6 +67,8 @@ class CFGNormalizer(NormalizerBase):
 
         if hasattr(g, "addr"):
             bb_store.addr = [g.addr[i] for i in bb_idx]
+        else:
+            bb_store.addr = torch.zeros(n_nodes, dtype=torch.long)
         inst_cnt = getattr(g, "inst_cnt", None)
         if inst_cnt is not None:
             bb_store.inst_cnt = torch.as_tensor(inst_cnt)[bb_idx]

--- a/src/graphs/normalizers/fcg_norm.py
+++ b/src/graphs/normalizers/fcg_norm.py
@@ -62,6 +62,8 @@ class FCGNormalizer(NormalizerBase):
 
         if hasattr(g, "addr"):
             fn_store.addr = [g.addr[i] for i in fn_idx]
+        else:
+            fn_store.addr = torch.zeros(len(fn_idx), dtype=torch.long)
         if hasattr(g, "name"):
             fn_store.name = [g.name[i] for i in fn_idx]
 


### PR DESCRIPTION
## Summary
- fill missing `addr` values with zero tensors in CFG and FCG normalizers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc7772fb0832eab00657fbb428976