### PR TITLE
Handle addr string lists in metadata encoding

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -298,6 +298,19 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         continue
                     elif isinstance(val, (list, tuple)):
                         if val and all(isinstance(x, str) for x in val):
+                            if attr == "addr":
+                                parsed: list[int] | None = []
+                                for x in val:
+                                    try:
+                                        parsed.append(
+                                            int(x, 16 if x.lower().startswith("0x") else 10)
+                                        )
+                                    except ValueError:
+                                        parsed = None
+                                        break
+                                if parsed is not None:
+                                    st[attr] = torch.tensor(parsed, dtype=torch.long)
+                                    continue
                             meta[attr] = list(val)
                             st[attr + "_id"] = torch.tensor(
                                 [vocab.get(x, 0) for x in val],

--- a/tests/test_encode_metadata.py
+++ b/tests/test_encode_metadata.py
@@ -84,3 +84,40 @@ def test_encode_metadata_tensor_numpy(tmp_path, monkeypatch):
     assert torch.equal(data.numpy_attr, torch.tensor([4, 5, 6]))
     assert "tensor_attr" not in meta
     assert "numpy_attr" not in meta
+
+
+def test_encode_metadata_addr_str_list_success(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    g = Data(x=torch.randn(3, 1))
+    g.num_nodes = 3
+    g.addr = ["0x1", "2", "0x3"]
+    torch.save(g, graph_dir / "a.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    data = ds[0]
+    meta = data.meta
+    assert torch.equal(data.addr, torch.tensor([1, 2, 3], dtype=torch.long))
+    assert "addr" not in meta
+    assert not hasattr(data, "addr_id")
+
+
+def test_encode_metadata_addr_str_list_fallback(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+    g = Data(x=torch.randn(2, 1))
+    g.num_nodes = 2
+    g.addr = ["0x1", "bogus"]
+    torch.save(g, graph_dir / "a.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    ds = HeteroGraphDiskDataset(graph_dir)
+    data = ds[0]
+    meta = data.meta
+    assert meta["addr"] == ["0x1", "bogus"]
+    assert hasattr(data, "addr_id")


### PR DESCRIPTION
## Summary
- parse string address lists when encoding metadata
- add tests for string list address encoding in `HeteroGraphDiskDataset`

## Testing
- `pytest tests/test_encode_metadata.py -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686cc80c2cf8832e894c376f1fa956fd