### PR TITLE
Fix missing num_nodes handling in SelfGCL dataset

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -414,7 +414,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
             if isinstance(g, HeteroData):
                 for ntype in g.node_types:
                     store = g[ntype]
-                    num_nodes = store.num_nodes
+                    num_nodes = store.num_nodes if "num_nodes" in store else 0
                     for attr in attr_union[ntype]:
                         if attr in store:
                             continue
@@ -446,7 +446,7 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         LOGGER.warning(msg, ntype, path)
                         logging.getLogger().warning(msg, ntype, path)
             else:
-                num_nodes = g.num_nodes
+                num_nodes = g.num_nodes if hasattr(g, "num_nodes") else 0
                 for attr in attr_union[""]:
                     if attr in g:
                         continue
@@ -466,6 +466,17 @@ class HeteroGraphDiskDataset(InMemoryDataset):
                         attr,
                         path,
                     )
+
+        # --- ensure num_nodes recorded for all node types ---
+        for g in data_list:
+            if isinstance(g, HeteroData):
+                for ntype in node_types:
+                    store = g[ntype]
+                    if "num_nodes" not in store:
+                        store.num_nodes = 0
+            else:
+                if "num_nodes" not in g:
+                    g.num_nodes = 0
 
         # --- ensure all graphs have every edge type ---
         for g in data_list:

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -344,3 +344,24 @@ def test_disable_embeds(tmp_path, monkeypatch):
     )
     data = ds[0]
     assert not hasattr(data["token"], "x")
+
+
+def test_empty_api_num_nodes(tmp_path, monkeypatch, caplog):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g = HeteroData()
+    g["bb"].x = torch.randn(1, 1)
+    g["bb"].num_nodes = 1
+    _ = g["api"]  # empty store without num_nodes
+    torch.save(g, graph_dir / "a.pt")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    with caplog.at_level("WARNING"):
+        ds = HeteroGraphDiskDataset(graph_dir)
+    assert not any("Filled missing attribute" in rec.message for rec in caplog.records)
+
+    api_store = ds[0]["api"]
+    assert api_store.num_nodes == 0


### PR DESCRIPTION
## Summary
- avoid warnings when num_nodes field is missing
- always create num_nodes field for all node types
- test for empty API node store

## Testing
- `pytest tests/test_selfgcl_dataset.py -q`
- `pytest -q tests/test_selfgcl_dataset.py::test_empty_api_num_nodes`

------
https://chatgpt.com/codex/tasks/task_e_686cc9096f34832e90fc23dfa0763478