### PR TITLE
Add validation to PGExplainer training

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,15 @@ python -m cli.explainer_train feature-mine \
 # `--saint {node,edge}` 옵션을 사용하면 GraphSAINT 샘플러로 서브그래프 단위 학습이 가능해 GPU 메모리를 절약할 수 있습니다.
 # 캐시된 점수만 사용할 경우 `--no-full-score` 옵션을 지정합니다.
 # 필요한 점수는 `scripts/precompute_scores.py` 스크립트로 미리 계산할 수 있습니다.
-# 평가
-# 기존의 `temp_explainer_runner.py` 스크립트는 더 이상 제공되지 않습니다.
-# 위의 `feature-mine` 하위 명령을 사용해 동일한 기능을 수행할 수 있습니다.
-# 평가
+```
+
+### Validation for global explainer training
+
+`global` 하위 명령에서는 검증 그래프를 지정해 학습 중 성능을 확인할 수 있습니다.
+`--val-graph-dir`와 `--val-meta-csv` 옵션을 사용하며 기본값은 각각
+`<graph_dir>/../val/graphs`, `<graph_dir>/../val/labels.csv` 입니다.
+각 에폭이 끝나면 평균 Fidelity와 Sparsity가 다음과 같이 출력됩니다.
+
+```
+Epoch 1 Val Fidelity: 0.9123  Val Sparsity: 0.0731
 ```

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -46,6 +46,7 @@ def _cast_graph_dtype(g: HeteroData, dtype: torch.dtype) -> None:
 
 
 import torch
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torch_geometric.data import HeteroData
 from tqdm import tqdm
@@ -215,6 +216,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--graph-dir", type=Path, required=True, help="Directory containing *.pt graphs"
     )
     g.add_argument("--output", type=Path, required=True, help="Output explainer path")
+    g.add_argument(
+        "--val-graph-dir",
+        type=Path,
+        help="Directory with validation *.pt graphs",
+    )
+    g.add_argument(
+        "--val-meta-csv",
+        type=Path,
+        help="Optional CSV with sha256,label for validation",
+    )
     g.add_argument("--tau-decay", type=float, default=0.995, help="Temperature decay")
     g.add_argument("--tau-min", type=float, default=0.5, help="Minimum temperature")
     add_common(g)
@@ -1309,6 +1320,62 @@ def _masked_score(
     return out
 
 
+def _evaluate_global(
+    explainer: PGExplainer,
+    model: RESGCLClassifier,
+    paths: list[Path],
+    device: torch.device,
+    args: argparse.Namespace,
+) -> tuple[float, float]:
+    """Return average fidelity and sparsity on validation graphs."""
+    if not paths:
+        return 0.0, 0.0
+
+    total_fid = 0.0
+    total_spars = 0.0
+    count = 0
+    param_dtype = next(model.parameters()).dtype
+
+    for gp in paths:
+        g = torch.load(gp, map_location="cpu", weights_only=False)
+        if not isinstance(g, HeteroData):
+            continue
+        sha = getattr(g, "sha256", gp.stem)
+        if not args.no_embeds:
+            _attach_embeddings(g, sha, args.embed_dir)
+        g = GraphDataset._ensure_num_nodes(g)
+        g = GraphDataset._ensure_x(g)
+        g = GraphDataset._ensure_meta_ids(g, model.encoder.attr_names)
+        view_name = Path(args.view).name if args.view is not None else None
+        if view_name is not None:
+            g = filter_view(g, view_name)
+        for nt in g.node_types:
+            g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
+        _reinit_input_proj(g, model, device)
+        _cast_graph_dtype(g, param_dtype)
+        g = g.to(device)
+
+        with torch.no_grad():
+            embeds = _compute_node_embeddings(g, model.encoder)
+            full_score = model(g, return_logits=True).squeeze()
+            mask_prob = explainer(g, embeddings=embeds, hard=True)
+            if mask_prob.numel() == 0:
+                continue
+            masked_score = _masked_score(g, mask_prob, args.view, model)
+            fidelity = F.binary_cross_entropy_with_logits(
+                masked_score, torch.sigmoid(full_score)
+            )
+            sparsity = mask_prob.mean()
+
+        total_fid += float(fidelity)
+        total_spars += float(sparsity)
+        count += 1
+
+    if count == 0:
+        return 0.0, 0.0
+    return total_fid / count, total_spars / count
+
+
 def train_global(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
     model = _load_model(args, device)
@@ -1316,6 +1383,21 @@ def train_global(args: argparse.Namespace) -> None:
     graph_paths = sorted(Path(args.graph_dir).glob("*.pt"))
     if not graph_paths:
         raise ValueError(f"No graphs found in {args.graph_dir}")
+
+    if args.val_graph_dir is None:
+        args.val_graph_dir = Path(args.graph_dir).parent / "val" / "graphs"
+    val_graph_paths = sorted(Path(args.val_graph_dir).glob("*.pt"))
+    if args.val_meta_csv is None:
+        args.val_meta_csv = Path(args.graph_dir).parent / "val" / "labels.csv"
+    if args.val_meta_csv.is_file():
+        try:
+            import pandas as pd
+
+            df = pd.read_csv(args.val_meta_csv)
+            allowed = set(df[df.get("label", 1) == 1]["sha256"].tolist())
+            val_graph_paths = [p for p in val_graph_paths if p.stem in allowed]
+        except Exception as e:
+            LOGGER.warning(f"Failed to read val meta CSV: {e}")
 
     explainer = PGExplainer(
         model=model,
@@ -1392,6 +1474,16 @@ def train_global(args: argparse.Namespace) -> None:
                     f"Epoch {epoch + 1}/{args.epochs} finished. Final Avg Loss: {avg_loss:.4f}. "
                     f"Graphs processed: {graph_count}. Graphs skipped: {skipped_count}."
                 )
+                if val_graph_paths:
+                    val_fid, val_spars = _evaluate_global(
+                        explainer, model, val_graph_paths, device, args
+                    )
+                    LOGGER.info(
+                        "Epoch %d Val Fidelity: %.4f  Val Sparsity: %.4f",
+                        epoch + 1,
+                        val_fid,
+                        val_spars,
+                    )
             else:
                 LOGGER.warning(
                     f"Epoch {epoch + 1}/{args.epochs} finished. No graphs were processed. "


### PR DESCRIPTION
## Summary
- allow passing validation set to `explainer_train global`
- evaluate average fidelity/sparsity on validation graphs each epoch
- document validation options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf94ca65c832eb7cdf6e11dee89b5