### PR TITLE
Add embed-dir option to feature mining CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ when an out-of-range index is found.
 python -m cli.rulegen_cli feature-mine \
        --graph-dir data/splits/ \
        --labels data/meta.csv \
+       --embed-dir data/embeds \
        --out features.json
 
 # 데이터셋 변환 예시

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -166,7 +166,7 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
         logger.info("Loaded selector from %s", args.selector_checkpoint)
 
     # GraphDataset does not support caching; simple on‑demand loading is fine
-    dataset = GraphDataset(graph_dir, split='train')
+    dataset = GraphDataset(graph_dir, split='train', embed_dir=args.embed_dir)
     miner = FeatureMiner()
 
     all_features: List[dict] = []
@@ -463,6 +463,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--labels",
         help="Optional labels file (.jsonl or .csv) with sha256 and label",
     )
+    fm.add_argument("--embed-dir", help="Directory containing .ftr token embeddings")
     fm.add_argument("--out", required=True, help="Output path for mined features (.json)")
     fm.add_argument(
         "--selector-checkpoint",

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -31,3 +31,21 @@ def test_read_string_array(tmp_path):
     fp.write_text('["A", "B"]')
     items = _read_json_lines(fp)
     assert items == ["A", "B"]
+
+
+def test_build_parser_accepts_embed_dir(monkeypatch):
+    import importlib
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args([
+        "feature-mine",
+        "--graph-dir",
+        "d",
+        "--out",
+        "o.json",
+        "--embed-dir",
+        "embeds",
+    ])
+    assert args.embed_dir == "embeds"
+    assert args.func == rulegen_cli.cmd_feature_mine


### PR DESCRIPTION
## Summary
- support loading token embeddings in `rulegen_cli feature-mine` via `--embed-dir`
- propagate the option to `GraphDataset`
- document new CLI flag in README
- test parser accepts the new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4a3b3cbc832e81be3fbbf559289b