### PR TITLE
Add classifier embed option to feature-mine

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ python -m cli.rulegen_cli feature-mine \
        --graph-dir data/splits/ \
        --labels data/meta.csv \
        --embed-dir data/embeds \
+       --classifier-ckpt models/gnn/res_gcl.pt \
        --out features.json
 
 # 데이터셋 변환 예시

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -165,6 +165,20 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
             selector.eval()
         logger.info("Loaded selector from %s", args.selector_checkpoint)
 
+    classifier = None
+    if args.classifier_ckpt:
+        try:
+            classifier = torch.load(args.classifier_ckpt, map_location="cpu", weights_only=False)
+        except FileNotFoundError:
+            logger.error("Classifier checkpoint not found at %s", args.classifier_ckpt)
+            raise SystemExit(1)
+        except Exception as exc:
+            logger.error("Failed to load classifier checkpoint %s: %s", args.classifier_ckpt, exc)
+            raise SystemExit(1)
+        if hasattr(classifier, "eval"):
+            classifier.eval()
+        logger.info("Loaded classifier from %s", args.classifier_ckpt)
+
     # GraphDataset does not support caching; simple on‑demand loading is fine
     dataset = GraphDataset(graph_dir, split='train', embed_dir=args.embed_dir)
     miner = FeatureMiner()
@@ -190,7 +204,17 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
         
         if selector:
             with torch.no_grad():
-                mask_prob = selector(graph)
+                embeds = None
+                if classifier is not None:
+                    from src.cli.explainer_train import _compute_node_embeddings
+                    embeds = _compute_node_embeddings(graph, classifier.encoder)
+                elif hasattr(selector, "model"):
+                    try:
+                        from src.cli.explainer_train import _compute_node_embeddings
+                        embeds = _compute_node_embeddings(graph, selector.model.encoder)
+                    except Exception:
+                        embeds = None
+                mask_prob = selector(graph, embeddings=embeds) if embeds is not None else selector(graph)
                 sal = selector.get_node_saliency(graph, mask_prob)
         else:
             sal = torch.ones(sum(graph[nt].num_nodes for nt in graph.node_types))
@@ -469,6 +493,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--selector-checkpoint",
         type=Path,
         help="Optional selector checkpoint to compute node saliency",
+    )
+    fm.add_argument(
+        "--classifier-ckpt",
+        type=Path,
+        help="Classifier checkpoint used during explainer training",
     )
     fm.set_defaults(func=cmd_feature_mine)
 

--- a/tests/test_feature_mine.py
+++ b/tests/test_feature_mine.py
@@ -9,8 +9,10 @@ pytest.importorskip("numpy")
 import torch
 from torch_geometric.data import HeteroData
 from pathlib import Path
+import types
 
 from src.cli import rulegen_cli
+
 
 
 class DummyMiner:
@@ -77,3 +79,56 @@ def test_cmd_feature_mine(tmp_path, monkeypatch):
     data2 = json.loads(out2.read_text())
     assert {d["sha256"] for d in data2} == {"a", "b"}
     assert calls == [("a", 1), ("b", 1)]
+
+    # --- with selector & classifier checkpoint ---
+    calls.clear()
+    out3 = tmp_path / "out3.json"
+
+    class DummySelector:
+        def __init__(self):
+            self.model = types.SimpleNamespace(encoder="enc")
+            self.calls = []
+
+        def eval(self):
+            return self
+
+        def __call__(self, g, embeddings=None):
+            self.calls.append(embeddings)
+            return torch.zeros(1)
+
+        def get_node_saliency(self, g, mask):
+            return torch.ones(sum(g[nt].num_nodes for nt in g.node_types))
+
+    selector = DummySelector()
+    classifier = types.SimpleNamespace(encoder="enc")
+
+    orig_load = torch.load
+
+    def fake_load(path, *a, **kw):
+        if str(path).endswith("sel.pt"):
+            return selector
+        if str(path).endswith("clf.pt"):
+            return classifier
+        return orig_load(path, *a, **kw)
+
+    monkeypatch.setattr(rulegen_cli.torch, "load", fake_load)
+
+    embed_obj = object()
+
+    def fake_compute(g, enc):
+        assert enc == "enc"
+        return embed_obj
+
+    monkeypatch.setattr(rulegen_cli, "_compute_node_embeddings", fake_compute)
+
+    args = argparse.Namespace(
+        graph_dir=str(root),
+        labels=None,
+        out=str(out3),
+        selector_checkpoint=str(tmp_path / "sel.pt"),
+        classifier_ckpt=str(tmp_path / "clf.pt"),
+        embed_dir=None,
+    )
+    rulegen_cli.cmd_feature_mine(args)
+
+    assert selector.calls == [embed_obj, embed_obj]

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 
 pytest.importorskip("torch")
 
@@ -46,6 +47,9 @@ def test_build_parser_accepts_embed_dir(monkeypatch):
         "o.json",
         "--embed-dir",
         "embeds",
+        "--classifier-ckpt",
+        "clf.pt",
     ])
     assert args.embed_dir == "embeds"
+    assert args.classifier_ckpt == Path("clf.pt")
     assert args.func == rulegen_cli.cmd_feature_mine


### PR DESCRIPTION
## Summary
- support `--classifier-ckpt` when mining features via `feature-mine`
- compute node embeddings and pass them to the selector
- document classifier checkpoint usage
- test new parser options and workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e04c02e5c832eac87a8ee5e9e691c