### PR TITLE
Add --features option to rule generation CLI

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -25,6 +25,7 @@ Typical work‑flow
 
       python -m cli.rulegen_cli generate \
              --agent-checkpoint models/rulebank/ppo_agent.pt \
+             --features features.json \
              --n-rules 200 \
              --rule-type yara \
              --out models/rulebank/yara/generated_rules.yar
@@ -359,7 +360,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
         raise SystemExit(f"[!] Missing builder implementation for {args.rule_type}")
 
     # Load features to build vocabulary
-    train_feats = _read_json_lines(Path("features.json"))
+    train_feats = _read_json_lines(Path(args.features))
     feats: list[str] = []
     for item in train_feats:
         fs = item.get("features")
@@ -540,6 +541,11 @@ def _build_parser() -> argparse.ArgumentParser:
     # ------------------- generate ------------------- #
     gen = sub.add_parser("generate", help="Generate YARA/CAPA rules with a trained agent")
     gen.add_argument("--agent-checkpoint", required=True, help="PPORuleAgent checkpoint (.pt)")
+    gen.add_argument(
+        "--features",
+        default="features.json",
+        help="Path to mined feature JSON for vocabulary",
+    )
     gen.add_argument("--n-rules", type=int, default=100, help="Number of rules to sample")
     gen.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature")
     gen.add_argument("--rule-type", choices=["yara", "capa"], default="yara")

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -53,3 +53,21 @@ def test_build_parser_accepts_embed_dir(monkeypatch):
     assert args.embed_dir == "embeds"
     assert args.classifier_ckpt == Path("clf.pt")
     assert args.func == rulegen_cli.cmd_feature_mine
+
+
+def test_generate_parser_accepts_features(monkeypatch):
+    import importlib
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args([
+        "generate",
+        "--agent-checkpoint",
+        "agent.pt",
+        "--out",
+        "rules.yar",
+        "--features",
+        "feats.json",
+    ])
+    assert args.features == "feats.json"
+    assert args.func == rulegen_cli.cmd_generate


### PR DESCRIPTION
## Summary
- support configurable feature JSON in `rulegen_cli generate`
- include new option in CLI help text and docs
- test parser for the new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e06587de8832e97d11cccfb8de2fb