### PR TITLE
Add chain handling in Yara builder

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -141,6 +141,30 @@ class YaraBuilder:
         if not unique_feats:
             unique_feats = ["dummy_token_unlikely_to_match"]
 
+        # chain 처리 – "chain:A→B" 를 분리해 call prefix 보정
+        processed: List[str] = []
+        chain_found = False
+        for feat in unique_feats:
+            if feat.startswith("chain:") and "→" in feat:
+                chain_found = True
+                rest = feat[len("chain:") :]
+                partA, partB = rest.split("→", 1)
+                if not partA.startswith("call:"):
+                    partA = "call:" + partA
+                if not partB.startswith("call:"):
+                    partB = "call:" + partB
+                processed.extend([partA, partB])
+            else:
+                processed.append(feat)
+
+        # 중복 제거, 순서 유지
+        seen = set()
+        unique_feats = []
+        for f in processed:
+            if f not in seen:
+                unique_feats.append(f)
+                seen.add(f)
+
         # 3) strings section
         strings_section_lines = []
         for idx, feat in enumerate(unique_feats):
@@ -148,7 +172,10 @@ class YaraBuilder:
             strings_section_lines.append(f"    $s{idx} = {yara_str}")
 
         # 4) condition
-        if self.condition_type == "any":
+        if chain_found:
+            cond_line = "    all of them"
+            _LOG.info("chain detected; forcing all-of-them condition")
+        elif self.condition_type == "any":
             cond_line = "    any of them"
         elif self.condition_type == "all":
             cond_line = "    all of them"

--- a/tests/test_chain_builders.py
+++ b/tests/test_chain_builders.py
@@ -1,0 +1,7 @@
+from src.rulegen.yara_builder import tokens_to_yara
+
+def test_chain_tokens_to_yara():
+    rule = tokens_to_yara(["chain:CreateFileW\u2192ReadFile"])
+    assert "$s0" in rule
+    assert "$s1" in rule
+    assert "all of them" in rule


### PR DESCRIPTION
## Summary
- support chain features in Yara rule generation
- force `all of them` condition when chains are detected
- add test covering chain handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e23d1e090832ea2882f085d21c2ae