### PR TITLE
Add CAPA chain sequence support

### DIFF
--- a/src/rulegen/capa_builder.py
+++ b/src/rulegen/capa_builder.py
@@ -172,7 +172,33 @@ class CapaBuilder:
         if not atoms:
             atoms = ["dummy_feature_that_never_matches"]
 
-        features_yaml = self._atoms_to_features_yaml(atoms)
+        # chain:FeatureA→FeatureB pattern → sequence feature
+        seq_pairs: List[List[Tuple[str, str]]] = []
+        rest_atoms: List[str] = []
+        for atom in atoms:
+            if atom.startswith("chain:") and "→" in atom:
+                partA, partB = atom[len("chain:") :].split("\u2192", 1)
+                if not partA.startswith("call:"):
+                    partA = "call:" + partA
+                if not partB.startswith("call:"):
+                    partB = "call:" + partB
+                seq_pairs.append([
+                    _map_atom_to_feature(partA),
+                    _map_atom_to_feature(partB),
+                ])
+            else:
+                rest_atoms.append(atom)
+
+        atoms = rest_atoms
+        features_yaml: List[str] = []
+        for seq in seq_pairs:
+            features_yaml.append("      - sequence:")
+            for ftype, val in seq:
+                if any(c in val for c in ":{}[]#,&*?|-<>=!%@`\\\"' \t"):
+                    val = f'"{val}"'
+                features_yaml.append(f"        - {ftype}: {val}")
+
+        features_yaml.extend(self._atoms_to_features_yaml(atoms))
 
         # 메타정보
         ts = _dt.datetime.utcnow().strftime("%Y-%m-%d")

--- a/tests/test_chain_builders.py
+++ b/tests/test_chain_builders.py
@@ -1,7 +1,13 @@
 from src.rulegen.yara_builder import tokens_to_yara
+from src.rulegen.capa_builder import tokens_to_capa
 
 def test_chain_tokens_to_yara():
     rule = tokens_to_yara(["chain:CreateFileW\u2192ReadFile"])
     assert "$s0" in rule
     assert "$s1" in rule
     assert "all of them" in rule
+
+
+def test_chain_tokens_to_capa():
+    rule = tokens_to_capa(["chain:CreateFileW\u2192ReadFile"])
+    assert "sequence:" in rule


### PR DESCRIPTION
## Summary
- handle chain tokens in CAPA rule builder by converting to `sequence:` features
- verify that `tokens_to_capa` emits `sequence` block when given a chain token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e24d77e40832e8cf216bc0ff0f2c4