### PR TITLE
Add path, reg, and url token extraction

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -251,6 +251,9 @@ class FeatureMiner:
             "import": ["import", "import_"],
             "bytes": ["bytes"],
             "syscall": ["syscall", "syscall_name"],
+            "path": ["path", "filepath"],
+            "url": ["url", "uri"],
+            "reg": ["reg", "key", "registry"],
         }
 
         # 메타 필드 단일 접근 헬퍼
@@ -317,6 +320,49 @@ class FeatureMiner:
             syscall = _get("name")
         if isinstance(syscall, str):
             candidates.append(f"syscall:{syscall}")
+
+        # 6) 파일 경로
+        path_val = _get("path")
+        if path_val is None and ntype == "file":
+            path_val = _get("name")
+        if isinstance(path_val, str):
+            p = self._STRING_FILTER.sub("", path_val)
+            if p:
+                candidates.append(f"\"{p}\" wide ascii nocase")
+                for seg in re.split(r"[\\\\/]+", p):
+                    seg = seg.strip()
+                    if seg:
+                        candidates.append(f"path:{seg}")
+
+        # 7) 레지스트리 경로
+        reg_val = _get("reg")
+        if reg_val is None and ntype == "registry":
+            reg_val = _get("name")
+        if isinstance(reg_val, str):
+            r = self._STRING_FILTER.sub("", reg_val)
+            if r:
+                candidates.append(f"\"{r}\" wide ascii nocase")
+                for seg in re.split(r"\\\\+", r):
+                    seg = seg.strip()
+                    if seg:
+                        candidates.append(f"reg:{seg}")
+
+        # 8) URL
+        url_val = _get("url")
+        if isinstance(url_val, str):
+            u = self._STRING_FILTER.sub("", url_val)
+            m = re.match(r"https?://([^/]+)(/.*)?", u, re.IGNORECASE)
+            if m:
+                domain = m.group(1)
+                if domain:
+                    candidates.append(f"url:{domain}")
+                path_part = m.group(2) or ""
+                for seg in path_part.split('/'):
+                    seg = seg.strip()
+                    if seg:
+                        candidates.append(f"url:{seg}")
+            elif u:
+                candidates.append(f"\"{u}\" wide ascii nocase")
 
         # 이웃 노드 동시 선택 시 chain 토큰 생성
         if selected_set is not None and chain_label is not None:


### PR DESCRIPTION
## Summary
- handle file paths, registry paths, and URLs in `FeatureMiner`
- extend alias map with path/url/reg fields
- generate tokens for each segment as well as quoted strings

## Testing
- `pytest -k feature_miner -q`


------
https://chatgpt.com/codex/tasks/task_e_686e25b4a0b0832e9d1798ff191bb6fe