### PR TITLE
Handle path-like tokens in capa builder

### DIFF
--- a/src/rulegen/capa_builder.py
+++ b/src/rulegen/capa_builder.py
@@ -140,6 +140,10 @@ def _map_atom_to_feature(atom: str) -> Tuple[str, str]:
             hex_pat = atom
         return "bytes", hex_pat.lower()
 
+    # 6) path|reg|url:VALUE → string
+    if atom.lower().startswith(("path:", "reg:", "url:")):
+        return "string", atom.split(":", 1)[1]
+
     # fallback: treat as string (best‑effort)
     return "string", atom
 

--- a/tests/test_capa_map_atom.py
+++ b/tests/test_capa_map_atom.py
@@ -1,0 +1,14 @@
+import pytest
+
+from src.rulegen.capa_builder import _map_atom_to_feature
+
+@pytest.mark.parametrize(
+    "atom,expected",
+    [
+        ("path:C\\Windows", ("string", "C\\Windows")),
+        ("reg:HKLM\\Software", ("string", "HKLM\\Software")),
+        ("url:http://example.com", ("string", "http://example.com")),
+    ],
+)
+def test_path_reg_url_mapped_to_string(atom, expected):
+    assert _map_atom_to_feature(atom) == expected


### PR DESCRIPTION
## Summary
- map `path:`, `reg:`, and `url:` tokens to string features in capa builder
- test the new mapping logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e26efbc14832ebc53e3dddceaea65