### PR TITLE
Implement basic rule evaluation

### DIFF
--- a/src/evaluation/rule_evaluator.py
+++ b/src/evaluation/rule_evaluator.py
@@ -2,6 +2,16 @@ from __future__ import annotations
 
 from typing import Sequence, Tuple
 
+import logging
+import json
+import subprocess
+from pathlib import Path
+
+try:
+    import yara  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yara = None
+
 import torch
 from torch_geometric.data import HeteroData
 
@@ -23,8 +33,106 @@ class RuleEvaluator:
     ) -> Tuple[float, float, float]:
         """Evaluate ``rule_text`` on provided datasets.
 
-        This simplified implementation returns zero scores and does not
-        perform any real rule matching.  Projects may replace this logic
-        with a proper evaluator.
+        Parameters
+        ----------
+        rule_text : str
+            YARA or CAPA rule text.
+        clean_set : sequence of :class:`HeteroData`
+            Clean (negative) samples.
+        dummy_set : sequence of :class:`HeteroData`
+            Dummy/malicious (positive) samples.
         """
-        return 0.0, 0.0, 0.0
+
+        log = logging.getLogger(__name__)
+
+        try:
+            rule_type = "capa" if rule_text.lstrip().startswith("rule:") else "yara"
+
+            if rule_type == "yara":
+                if yara is None:
+                    raise RuntimeError("yara module not available")
+                compiled = yara.compile(source=rule_text)
+
+                def _match(path: Path) -> bool:
+                    try:
+                        return bool(compiled.match(str(path)))
+                    except Exception:  # pragma: no cover - yara errors
+                        return False
+
+            else:  # capa rule
+                with subprocess.NamedTemporaryFile("w", suffix=".yml", delete=False) as tmp:
+                    tmp.write(rule_text)
+                    tmp.flush()
+
+                def _match(path: Path) -> bool:
+                    try:
+                        proc = subprocess.run(
+                            ["capa", str(path), "-r", tmp.name, "--json"],
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                    except FileNotFoundError as exc:  # pragma: no cover - capa missing
+                        raise RuntimeError("capa executable not available") from exc
+
+                    if proc.returncode != 0:
+                        return False
+                    try:
+                        js = json.loads(proc.stdout)
+                    except Exception:
+                        return False
+                    return bool(js.get("rules"))
+
+        except Exception as exc:
+            log.warning("Rule compilation failed: %s", exc)
+            return 0.0, 0.0, 0.0
+
+        TP = FP = FN = TN = 0
+
+        def _get_path(g: HeteroData) -> Path | None:
+            p = getattr(g, "file_path", None)
+            if p is not None:
+                return Path(p)
+            sha = getattr(g, "sha256", None)
+            if sha is not None:
+                return Path(str(sha))
+            return None
+
+        try:
+            for g in dummy_set:
+                path = _get_path(g)
+                matched = _match(path) if path is not None else False
+                if matched:
+                    TP += 1
+                else:
+                    FN += 1
+
+            for g in clean_set:
+                path = _get_path(g)
+                matched = _match(path) if path is not None else False
+                if matched:
+                    FP += 1
+                else:
+                    TN += 1
+
+            # F1 for positive (dummy)
+            denom = 2 * TP + FP + FN
+            f1_dummy = 0.0 if denom == 0 else 2 * TP / denom
+
+            # F1 for negative (clean) – treat label 0 as positive
+            denom_clean = 2 * TN + FP + FN
+            f1_clean = 0.0 if denom_clean == 0 else 2 * TN / denom_clean
+
+            certified_r = 0.0
+            calc_r = getattr(self.clf, "calc_certified_radius", None)
+            if callable(calc_r):
+                try:
+                    certified_r = float(calc_r())
+                except Exception as exc:  # pragma: no cover - robustness errors
+                    log.warning("certified radius computation failed: %s", exc)
+                    certified_r = 0.0
+
+            return f1_clean, f1_dummy, certified_r
+        except Exception as exc:  # pragma: no cover - unexpected evaluation errors
+            log.warning("rule evaluation failed: %s", exc)
+            return 0.0, 0.0, 0.0


### PR DESCRIPTION
## Summary
- implement rule compilation and matching in `RuleEvaluator.evaluate_rule`
- support YARA rules and CAPA through subprocess
- compute F1 scores and call `calc_certified_radius` when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e27377c1c832e9a2e6f6c8664eda5