### PR TITLE
Improve tokenizer splitting logic

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -39,6 +39,7 @@ import logging
 import random
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
+import re
 
 import gymnasium as gym
 import numpy as np
@@ -396,7 +397,26 @@ class RuleGenEnv(gym.Env):
     # rule string tokenizer (공용)
     @staticmethod
     def _rule_tokenize(text: str) -> List[str]:
-        return text.replace("(", " ( ").replace(")", " ) ").replace(":", " : ").split()
+        tokens = (
+            text.replace("(", " ( ")
+            .replace(")", " ) ")
+            .replace(":", " : ")
+            .split()
+        )
+        out: List[str] = []
+        for tok in tokens:
+            subtokens = [tok]
+            if re.search(r"[a-z][A-Z]", tok) or re.search(r"[A-Za-z]\d", tok):
+                subtokens = re.findall(r"[A-Z][^A-Z]*", tok)
+            if "_" in tok:
+                tmp: List[str] = []
+                for st in subtokens:
+                    tmp.extend(st.split("_"))
+                subtokens = tmp
+            for st in subtokens:
+                if st:
+                    out.append(st)
+        return out
 
 
 # ──────────────────────────────── quick smoke‑test ────────────

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -146,3 +146,8 @@ def test_action_mask_length(tmp_path):
     mask = env.get_action_mask()
     assert mask.sum() == 1
     assert mask[env.token2id[env.END]] == 1
+
+
+def test_rule_tokenize_subtokens():
+    result = RuleGenEnv._rule_tokenize("CreateFileW")
+    assert result == ["Create", "File", "W"]


### PR DESCRIPTION
## Summary
- enhance `_rule_tokenize` with regex-based subtoken splitting
- skip empty subtokens and maintain bracket/colon handling
- test tokenization of `CreateFileW`

## Testing
- `pytest -k rule_tokenize_subtokens -q` *(fails: all tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686e29116d50832e86f8faabb2e64c1f