### PR TITLE
Add seeding option to rulegen CLI

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -58,6 +58,8 @@ import subprocess
 from pathlib import Path
 from typing import List, Sequence
 
+from common.utils import set_random_seed
+
 import torch
 import matplotlib.pyplot as plt
 from omegaconf import OmegaConf
@@ -289,6 +291,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         device=device,
         hint_features=hint_feats,
         classifier_ckpt=args.classifier_ckpt,
+        seed=args.seed,
     )
     sched_cfg = cfg.get("scheduler", {})
     sched_name = sched_cfg.get("name")
@@ -299,6 +302,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             policy_net=policy_net,
             schedule_type=sched_name,
             total_updates=total_steps,
+            seed=args.seed,
         )
     except TypeError:
         # backward compatibility with older API in tests
@@ -375,8 +379,9 @@ def cmd_generate(args: argparse.Namespace) -> None:
         dataset_dir=Path("data/rulegen_dataset"),
         device="cpu",
         hint_features=hint_feats,
+        seed=args.seed,
     )
-    agent = PPORuleAgent(env)
+    agent = PPORuleAgent(env, seed=args.seed)
     agent.load(args.agent_checkpoint)
 
     builder = builder_cls()  # type: ignore[call-arg]
@@ -474,6 +479,12 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Rule generation pipeline for robust‑malware‑graph project",
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="verbose logging")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility",
+    )
 
     sub = parser.add_subparsers(dest="command", required=True, metavar="<command>")
 
@@ -587,6 +598,7 @@ def main(argv: List[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     _setup_logger(args.verbose)
+    set_random_seed(args.seed, deterministic=True)
 
     # Dispatch to sub‑command
     args.func(args)  # type: ignore[misc]

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -149,6 +149,7 @@ def make_env(
     rule_type: str = "yara",
     *,
     classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
+    seed: int | None = None,
     **kwargs: Any,
 ) -> RuleGenEnv:
     """
@@ -161,6 +162,7 @@ def make_env(
     env = RuleGenEnv(
         rule_type=rule_type,
         classifier_ckpt=classifier_ckpt,
+        seed=seed if seed is not None else 2024,
         **kwargs,
     )
     _LOG.info("Created RuleGenEnv(rule_type=%s)", rule_type)
@@ -173,6 +175,7 @@ def load_agent(
     policy_net: str = "gru",
     schedule_type: str | None = None,
     total_updates: int | None = None,
+    seed: int | None = None,
     **env_kwargs: Any,
 ) -> PPORuleAgent:
     """
@@ -192,12 +195,13 @@ def load_agent(
     PPORuleAgent  (policy weights 로드 완료 상태)
     """
     if env is None:
-        env = make_env(**env_kwargs)
+        env = make_env(seed=seed, **env_kwargs)
     agent = PPORuleAgent(
         env,
         policy_net=policy_net,
         schedule_type=schedule_type,
         total_updates=total_updates,
+        seed=seed if seed is not None else 2024,
     )
     if ckpt_path:
         agent.load(ckpt_path)

--- a/src/rulegen/__init__.pyi
+++ b/src/rulegen/__init__.pyi
@@ -14,12 +14,17 @@ def make_env(
     rule_type: str = "yara",
     *,
     classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
+    seed: int | None = None,
     **kwargs: Any,
 ) -> RuleGenEnv: ...
 
 def load_agent(
     ckpt_path: str | None = None,
     env: Optional[RuleGenEnv] = ...,
+    policy_net: str = ...,  # maintain param for completeness
+    schedule_type: str | None = ...,
+    total_updates: int | None = ...,
+    seed: int | None = None,
     **env_kwargs: Dict[str, Any],
 ) -> PPORuleAgent: ...
 

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -56,6 +56,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from common.utils import set_random_seed
+
 # ───────────────────────────── 내부 모듈
 try:
     from common.logger import get_logger  # type: ignore
@@ -224,7 +226,9 @@ class PPORuleAgent:
         minibatch_size: int = 64,
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         use_hint: bool = False,
+        seed: int = 2024,
     ):
+        set_random_seed(seed)
         self.env = env
         self.gamma = gamma
         self.gae_lambda = gae_lambda
@@ -620,7 +624,7 @@ def _cli():
         max_len=64,
     )
 
-    agent = PPORuleAgent(env, n_steps=512, minibatch_size=128)
+    agent = PPORuleAgent(env, n_steps=512, minibatch_size=128, seed=2024)
 
     if args.smoke_test:
         _LOG.info("Running smoke‑test (%d timesteps) …", args.timesteps)


### PR DESCRIPTION
## Summary
- add global `--seed` argument and use it in main
- seed RuleGenEnv and PPO agent via CLI
- propagate seed through `rulegen.make_env` and `load_agent`
- initialize `PPORuleAgent` with set_random_seed

## Testing
- `pip install -q -r requirements.txt` *(fails: operation canceled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e28fbe60c832e932916b5f4ac96fa