### PR TITLE
Improve hint tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ python -m cli.rulegen_cli ppo-train \
 ```python
 from rulegen import make_env
 
-# 힌트 문구를 주면 초기 관측에 해당 토큰들이 포함됩니다
-env = make_env(hint_features=["import pe", "strings $a"])
+# 힌트 문구는 `_rule_tokenize`로 분할되어 토큰 사전이 만들어집니다
+env = make_env(hint_features=["import", "pe", "strings", "$a"])
 obs, _ = env.reset()  # `reset()` 호출 시 다른 힌트를 전달할 수도 있습니다.
 ```
 # XAI selector 학습

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -280,6 +280,27 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         seen = set()
         hint_feats = [f for f in feats if not (f in seen or seen.add(f))]
 
+    # Collect token vocabulary from hint features
+    token_set: set[str] = set()
+    try:
+        rule_tokenize = rulegen.rl_env.RuleGenEnv._rule_tokenize  # type: ignore[attr-defined]
+    except AttributeError:  # fallback in tests where rulegen.rl_env is stubbed
+        def rule_tokenize(text: str) -> list[str]:
+            return text.replace("(", " ( ").replace(")", " ) ").replace(":", " : ").split()
+
+    for f in hint_feats or []:
+        for tok in rule_tokenize(str(f)):
+            token_set.add(tok)
+            tok_lower = tok.lower()
+            if "file" in tok_lower:
+                token_set.add("<FileOp>")
+            if "reg" in tok_lower:
+                token_set.add("<RegistryOp>")
+
+    token_list = sorted(token_set)
+    token2id = {tok: idx for idx, tok in enumerate(token_list)}
+    hint_tokens = token_list
+
 
     # ------------------------------------------------------------------
     # 3) Environment & agent instantiation
@@ -287,7 +308,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     env = rulegen.make_env(
         dataset_dir=dataset_dir,
         device=device,
-        hint_features=hint_feats,
+        hint_features=hint_tokens,
         classifier_ckpt=args.classifier_ckpt,
     )
     sched_cfg = cfg.get("scheduler", {})


### PR DESCRIPTION
## Summary
- tokenize hint features via `RuleGenEnv._rule_tokenize`
- add category tokens like `<FileOp>`/`<RegistryOp>`
- construct vocab from hints and feed to `make_env`
- document new hint tokenization example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2a602018832e894c725d34ddd4ab