### PR TITLE
Implement default rule output path and evaluation logs

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import argparse
 import json
 import csv
+import datetime as _dt
 import logging
 import sys
 import subprocess
@@ -388,11 +389,18 @@ def cmd_generate(args: argparse.Namespace) -> None:
     rules = agent.sample_rules(n=args.n_rules, temperature=args.temperature)
     rules_text = "\n\n".join(builder.build(r) for r in rules)
 
-    out_path = Path(args.out)
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        ts = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        out_dir = Path("models") / "rulebank" / args.rule_type
+        out_path = out_dir / f"generated_{ts}.yar"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w", encoding="utf-8") as fp:
         fp.write(rules_text)
-    logger.info("Generated %d %s rules → %s", len(rules), args.rule_type.upper(), out_path)
+    logger.info(
+        "Generated %d %s rules → %s", len(rules), args.rule_type.upper(), out_path
+    )
 
 
 
@@ -445,6 +453,23 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
     results = _evaluate_metrics(preds, labels, args.metrics)
     for k, v in results.items():
         logger.info("%s = %.4f", k.upper(), v)
+
+    log_path = Path("evaluation_logs.csv")
+    header = ["timestamp", "rule_file", "n_rules", "n_samples", *args.metrics]
+    if not log_path.exists():
+        with log_path.open("w", newline="", encoding="utf-8") as fp:
+            writer = csv.writer(fp)
+            writer.writerow(header)
+    with log_path.open("a", newline="", encoding="utf-8") as fp:
+        writer = csv.writer(fp)
+        row = [
+            _dt.datetime.utcnow().isoformat(),
+            str(rule_path),
+            getattr(builder, "rule_count", 0),
+            len(samples),
+            *(results.get(m, 0.0) for m in args.metrics),
+        ]
+        writer.writerow(row)
 
 
 def cmd_build_dataset(args: argparse.Namespace) -> None:
@@ -560,7 +585,10 @@ def _build_parser() -> argparse.ArgumentParser:
     gen.add_argument("--n-rules", type=int, default=100, help="Number of rules to sample")
     gen.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature")
     gen.add_argument("--rule-type", choices=["yara", "capa"], default="yara")
-    gen.add_argument("--out", required=True, help="Output rule file (.yar/.yml)")
+    gen.add_argument(
+        "--out",
+        help="Output rule file (.yar/.yml); defaults to models/rulebank/<type>/generated_<timestamp>.yar",
+    )
     gen.set_defaults(func=cmd_generate)
 
     # ------------------- evaluate ------------------- #

--- a/src/rulegen/capa_builder.py
+++ b/src/rulegen/capa_builder.py
@@ -238,6 +238,25 @@ class CapaBuilder:
         except Exception as e:  # pylint: disable=broad-except
             return False, str(e)
 
+    def load(self, path: Path) -> None:
+        """Load CAPA rules from a YAML file."""
+        text = Path(path).read_text(encoding="utf-8")
+        if yaml is not None:
+            try:
+                docs = [d for d in yaml.safe_load_all(text) if d]
+                self.rule_count = len(docs)
+            except Exception as exc:  # pragma: no cover - best effort
+                _LOG.warning("capa yaml parse failed: %s", exc)
+                self.rule_count = text.count("rule:")
+        else:
+            self.rule_count = text.count("rule:")
+        self._loaded = text
+
+    def match_file(self, sample_path: Path) -> bool:
+        """Placeholder matcher; real CAPA engine is optional."""
+        # Without capa engine we cannot perform matching. Always return False.
+        return False
+
     # ────────────────────────────── 내부 헬퍼 ───────────────────
     def _atoms_to_features_yaml(self, atoms: List[str]) -> List[str]:
         """

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -210,6 +210,27 @@ class YaraBuilder:
         except Exception as e:  # pylint:disable=broad-except
             return False, str(e)
 
+    def load(self, path: Path) -> None:
+        """Load rules from a file and compile if yara-python is available."""
+        text = Path(path).read_text(encoding="utf-8")
+        self.rule_count = text.count("rule ")
+        self._compiled = None
+        if yara is not None:
+            try:
+                self._compiled = yara.compile(filepath=str(path))
+            except Exception as exc:  # pragma: no cover - best effort
+                _LOG.warning("yara compile failed: %s", exc)
+
+    def match_file(self, sample_path: Path) -> bool:
+        """Return True if any rule matches the given file."""
+        if yara is None or self._compiled is None:
+            return False
+        try:
+            return bool(self._compiled.match(sample_path))
+        except Exception as exc:  # pragma: no cover - best effort
+            _LOG.warning("yara match failed for %s: %s", sample_path, exc)
+            return False
+
     # ─────────────────────────────────── helpers ───────────────
     def _extract_features(self, tokens: Sequence[str]) -> List[str]:
         """


### PR DESCRIPTION
## Summary
- add support for optional `--out` in `generate` to default into `models/rulebank/<type>`
- persist evaluation metrics into `evaluation_logs.csv`
- capture rule count when loading rule files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e2b1a14ac832e8d14c268a7507a13