### PR TITLE
Improve rulegen logging and add training note

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -85,12 +85,16 @@ def _lazy_imports():
 # Utility helpers
 # ---------------------------------------------------------------------------
 
-def _setup_logger(verbose: bool = False) -> None:
+def _setup_logger(verbose: bool = False, log_file: str | None = None) -> None:
     level = logging.DEBUG if verbose else logging.INFO
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file, encoding="utf-8"))
     logging.basicConfig(
         format="[%(asctime)s] %(levelname)s – %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
         level=level,
+        handlers=handlers,
     )
 
 
@@ -352,6 +356,9 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         Path(args.checkpoint).parent.mkdir(parents=True, exist_ok=True)
         agent.save(args.checkpoint)
         logger.info("Agent checkpoint saved → %s", args.checkpoint)
+
+        # NOTE: 학습에 사용된 설정 파일과 생성된 예시 룰을
+        #       동일한 디렉터리 아래에 보관하면 관리가 용이하다.
 
         builder = YaraBuilder()
         sample_tokens = agent.sample_rules(n=1)[0]
@@ -646,7 +653,18 @@ def main(argv: List[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    _setup_logger(args.verbose)
+    ts = _dt.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path("runs") / args.command / ts
+    ensure_dir(run_dir)
+    name_map = {
+        "feature-mine": "feature_mine.log",
+        "build-dataset": "build_dataset.log",
+        "ppo-train": "train.log",
+        "generate": "generate.log",
+        "evaluate": "evaluate.log",
+    }
+    log_path = run_dir / name_map.get(args.command, "run.log")
+    _setup_logger(args.verbose, log_file=str(log_path))
     set_random_seed(args.seed, deterministic=True)
 
     # Dispatch to sub‑command


### PR DESCRIPTION
## Summary
- allow specifying log file in `_setup_logger`
- record logs under `runs/<command>/<timestamp>` per subcommand
- add note about saving config and sample rule in same directory after PPO training

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'augment')*

------
https://chatgpt.com/codex/tasks/task_e_686e2caf9618832ea10af7dfe85ac687