### PR TITLE
Add running reward stats and standardization option

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -36,6 +36,7 @@ from .utils import (                               # noqa: F401
     ensure_dir,
     timer,
 )
+from .running_stats import RunningStats  # noqa: F401
 
 __all__: list[str] = [
     # logger.py
@@ -49,6 +50,7 @@ __all__: list[str] = [
     "tqdm_wrap",
     "ensure_dir",
     "timer",
+    "RunningStats",
 ]
 
 # --------------------------------------------------------------------------- #

--- a/src/common/running_stats.py
+++ b/src/common/running_stats.py
@@ -1,0 +1,39 @@
+"""Incremental running mean and variance utility."""
+from __future__ import annotations
+
+import math
+
+
+class RunningStats:
+    """Compute running mean and variance.
+
+    Uses Welford's online algorithm for numerical stability.
+    """
+
+    def __init__(self) -> None:
+        self.n = 0
+        self._mean = 0.0
+        self._m2 = 0.0
+
+    def update(self, x: float) -> None:
+        """Update statistics with a new value ``x``."""
+        self.n += 1
+        delta = x - self._mean
+        self._mean += delta / self.n
+        delta2 = x - self._mean
+        self._m2 += delta * delta2
+
+    @property
+    def mean(self) -> float:
+        """Return the current mean (0 if no samples)."""
+        return self._mean if self.n else 0.0
+
+    @property
+    def var(self) -> float:
+        """Return the current variance (0 if fewer than 2 samples)."""
+        return self._m2 / self.n if self.n else 0.0
+
+    @property
+    def std(self) -> float:
+        """Return the current standard deviation."""
+        return math.sqrt(self.var)

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -93,6 +93,7 @@ class RuleGenEnv(gym.Env):
         token_saliency: Dict[str, float] | None = None,
         step_penalty: float = -0.01,
         per_token_saliency: float = 0.02,
+        normalize_reward: bool = False,
     ):
         """
         Parameters
@@ -109,6 +110,7 @@ class RuleGenEnv(gym.Env):
         token_saliency   : 토큰별 중요도 가중치 딕셔너리
         step_penalty     : 매 스텝 적용할 패널티 (e.g. ``-0.01``)
         per_token_saliency : 선택한 토큰 saliency 가중치 배율
+        normalize_reward : ``True``면 보상을 평균 0, 표준편차 1로 표준화해 반환
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -147,6 +149,12 @@ class RuleGenEnv(gym.Env):
         self.token_saliency = token_saliency or {}
         self.step_penalty = step_penalty
         self.per_token_saliency = per_token_saliency
+        self.normalize_reward = normalize_reward
+
+        # running reward statistics
+        from common.running_stats import RunningStats
+
+        self.running_stats = RunningStats()
 
         # Hint features / tokens
         self.hint_features = hint_features or []
@@ -238,6 +246,9 @@ class RuleGenEnv(gym.Env):
             truncated = total_len >= max_tokens
             rule_text = self._tokens_to_rule(self._tokens)
             final_r, metrics = self._compute_reward(rule_text)
+            if self.normalize_reward:
+                std = self.running_stats.std or 1.0
+                final_r = (final_r - self.running_stats.mean) / std
             reward += final_r
             info["metrics"] = metrics
 
@@ -392,6 +403,8 @@ class RuleGenEnv(gym.Env):
             saliency_bonus=bonus,
             reward=reward,
         )
+        # update running reward statistics
+        self.running_stats.update(float(reward))
         return reward, metrics
 
     # rule string tokenizer (공용)

--- a/tests/test_running_stats.py
+++ b/tests/test_running_stats.py
@@ -1,0 +1,24 @@
+import math
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "running_stats",
+    Path(__file__).resolve().parents[1] / "src" / "common" / "running_stats.py",
+)
+running_stats = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(running_stats)
+RunningStats = running_stats.RunningStats
+
+
+def test_running_stats_basic():
+    rs = RunningStats()
+    values = [1.0, 2.0, 3.0]
+    for v in values:
+        rs.update(v)
+
+    assert math.isclose(rs.mean, 2.0, rel_tol=1e-7)
+    expected_var = 2.0 / 3.0
+    assert math.isclose(rs.var, expected_var, rel_tol=1e-7)
+    assert math.isclose(rs.std, math.sqrt(expected_var), rel_tol=1e-7)


### PR DESCRIPTION
## Summary
- implement `RunningStats` for running mean and variance
- export `RunningStats` from `src.common`
- integrate running reward stats in `RuleGenEnv`
- add reward normalization option
- test `RunningStats`

## Testing
- `pytest tests/test_running_stats.py::test_running_stats_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_686e31197858832eb81475812cf32f12