### PR TITLE
Add warmcos LR scheduler option

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -35,7 +35,8 @@ ppo:
   grad_clip: 1.0
 
 scheduler:
-  name: "cosine"
+  name: "warmcos"
+  warmup_steps: 5000
   total_updates: 1_000_000
 
 checkpoint:

--- a/src/lr_scheduler.py
+++ b/src/lr_scheduler.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, SequentialLR, LRScheduler
+
+
+def build_warm_cosine(
+    optimizer: Optimizer,
+    warmup_steps: int,
+    total_steps: int,
+) -> LRScheduler:
+    """Return scheduler with linear warm-up followed by cosine annealing."""
+    warmup_steps = int(warmup_steps)
+    total_steps = int(total_steps)
+    cosine = CosineAnnealingLR(optimizer, T_max=max(1, total_steps - warmup_steps))
+    if warmup_steps > 0:
+        linear = LinearLR(
+            optimizer,
+            start_factor=1e-6,
+            end_factor=1.0,
+            total_iters=warmup_steps,
+        )
+        scheduler = SequentialLR(
+            optimizer,
+            schedulers=[linear, cosine],
+            milestones=[warmup_steps],
+        )
+    else:
+        scheduler = cosine
+    return scheduler
+

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -69,6 +69,7 @@ except ModuleNotFoundError:
 
 
 from .rl_env import RuleGenEnv
+from lr_scheduler import build_warm_cosine
 
 _LOG = get_logger(__name__)
 
@@ -294,6 +295,12 @@ class PPORuleAgent:
             elif schedule_type == "cosine":
                 self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
                     self.optimizer, T_max=total_updates
+                )
+            elif schedule_type == "warmcos":
+                self.scheduler = build_warm_cosine(
+                    self.optimizer,
+                    warmup_steps=5000,
+                    total_steps=total_updates,
                 )
             else:
                 raise ValueError(f"Unknown schedule_type '{schedule_type}'")


### PR DESCRIPTION
## Summary
- implement `build_warm_cosine` LR scheduler helper
- support `schedule_type="warmcos"` in `PPORuleAgent`
- show warmcos scheduler example in PPO config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e33c430ac832ebda5e712475dbe21