### PR TITLE
Add entropy coef schedule for PPO agent

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -27,6 +27,7 @@ ppo:
   clip_eps: 0.2
   kl_target: 0.02
   entropy_coef: 0.001
+  entropy_coef_final: 0.0
   vf_coef: 0.5
   rollout_steps: 2048
   minibatch_size: 256

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -220,6 +220,7 @@ class PPORuleAgent:
         total_updates: int | None = None,
         vf_coef: float = 0.5,
         entropy_coef: float = 0.01,
+        entropy_coef_final: float = 0.0,
         max_grad_norm: float = 0.5,
         n_steps: int = 1024,
         n_epochs: int = 4,
@@ -236,6 +237,8 @@ class PPORuleAgent:
         self.clip_eps = clip_eps
         self.vf_coef = vf_coef
         self.entropy_coef = entropy_coef
+        self.entropy_coef_init = entropy_coef
+        self.entropy_coef_final = entropy_coef_final
         self.max_grad_norm = max_grad_norm
         self.n_steps = n_steps
         self.n_epochs = n_epochs
@@ -405,6 +408,9 @@ class PPORuleAgent:
 
                 # ── dynamic max_len schedule
                 progress_ratio = global_step / float(total_timesteps)
+                self.entropy_coef = self.entropy_coef_init + (
+                    self.entropy_coef_final - self.entropy_coef_init
+                ) * progress_ratio
                 if (
                     not self._max_len_updated
                     and global_step >= 50_000


### PR DESCRIPTION
## Summary
- support entropy coefficient scheduling in `PPORuleAgent`
- add `entropy_coef_final` field in PPO config

## Testing
- `pytest tests/test_ppo_train_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686e352c4f88832eaf2c69b80c81613a