### PR TITLE
Add reward shaping to RuleGenEnv

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -94,6 +94,8 @@ class RuleGenEnv(gym.Env):
         step_penalty: float = -0.01,
         per_token_saliency: float = 0.02,
         normalize_reward: bool = False,
+        core_tokens: Sequence[str] | None = None,
+        use_shaping: bool = False,
     ):
         """
         Parameters
@@ -111,6 +113,8 @@ class RuleGenEnv(gym.Env):
         step_penalty     : 매 스텝 적용할 패널티 (e.g. ``-0.01``)
         per_token_saliency : 선택한 토큰 saliency 가중치 배율
         normalize_reward : ``True``면 보상을 평균 0, 표준편차 1로 표준화해 반환
+        core_tokens      : shaping potential 계산에 사용할 핵심 토큰 시퀀스
+        use_shaping      : ``True``면 potential based reward shaping 활성화
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -155,6 +159,12 @@ class RuleGenEnv(gym.Env):
         from common.running_stats import RunningStats
 
         self.running_stats = RunningStats()
+
+        self.core_tokens = set(core_tokens or [])
+        self.use_shaping = use_shaping
+        self._phi_last = 0.0
+        self._episode_steps = 0
+        self.gamma = 0.99
 
         # Hint features / tokens
         self.hint_features = hint_features or []
@@ -212,6 +222,8 @@ class RuleGenEnv(gym.Env):
 
         self._hint_tokens = list(hint_tokens)
         self._tokens = []
+        self._phi_last = 0.0
+        self._episode_steps = 0
         # adjust observation space for current hint length
         self.observation_space = gym.spaces.Box(
             low=0,
@@ -231,6 +243,7 @@ class RuleGenEnv(gym.Env):
         truncated = False
         reward = 0.0
         info: dict = {}
+        self._episode_steps += 1
 
         # 1) 토큰 append
         self._tokens.append(action)
@@ -241,18 +254,36 @@ class RuleGenEnv(gym.Env):
         # 2) 종료 조건
         max_tokens = self.observation_space.shape[0]
         total_len = len(self._tokens) + len(self._hint_tokens)
+        rule_text = self._tokens_to_rule(self._tokens)
+
+        compute_reward = False
         if action == self.token2id[self.END] or total_len >= max_tokens:
             done = True
             truncated = total_len >= max_tokens
-            rule_text = self._tokens_to_rule(self._tokens)
-            final_r, metrics = self._compute_reward(rule_text)
-            if self.normalize_reward:
-                std = self.running_stats.std or 1.0
-                final_r = (final_r - self.running_stats.mean) / std
-            reward += final_r
-            info["metrics"] = metrics
+            compute_reward = True
+        elif self.use_shaping and self.core_tokens:
+            tokens_now = set(self._rule_tokenize(rule_text))
+            if set(self.core_tokens).issubset(tokens_now):
+                compute_reward = True
+
+        shaping = 0.0
+        metrics = {}
+        if compute_reward:
+            final_r, metrics, shaping = self._compute_reward(rule_text, update_stats=done)
+            if done:
+                if self.normalize_reward:
+                    std = self.running_stats.std or 1.0
+                    final_r = (final_r - self.running_stats.mean) / std
+                reward += final_r
+                info["metrics"] = metrics
+
+        if self.use_shaping:
+            reward += shaping
+            info["shaping"] = shaping
 
         obs = self._pad_obs(self._tokens)
+        if done:
+            info["episode_len"] = self._episode_steps
         return obs, reward, done, truncated, info
 
     def render(self, mode: str = "human"):
@@ -372,7 +403,7 @@ class RuleGenEnv(gym.Env):
 
     # reward
     @torch.inference_mode()
-    def _compute_reward(self, rule_text: str) -> Tuple[float, dict]:
+    def _compute_reward(self, rule_text: str, *, update_stats: bool = True) -> Tuple[float, dict, float]:
         # 1) 룰 적용 → 예측 mask
         f1_clean, f1_dummy, certified_r = self.evaluator.evaluate_rule(
             rule_text,
@@ -403,9 +434,16 @@ class RuleGenEnv(gym.Env):
             saliency_bonus=bonus,
             reward=reward,
         )
-        # update running reward statistics
-        self.running_stats.update(float(reward))
-        return reward, metrics
+        shaping = 0.0
+        if self.core_tokens:
+            used = set(self._rule_tokenize(rule_text))
+            if set(self.core_tokens).issubset(used):
+                phi = reward
+                shaping = self.gamma * phi - self._phi_last
+                self._phi_last = phi
+        if update_stats:
+            self.running_stats.update(float(reward))
+        return reward, metrics, shaping
 
     # rule string tokenizer (공용)
     @staticmethod


### PR DESCRIPTION
## Summary
- extend `RuleGenEnv` with `core_tokens` and `use_shaping`
- compute potential-based reward shaping
- record episode length and shaping info in `info`

## Testing
- `pytest tests/test_rl_env.py::test_reset_with_hints -q` *(fails: ModuleNotFoundError: No module named 'models.gnn.res_wrapper')*

------
https://chatgpt.com/codex/tasks/task_e_686e3846b9fc832eb916a1577ac0032c