### PR TITLE
Implement domain randomization and FGSM options

### DIFF
--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -150,6 +150,9 @@ def make_env(
     *,
     classifier_ckpt: str | Path = "models/gnn/res_gcl.pt",
     seed: int | None = None,
+    use_domain_rand: bool = False,
+    edge_drop_range: tuple[float, float] = (0.0, 0.1),
+    use_adv_perturb: bool = False,
     **kwargs: Any,
 ) -> RuleGenEnv:
     """
@@ -165,6 +168,24 @@ def make_env(
         seed=seed if seed is not None else 2024,
         **kwargs,
     )
+
+    env.use_adv_perturb = bool(use_adv_perturb)
+
+    if use_domain_rand:
+        from augment.ops.drop_edge import EdgeDrop
+        import random
+
+        low, high = edge_drop_range
+        rng = random.Random(seed)
+        for ds in (env.clean_set, env.dummy_set):
+            for i, g in enumerate(ds):
+                drop_p = rng.uniform(low, high)
+                keep_p = 1.0 - drop_p
+                ds[i] = EdgeDrop(keep_p)(g)
+        _LOG.info(
+            "Applied EdgeDrop domain randomization p=[%.2f, %.2f]", low, high
+        )
+
     _LOG.info("Created RuleGenEnv(rule_type=%s)", rule_type)
     return env
 

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -44,6 +44,7 @@ import re
 import gymnasium as gym
 import numpy as np
 import torch
+import torch.nn.functional as F
 from torch_geometric.loader import DataLoader  # torch_geometric 필수 조건
 from torch_geometric.data import HeteroData
 
@@ -96,6 +97,7 @@ class RuleGenEnv(gym.Env):
         normalize_reward: bool = False,
         core_tokens: Sequence[str] | None = None,
         use_shaping: bool = False,
+        use_adv_perturb: bool = False,
     ):
         """
         Parameters
@@ -165,6 +167,7 @@ class RuleGenEnv(gym.Env):
         self._phi_last = 0.0
         self._episode_steps = 0
         self.gamma = 0.99
+        self.use_adv_perturb = bool(use_adv_perturb)
 
         # Hint features / tokens
         self.hint_features = hint_features or []
@@ -336,6 +339,40 @@ class RuleGenEnv(gym.Env):
             len(self.dummy_set),
         )
 
+    def _fgsm_graph(self, g: HeteroData, label: int, epsilon: float) -> HeteroData:
+        g_adv = g.clone().to(self.device)
+        for nt in g_adv.node_types:
+            x = g_adv[nt].get("x")
+            if x is not None and torch.is_floating_point(x):
+                g_adv[nt].x = x.clone().detach().requires_grad_(True)
+
+        self.classifier.eval()
+        logit = self.classifier(g_adv, return_logits=True)
+        target = torch.tensor([float(label)], device=self.device)
+        loss = F.binary_cross_entropy_with_logits(logit.squeeze(), target)
+        self.classifier.zero_grad()
+        loss.backward()
+
+        for nt in g_adv.node_types:
+            x = g_adv[nt].get("x")
+            if x is not None and x.grad is not None:
+                adv = x + epsilon * x.grad.sign()
+                g_adv[nt].x = adv.detach()
+        return g_adv.cpu()
+
+    def _perturb_set(
+        self, dataset: Sequence[HeteroData], label: int, ratio: float, epsilon: float
+    ) -> List[HeteroData]:
+        n_adv = max(1, int(len(dataset) * ratio))
+        idx = random.sample(range(len(dataset)), n_adv)
+        out: List[HeteroData] = []
+        for i, g in enumerate(dataset):
+            if i in idx:
+                out.append(self._fgsm_graph(g, label, epsilon))
+            else:
+                out.append(g)
+        return out
+
     # 관측 pad
     def _pad_obs(self, toks: Sequence[int]) -> np.ndarray:
         obs_len = self.observation_space.shape[0]
@@ -404,11 +441,16 @@ class RuleGenEnv(gym.Env):
     # reward
     @torch.inference_mode()
     def _compute_reward(self, rule_text: str, *, update_stats: bool = True) -> Tuple[float, dict, float]:
-        # 1) 룰 적용 → 예측 mask
+        clean_set = self.clean_set
+        dummy_set = self.dummy_set
+        if self.use_adv_perturb:
+            clean_set = self._perturb_set(self.clean_set, 0, 0.2, 0.05)
+            dummy_set = self._perturb_set(self.dummy_set, 1, 0.2, 0.05)
+
         f1_clean, f1_dummy, certified_r = self.evaluator.evaluate_rule(
             rule_text,
-            self.clean_set,
-            self.dummy_set,
+            clean_set,
+            dummy_set,
         )
 
         rule_len = len(self._rule_tokenize(rule_text))


### PR DESCRIPTION
## Summary
- allow `rulegen.make_env()` to optionally apply EdgeDrop domain randomization
- add `use_adv_perturb` option and FGSM perturb routines in `RuleGenEnv`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in tests/test_ppo_train_cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_686e3b29867c832ebd8c9520935fedbf