### PR TITLE
Improve debug logging for SelfGraphCL training

### DIFF
--- a/src/augment/ops/attr_mask.py
+++ b/src/augment/ops/attr_mask.py
@@ -30,6 +30,9 @@ import math
 import numbers
 from typing import Any, List
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 import numpy as np
 import torch
 from torch_geometric.data import Data, HeteroData
@@ -77,6 +80,10 @@ class AttrMask(SimpleAug, AugmentBase):
             # 아무 것도 안 지울 때는 원본 그대로 반환
             return g
 
+        LOGGER.debug(
+            "AttrMask: start | p=%.3f cols=%s", self.p, self.cols
+        )
+
         sg = g.clone()  # 구조 공유 + feature 딥 카피
 
         # ────────────────────────────────────────────────────────────── #
@@ -99,6 +106,7 @@ class AttrMask(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
+        LOGGER.debug("AttrMask: end")
         return sg
 
     # ------------------------------------------------------------------ #
@@ -120,6 +128,12 @@ class AttrMask(SimpleAug, AugmentBase):
         if not mask_np.any():  # 모든 노드가 보존되면 최소 1개 강제 마스킹
             mask_np[self._rng.randint(0, num_nodes)] = True
         mask_bool = torch.from_numpy(mask_np).to(torch.bool)
+        LOGGER.debug(
+            "AttrMask: masking %d / %d nodes on store %s",
+            int(mask_bool.sum()),
+            num_nodes,
+            getattr(store, 'name', 'unknown'),
+        )
 
         for key in target_keys:
             feat = store[key]

--- a/src/augment/ops/drop_edge.py
+++ b/src/augment/ops/drop_edge.py
@@ -27,6 +27,9 @@ import math
 import numbers
 from typing import Any, Dict, Mapping
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 import numpy as np
 import torch
 from torch_geometric.data import Data, HeteroData
@@ -81,6 +84,7 @@ class EdgeDrop(SimpleAug, AugmentBase):
             # 삭제 확률이 0이면 그대로 반환
             return g
 
+        LOGGER.debug("EdgeDrop: start | keep_prob=%s", self.keep_prob)
         sg = g.clone()  # 구조 공유 + feature 딥 카피
 
         # ────────────────────────────────────────────────────────────── #
@@ -88,7 +92,9 @@ class EdgeDrop(SimpleAug, AugmentBase):
         # ────────────────────────────────────────────────────────────── #
         if isinstance(sg, Data):
             p = self.keep_prob.get("*", 1.0)
+            before = sg.num_edges
             self._drop_on_store(sg, p)
+            LOGGER.debug("EdgeDrop: Data edges %d -> %d", before, sg.num_edges)
 
         # ────────────────────────────────────────────────────────────── #
         # (2) heterogeneous HeteroData                                   #
@@ -98,7 +104,14 @@ class EdgeDrop(SimpleAug, AugmentBase):
                 # etype: tuple (src_ntype, rel_type, dst_ntype)
                 rel_type = etype[1]
                 p = self.keep_prob.get(rel_type, self.keep_prob.get("*", 1.0))
+                before = sg[etype].num_edges
                 self._drop_on_store(sg[etype], p)
+                LOGGER.debug(
+                    "EdgeDrop: etype %s edges %d -> %d",
+                    etype,
+                    before,
+                    sg[etype].num_edges,
+                )
 
         else:  # pragma: no cover
             raise TypeError(
@@ -106,6 +119,7 @@ class EdgeDrop(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
+        LOGGER.debug("EdgeDrop: end")
         return sg
 
     # ------------------------------------------------------------------ #

--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -17,6 +17,9 @@ import numbers
 from typing import Any, Dict, Mapping, Tuple
 
 import logging
+LOGGER = logging.getLogger(__name__)
+
+import logging
 
 import numpy as np
 import torch
@@ -89,6 +92,11 @@ class NodeDrop(SimpleAug, AugmentBase):
         torch_geometric.data.Data | HeteroData
             Node-dropped 새 그래프.
         """
+        LOGGER.debug(
+            "NodeDrop: start | keep_prob=%s target_node=%s",
+            self.keep_prob,
+            self.target_node,
+        )
         sg = g.clone()  # 구조 공유 + feature 깊은 복사
 
         if isinstance(sg, Data):
@@ -124,6 +132,20 @@ class NodeDrop(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
+        if isinstance(g, Data):
+            LOGGER.debug(
+                "NodeDrop: Data nodes %d -> %d",
+                g.num_nodes,
+                sg.num_nodes,
+            )
+        elif isinstance(g, HeteroData):
+            msg = {
+                nt: (int(g[nt].num_nodes), int(sg[nt].num_nodes))
+                for nt in g.node_types
+            }
+            LOGGER.debug("NodeDrop: Hetero nodes %s", msg)
+
+        LOGGER.debug("NodeDrop: end")
         return sg
 
     # ------------------------------------------------------------------ #

--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 import numbers
 from typing import Any, List, Tuple
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 import numpy as np
 import torch
 from torch_geometric.data import Data, HeteroData
@@ -97,6 +100,9 @@ class InjectAPICall(SimpleAug, AugmentBase):
         torch_geometric.data.Data | HeteroData
             Dummy API 노드가 주입된 **새 그래프** (원본과 동일 device).
         """
+        LOGGER.debug(
+            "InjectAPICall: start | k=%d attach_strategy=%s", self.k, self.attach_strategy
+        )
         sg = g.clone()  # 구조 공유 + feature 딥 카피
 
         if isinstance(sg, Data):
@@ -111,6 +117,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
+        LOGGER.debug("InjectAPICall: end")
         return sg
 
     # ================================================================== #
@@ -118,6 +125,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
     # ================================================================== #
     def _inject_api_homo(self, data: Data) -> None:
         device = self._pick_device(data)
+        before = data.num_nodes
 
         num_bb = data.num_nodes
         if num_bb == 0:
@@ -155,6 +163,9 @@ class InjectAPICall(SimpleAug, AugmentBase):
             data.edge_index = torch.cat([data.edge_index, new_edges], dim=1)
         else:
             data.edge_index = new_edges
+        LOGGER.debug(
+            "InjectAPICall(homo): nodes %d -> %d", before, data.num_nodes
+        )
 
     # ================================================================== #
     #                        heterogeneous HeteroData                     #
@@ -221,6 +232,9 @@ class InjectAPICall(SimpleAug, AugmentBase):
             edge_store.edge_type = torch.cat([edge_store.edge_type, new_types])
         else:
             edge_store.edge_type = new_types
+        LOGGER.debug(
+            "InjectAPICall(hetero): api nodes %d -> %d", old_api_n, api_store.num_nodes
+        )
 
     # ================================================================== #
     #                               utils                                #

--- a/src/augment/ops/swap_block.py
+++ b/src/augment/ops/swap_block.py
@@ -25,6 +25,9 @@ from torch_geometric.data import Data, HeteroData
 from augment import register_op
 from augment.base import SimpleAug, AugmentBase
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 
 @register_op
 class CodeBlockSwap(SimpleAug, AugmentBase):
@@ -56,6 +59,8 @@ class CodeBlockSwap(SimpleAug, AugmentBase):
         if math.isclose(self.prob_pair, 0.0):
             return g  # 증강 스킵
 
+        LOGGER.debug("CodeBlockSwap: start | prob_pair=%.3f", self.prob_pair)
+
         sg = g.clone()  # 구조 공유 + feature 딥 카피
 
         if isinstance(sg, Data):
@@ -70,6 +75,7 @@ class CodeBlockSwap(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
+        LOGGER.debug("CodeBlockSwap: end")
         return sg
 
     # ------------------------------------------------------------------ #
@@ -86,6 +92,8 @@ class CodeBlockSwap(SimpleAug, AugmentBase):
         n_swap_nodes = n_swap_nodes if n_swap_nodes % 2 == 0 else n_swap_nodes - 1
         if n_swap_nodes < 2:
             n_swap_nodes = 2  # 최소 1쌍
+
+        LOGGER.debug("CodeBlockSwap: swapping %d pairs", n_swap_nodes // 2)
 
         # (2) 무작위로 대상 노드 선택 후 셔플 → 페어링
         idx_pool = self._rng.choice(num_bb, size=n_swap_nodes, replace=False)

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -136,6 +136,7 @@ loads torch_geometric ``Data``/``HeteroData`` pickles from ``root``."""
                 self._data.x = self._data.feat
 
     def get(self, idx):  # type: ignore[override]
+        LOGGER.debug("Dataset get: index %d", idx)
         data = super().get(idx)
         if self.graph_meta is not None:
             meta = self.graph_meta[idx]
@@ -169,6 +170,7 @@ loads torch_geometric ``Data``/``HeteroData`` pickles from ``root``."""
         if sha is not None:
             data = self._attach_embeds(sha, data)
             data.sha256 = sha
+        LOGGER.debug("Dataset get: sha=%s types=%s", sha, getattr(data, 'node_types', 'homo'))
         return data
 
     def _attach_embeds(self, sha: str, g: Data | HeteroData) -> Data | HeteroData:
@@ -1153,7 +1155,9 @@ def _make_transform(ops: list[str], target_node: str | None):
     def filter_ops(op_list):
         return [op for op in op_list if op.__class__.__name__ in ops]
 
-    return StandardPair(filter_ops(base.ops_a), filter_ops(base.ops_b))
+    pair = StandardPair(filter_ops(base.ops_a), filter_ops(base.ops_b))
+    LOGGER.debug("Transform ops: %s", ops)
+    return pair
 
 
 def _ops_for_epoch(schedule: list[dict], epoch: int) -> list[str]:
@@ -1167,5 +1171,4 @@ def _ops_for_epoch(schedule: list[dict], epoch: int) -> list[str]:
     return []
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":    main()


### PR DESCRIPTION
## Summary
- add detailed debug logs for dataset retrieval and augmentation operations
- log active transform operations
- help pinpoint failures in augmentation or batch processing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy==1.24.1` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_686e5e28010c832eb360168feeb453c1