### PR TITLE
Improve logging visibility for encoder training

### DIFF
--- a/src/augment/ops/attr_mask.py
+++ b/src/augment/ops/attr_mask.py
@@ -80,7 +80,7 @@ class AttrMask(SimpleAug, AugmentBase):
             # 아무 것도 안 지울 때는 원본 그대로 반환
             return g
 
-        LOGGER.debug(
+        LOGGER.info(
             "AttrMask: start | p=%.3f cols=%s", self.p, self.cols
         )
 
@@ -106,7 +106,7 @@ class AttrMask(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
-        LOGGER.debug("AttrMask: end")
+        LOGGER.info("AttrMask: end")
         return sg
 
     # ------------------------------------------------------------------ #
@@ -128,7 +128,7 @@ class AttrMask(SimpleAug, AugmentBase):
         if not mask_np.any():  # 모든 노드가 보존되면 최소 1개 강제 마스킹
             mask_np[self._rng.randint(0, num_nodes)] = True
         mask_bool = torch.from_numpy(mask_np).to(torch.bool)
-        LOGGER.debug(
+        LOGGER.info(
             "AttrMask: masking %d / %d nodes on store %s",
             int(mask_bool.sum()),
             num_nodes,

--- a/src/augment/ops/drop_edge.py
+++ b/src/augment/ops/drop_edge.py
@@ -84,7 +84,7 @@ class EdgeDrop(SimpleAug, AugmentBase):
             # 삭제 확률이 0이면 그대로 반환
             return g
 
-        LOGGER.debug("EdgeDrop: start | keep_prob=%s", self.keep_prob)
+        LOGGER.info("EdgeDrop: start | keep_prob=%s", self.keep_prob)
         sg = g.clone()  # 구조 공유 + feature 딥 카피
 
         # ────────────────────────────────────────────────────────────── #
@@ -94,7 +94,7 @@ class EdgeDrop(SimpleAug, AugmentBase):
             p = self.keep_prob.get("*", 1.0)
             before = sg.num_edges
             self._drop_on_store(sg, p)
-            LOGGER.debug("EdgeDrop: Data edges %d -> %d", before, sg.num_edges)
+            LOGGER.info("EdgeDrop: Data edges %d -> %d", before, sg.num_edges)
 
         # ────────────────────────────────────────────────────────────── #
         # (2) heterogeneous HeteroData                                   #
@@ -106,7 +106,7 @@ class EdgeDrop(SimpleAug, AugmentBase):
                 p = self.keep_prob.get(rel_type, self.keep_prob.get("*", 1.0))
                 before = sg[etype].num_edges
                 self._drop_on_store(sg[etype], p)
-                LOGGER.debug(
+                LOGGER.info(
                     "EdgeDrop: etype %s edges %d -> %d",
                     etype,
                     before,
@@ -119,7 +119,7 @@ class EdgeDrop(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
-        LOGGER.debug("EdgeDrop: end")
+        LOGGER.info("EdgeDrop: end")
         return sg
 
     # ------------------------------------------------------------------ #

--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -92,7 +92,7 @@ class NodeDrop(SimpleAug, AugmentBase):
         torch_geometric.data.Data | HeteroData
             Node-dropped 새 그래프.
         """
-        LOGGER.debug(
+        LOGGER.info(
             "NodeDrop: start | keep_prob=%s target_node=%s",
             self.keep_prob,
             self.target_node,
@@ -133,7 +133,7 @@ class NodeDrop(SimpleAug, AugmentBase):
             )
 
         if isinstance(g, Data):
-            LOGGER.debug(
+            LOGGER.info(
                 "NodeDrop: Data nodes %d -> %d",
                 g.num_nodes,
                 sg.num_nodes,
@@ -143,9 +143,9 @@ class NodeDrop(SimpleAug, AugmentBase):
                 nt: (int(g[nt].num_nodes), int(sg[nt].num_nodes))
                 for nt in g.node_types
             }
-            LOGGER.debug("NodeDrop: Hetero nodes %s", msg)
+            LOGGER.info("NodeDrop: Hetero nodes %s", msg)
 
-        LOGGER.debug("NodeDrop: end")
+        LOGGER.info("NodeDrop: end")
         return sg
 
     # ------------------------------------------------------------------ #

--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -100,7 +100,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
         torch_geometric.data.Data | HeteroData
             Dummy API 노드가 주입된 **새 그래프** (원본과 동일 device).
         """
-        LOGGER.debug(
+        LOGGER.info(
             "InjectAPICall: start | k=%d attach_strategy=%s", self.k, self.attach_strategy
         )
         sg = g.clone()  # 구조 공유 + feature 딥 카피
@@ -117,7 +117,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
-        LOGGER.debug("InjectAPICall: end")
+        LOGGER.info("InjectAPICall: end")
         return sg
 
     # ================================================================== #
@@ -163,7 +163,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
             data.edge_index = torch.cat([data.edge_index, new_edges], dim=1)
         else:
             data.edge_index = new_edges
-        LOGGER.debug(
+        LOGGER.info(
             "InjectAPICall(homo): nodes %d -> %d", before, data.num_nodes
         )
 
@@ -232,7 +232,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
             edge_store.edge_type = torch.cat([edge_store.edge_type, new_types])
         else:
             edge_store.edge_type = new_types
-        LOGGER.debug(
+        LOGGER.info(
             "InjectAPICall(hetero): api nodes %d -> %d", old_api_n, api_store.num_nodes
         )
 

--- a/src/augment/ops/swap_block.py
+++ b/src/augment/ops/swap_block.py
@@ -59,7 +59,7 @@ class CodeBlockSwap(SimpleAug, AugmentBase):
         if math.isclose(self.prob_pair, 0.0):
             return g  # 증강 스킵
 
-        LOGGER.debug("CodeBlockSwap: start | prob_pair=%.3f", self.prob_pair)
+        LOGGER.info("CodeBlockSwap: start | prob_pair=%.3f", self.prob_pair)
 
         sg = g.clone()  # 구조 공유 + feature 딥 카피
 
@@ -75,7 +75,7 @@ class CodeBlockSwap(SimpleAug, AugmentBase):
                 f"got {type(sg)}"
             )
 
-        LOGGER.debug("CodeBlockSwap: end")
+        LOGGER.info("CodeBlockSwap: end")
         return sg
 
     # ------------------------------------------------------------------ #
@@ -93,7 +93,7 @@ class CodeBlockSwap(SimpleAug, AugmentBase):
         if n_swap_nodes < 2:
             n_swap_nodes = 2  # 최소 1쌍
 
-        LOGGER.debug("CodeBlockSwap: swapping %d pairs", n_swap_nodes // 2)
+        LOGGER.info("CodeBlockSwap: swapping %d pairs", n_swap_nodes // 2)
 
         # (2) 무작위로 대상 노드 선택 후 셔플 → 페어링
         idx_pool = self._rng.choice(num_bb, size=n_swap_nodes, replace=False)

--- a/src/augment/view_generators/standard_pair.py
+++ b/src/augment/view_generators/standard_pair.py
@@ -55,35 +55,35 @@ class StandardPair(ViewGenerator):
     ) -> tuple[Data | HeteroData, Data | HeteroData]:
         """원본 그래프 → (augmented g₁, augmented g₂)."""
         sha = getattr(g, 'sha256', 'unknown_sha')
-        LOGGER.debug(f"[{sha}] StandardPair.__call__ entered. Attempting deepcopy...")
+        LOGGER.info(f"[{sha}] StandardPair.__call__ entered. Attempting deepcopy...")
 
         try:
             g1 = copy.deepcopy(g)
             g2 = copy.deepcopy(g)
-            LOGGER.debug(f"[{sha}] Deepcopy successful.")
+            LOGGER.info(f"[{sha}] Deepcopy successful.")
         except Exception as e:
             LOGGER.error(f"[{sha}] CRASH during deepcopy: {e}", exc_info=True)
             raise
 
-        LOGGER.debug(f"[{sha}] Augmenting view A...")
+        LOGGER.info(f"[{sha}] Augmenting view A...")
         for op in self.ops_a:
             op_name = op.__class__.__name__
-            LOGGER.debug(f"[{sha}] Applying op {op_name} to view A.")
+            LOGGER.info(f"[{sha}] Applying op {op_name} to view A.")
             try:
                 g1 = op(g1)  # type: ignore[arg-type]
             except Exception:
                 LOGGER.warning(f"[{sha}] Failed to apply op {op_name} to view A.", exc_info=True)
         
-        LOGGER.debug(f"[{sha}] Augmenting view B...")
+        LOGGER.info(f"[{sha}] Augmenting view B...")
         for op in self.ops_b:
             op_name = op.__class__.__name__
-            LOGGER.debug(f"[{sha}] Applying op {op_name} to view B.")
+            LOGGER.info(f"[{sha}] Applying op {op_name} to view B.")
             try:
                 g2 = op(g2)  # type: ignore[arg-type]
             except Exception:
                 LOGGER.warning(f"[{sha}] Failed to apply op {op_name} to view B.", exc_info=True)
 
-        LOGGER.debug(f"[{sha}] Augmentation finished.")
+        LOGGER.info(f"[{sha}] Augmentation finished.")
         return g1, g2
 
     # ------------------------------------------------------------------ #

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -631,9 +631,9 @@ def train_epoch(
     total_loss = 0.0
     align = Alignment()
     uni = Uniformity()
-    LOGGER.debug(f"--- train_epoch {epoch} started ---")
+    LOGGER.info(f"--- train_epoch {epoch} started ---")
     for step, batch_data in enumerate(loader):
-        LOGGER.debug(f"Batch {step}: Loaded from DataLoader.")
+        LOGGER.info(f"Batch {step}: Loaded from DataLoader.")
         
         # Ensure batch_data is a Batch object
         if isinstance(batch_data, list):
@@ -651,7 +651,7 @@ def train_epoch(
 
         graphs = batch.to_data_list()
         sha = getattr(graphs[0], 'sha256', f'unknown_sha_at_step_{step}')
-        LOGGER.debug(f"Batch {step}: Processing graph {sha}. Applying transforms...")
+        LOGGER.info(f"Batch {step}: Processing graph {sha}. Applying transforms...")
 
         view1_list = []
         view2_list = []
@@ -660,30 +660,30 @@ def train_epoch(
                 v1, v2 = transform(g)
                 view1_list.append(v1)
                 view2_list.append(v2)
-            LOGGER.debug(f"Batch {step}: Graph {sha} transformed successfully.")
+            LOGGER.info(f"Batch {step}: Graph {sha} transformed successfully.")
         except Exception as e:
             LOGGER.error(f"CRASH during transform of graph {sha}: {e}", exc_info=True)
             raise
 
-        LOGGER.debug(f"Batch {step}: Collating augmented views for graph {sha}...")
+        LOGGER.info(f"Batch {step}: Collating augmented views for graph {sha}...")
         view1 = Batch.from_data_list(view1_list).to(device)
         view2 = Batch.from_data_list(view2_list).to(device)
-        LOGGER.debug(f"Batch {step}: Views moved to device. Executing model forward pass for {sha}...")
+        LOGGER.info(f"Batch {step}: Views moved to device. Executing model forward pass for {sha}...")
         
         optimizer.zero_grad(set_to_none=True)
         
         out = model(view1, view2, return_emb=True)
         loss = out["loss"]
         emb = out["emb"]
-        LOGGER.debug(f"Batch {step}: Forward pass for {sha} complete. Loss: {loss.item()}.")
+        LOGGER.info(f"Batch {step}: Forward pass for {sha} complete. Loss: {loss.item()}.")
 
         B = emb.size(0) // 2
         align.update(emb[:B], emb[B:])
         uni.update(emb)
         
-        LOGGER.debug(f"Batch {step}: Backward pass for {sha} starting...")
+        LOGGER.info(f"Batch {step}: Backward pass for {sha} starting...")
         loss.backward()
-        LOGGER.debug(f"Batch {step}: Backward pass for {sha} complete.")
+        LOGGER.info(f"Batch {step}: Backward pass for {sha} complete.")
         
         optimizer.step()
 
@@ -874,14 +874,14 @@ def main():
     schedule = _load_aug_schedule(args.config)
 
     for epoch in range(1, args.epochs + 1):
-        LOGGER.debug(f"--- Epoch {epoch}/{args.epochs} Started ---")
+        LOGGER.info(f"--- Epoch {epoch}/{args.epochs} Started ---")
         ops = _ops_for_epoch(schedule, epoch)
         transform = (
             _make_transform(ops, target_node)
             if ops
             else get_default_graphcl_transforms(target_node=target_node)
         )
-        LOGGER.debug("Using augmentation ops: %s", ops if ops else ["default"])
+        LOGGER.info("Using augmentation ops: %s", ops if ops else ["default"])
         train_ds.transform = transform
         
         # Re-create loader to apply new transform
@@ -923,7 +923,7 @@ def main():
 
             if scheduler is not None:
                 scheduler.step(epoch_loss if isinstance(scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau) else None)
-                LOGGER.debug("Scheduler step taken.")
+                LOGGER.info("Scheduler step taken.")
 
         except Exception as e:
             LOGGER.error(f"Error during epoch {epoch}: {e}", exc_info=True)
@@ -1156,7 +1156,7 @@ def _make_transform(ops: list[str], target_node: str | None):
         return [op for op in op_list if op.__class__.__name__ in ops]
 
     pair = StandardPair(filter_ops(base.ops_a), filter_ops(base.ops_b))
-    LOGGER.debug("Transform ops: %s", ops)
+    LOGGER.info("Transform ops: %s", ops)
     return pair
 
 
@@ -1169,6 +1169,5 @@ def _ops_for_epoch(schedule: list[dict], epoch: int) -> list[str]:
             ops = item.get("ops", [])
             return [str(op) for op in ops]
     return []
-
 
 if __name__ == "__main__":    main()


### PR DESCRIPTION
## Summary
- use info level for encoder training steps in `pretrain_selfgcl`
- bump augmentation op messages to info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686e6198be9c832e88b8781ea067143a