### PR TITLE
Expose sanitize_edge_index helper

### DIFF
--- a/src/graphs/utils.py
+++ b/src/graphs/utils.py
@@ -177,6 +177,45 @@ def hash_graph_structure(
     return hasher.hexdigest()
 
 
+def sanitize_edge_index(
+    store: Data | HeteroData,
+    *,
+    src_nodes: int,
+    dst_nodes: int,
+) -> Data | HeteroData:
+    """Remove edges with invalid node indices.
+
+    Edges whose source or destination IDs fall outside
+    ``[0, num_nodes - 1]`` will be dropped along with any edge
+    attributes of matching length. The input ``store`` is modified in
+    place and also returned for convenience.
+    """
+
+    edge_index = getattr(store, "edge_index", None)
+    if not isinstance(edge_index, torch.Tensor) or edge_index.numel() == 0:
+        return store
+
+    num_e = edge_index.size(1)
+    src, dst = edge_index
+    valid = (
+        (src >= 0)
+        & (src < src_nodes)
+        & (dst >= 0)
+        & (dst < dst_nodes)
+    )
+    if valid.all():
+        return store
+
+    store.edge_index = edge_index[:, valid]
+    for key, val in list(store.items()):
+        if key == "edge_index":
+            continue
+        if torch.is_tensor(val) and val.size(0) == num_e:
+            store[key] = val[valid]
+
+    return store
+
+
 __all__ = [
     "set_random_seed",
     "get_logger",
@@ -185,4 +224,5 @@ __all__ = [
     "ensure_dir",
     "graph_size_bytes",
     "hash_graph_structure",
+    "sanitize_edge_index",
 ]

--- a/tests/test_utils_sanitize_edge_index.py
+++ b/tests/test_utils_sanitize_edge_index.py
@@ -1,0 +1,30 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import Data, HeteroData
+
+from src.graphs.utils import sanitize_edge_index
+
+
+def test_sanitize_edge_index_data():
+    g = Data(
+        edge_index=torch.tensor([[0, 1, 2], [1, 3, -1]]),
+        edge_attr=torch.tensor([10, 20, 30]),
+    )
+    sanitize_edge_index(g, src_nodes=2, dst_nodes=2)
+    assert torch.equal(g.edge_index, torch.tensor([[0], [1]]))
+    assert torch.equal(g.edge_attr, torch.tensor([10]))
+
+
+def test_sanitize_edge_index_hetero():
+    g = HeteroData()
+    g["a"].num_nodes = 2
+    g["b"].num_nodes = 1
+    g[("a", "to", "b")].edge_index = torch.tensor([[0, 1], [0, 5]])
+
+    sanitize_edge_index(g[("a", "to", "b")], src_nodes=g["a"].num_nodes, dst_nodes=g["b"].num_nodes)
+
+    assert torch.equal(g[("a", "to", "b")].edge_index, torch.tensor([[0], [0]]))


### PR DESCRIPTION
## Summary
- provide public `sanitize_edge_index` util for dropping invalid edges
- export helper via `graphs.utils` module
- test new helper

## Testing
- `pytest tests/test_utils_sanitize_edge_index.py -q`
- `pytest -k sanitize_edge_index -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6882645c832eb8f09b1a89e84d60