### PR TITLE
InjectCall sanitizes new edges

### DIFF
--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -22,6 +22,8 @@ import numpy as np
 import torch
 from torch_geometric.data import Data, HeteroData
 
+from src.graphs.utils import sanitize_edge_index
+
 from augment import register_op
 from augment.base import SimpleAug, AugmentBase
 from importlib import util as _import_util
@@ -163,6 +165,16 @@ class InjectAPICall(SimpleAug, AugmentBase):
             data.edge_index = torch.cat([data.edge_index, new_edges], dim=1)
         else:
             data.edge_index = new_edges
+
+        # sanitize edges and warn if any were dropped
+        before_e = data.edge_index.size(1)
+        sanitize_edge_index(data, src_nodes=data.num_nodes, dst_nodes=data.num_nodes)
+        after_e = data.edge_index.size(1)
+        if after_e < before_e:
+            logging.warning(
+                "InjectAPICall filtered %d out-of-range edges", before_e - after_e
+            )
+
         LOGGER.info(
             "InjectAPICall(homo): nodes %d -> %d", before, data.num_nodes
         )
@@ -232,6 +244,19 @@ class InjectAPICall(SimpleAug, AugmentBase):
             edge_store.edge_type = torch.cat([edge_store.edge_type, new_types])
         else:
             edge_store.edge_type = new_types
+
+        # sanitize edges and warn if any were dropped
+        before_e = edge_store.edge_index.size(1)
+        sanitize_edge_index(
+            edge_store,
+            src_nodes=data["bb"].num_nodes or 0,
+            dst_nodes=api_store.num_nodes or 0,
+        )
+        after_e = edge_store.edge_index.size(1)
+        if after_e < before_e:
+            logging.warning(
+                "InjectAPICall filtered %d out-of-range edges", before_e - after_e
+            )
         LOGGER.info(
             "InjectAPICall(hetero): api nodes %d -> %d", old_api_n, api_store.num_nodes
         )


### PR DESCRIPTION
## Summary
- bring in `sanitize_edge_index` for `InjectAPICall`
- run the sanitation at the end of `_inject_api_homo` and `_inject_api_hetero`
- log a warning when invalid edges are removed

## Testing
- `pytest -k sanitize_edge_index -q`
- `pytest -k inject_call -q`

------
https://chatgpt.com/codex/tasks/task_e_686e69e4ddb8832eb15c53b223210cb9