### PR TITLE
Fix as_tensor call

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -335,7 +335,7 @@ loads torch_geometric ``Data``/``HeteroData`` pickles from ``root``."""
                             )
                             delattr(st, attr)
                         elif val and all(isinstance(x, (int, float)) for x in val):
-                            st[attr] = torch.as_as_tensor(val)
+                            st[attr] = torch.as_tensor(val)
                         else:
                             try:
                                 meta[attr] = json.dumps(list(val))


### PR DESCRIPTION
## Summary
- fix incorrect torch function call in `pretrain_selfgcl`

## Testing
- `pytest -q` *(fails: ImportError: Cannot import 'augment.registry'. Ensure src/augment/__init__.py exposes `registry`)*

------
https://chatgpt.com/codex/tasks/task_e_686e668cb2d0832ebf79ed3e188898c8