### PR TITLE
Sanitize StandardPair outputs

### DIFF
--- a/src/augment/view_generators/standard_pair.py
+++ b/src/augment/view_generators/standard_pair.py
@@ -83,7 +83,15 @@ class StandardPair(ViewGenerator):
             except Exception:
                 LOGGER.warning(f"[{sha}] Failed to apply op {op_name} to view B.", exc_info=True)
 
-        LOGGER.info(f"[{sha}] Augmentation finished.")
+        LOGGER.info(f"[{sha}] Augmentation finished. Sanitizing edges...")
+        try:
+            from graphs.dataset.graph_dataset import GraphDataset
+
+            g1 = GraphDataset._sanitize_edges(g1)
+            g2 = GraphDataset._sanitize_edges(g2)
+        except Exception:  # pragma: no cover - log and proceed
+            LOGGER.warning(f"[{sha}] Failed to sanitize graphs", exc_info=True)
+
         return g1, g2
 
     # ------------------------------------------------------------------ #

--- a/tests/test_standard_pair_sanitize.py
+++ b/tests/test_standard_pair_sanitize.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import Data
+
+from src.augment.view_generators.standard_pair import StandardPair
+from src.augment.base import AugmentBase
+
+
+class BadEdges(AugmentBase):
+    """Augmenter that injects invalid edges."""
+
+    def __call__(self, g: Data) -> Data:  # type: ignore[override]
+        g.edge_index = torch.tensor([[0, 5], [1, -1]])
+        return g
+
+
+def test_standard_pair_sanitizes_edges():
+    g = Data(x=torch.randn(2, 1), edge_index=torch.tensor([[0], [1]]), num_nodes=2)
+
+    aug = BadEdges()
+    vg = StandardPair([aug], [aug])
+    g1, g2 = vg(g)
+
+    assert g1.edge_index.numel() == 0
+    assert g2.edge_index.numel() == 0


### PR DESCRIPTION
## Summary
- sanitize edges after applying augmentations in `StandardPair`
- add regression test for graph sanitation

## Testing
- `pytest -q tests/test_standard_pair_sanitize.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6cc890d8832ea4055f8bb8f4fb12