### PR TITLE
Add GPU memory cleanup in pretraining

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -44,6 +44,7 @@ from typing import Sequence
 import warnings
 from collections import defaultdict
 import logging
+import gc
 import numpy as np
 
 import torch
@@ -686,6 +687,12 @@ def train_epoch(
         LOGGER.info(f"Batch {step}: Backward pass for {sha} complete.")
         
         optimizer.step()
+
+        # Explicitly free GPU memory to avoid accumulation
+        del view1, view2, out, emb, loss
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         total_loss += loss.item()
         if (step + 1) % log_interval == 0:


### PR DESCRIPTION
## Summary
- free GPU memory after each batch during `pretrain_selfgcl` execution
- import `gc` for memory management utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e7387d090832e97d867dcb48a2c09