### PR TITLE
Fix train_epoch loss deletion order

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -688,13 +688,13 @@ def train_epoch(
         
         optimizer.step()
 
+        total_loss += loss.item()
+
         # Explicitly free GPU memory to avoid accumulation
         del view1, view2, out, emb, loss
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-
-        total_loss += loss.item()
         if (step + 1) % log_interval == 0:
             LOGGER.info(
                 "Epoch %d | Step %d/%d | Loss %.4f",


### PR DESCRIPTION
## Summary
- accumulate loss before deleting loss tensor in `train_epoch`
- ran partial tests to ensure functionality

## Testing
- `pytest tests/test_selfgcl_dataset.py -k meta -q`
- `pytest tests/test_selfgcl_dataset.py -k test_hetero_disk_dataset_meta -q`


------
https://chatgpt.com/codex/tasks/task_e_686e77ab0bf8832e9b9c5b9196c5329b