### PR TITLE
Add memory usage info to logger

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -17,6 +17,7 @@ Key Features
 * ``tqdm_wrap``       – safe import wrapper: returns *tqdm* if available else
                        the original iterable (graceful degradation).
 * ``human_bytes``     – convert raw byte counts to **GiB, MiB, KiB** strings.
+* ``MemoryUsageFilter`` – add RAM/VRAM info to logger output.
 * ``flatten_dict``    – flatten nested mapping into ``"a.b.c"`` dotted keys.
 * ``get_device``      – auto‑detect *CUDA/MPS* → *torch.device* helper.
 * ``to_numpy`` / ``to_tensor`` – zero‑copy conversions where possible.
@@ -34,6 +35,8 @@ import os
 import random
 import sys
 import time
+
+import psutil
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Dict, Generator, Iterable, Iterator, Mapping, MutableMapping, Optional, Tuple, Type, TypeVar, Union
@@ -50,6 +53,26 @@ except ImportError as _e:  # pragma: no cover – torch is optional in some envs
 # ---------------------------------------------------------------------------
 
 _LOGGERS: dict[str, logging.Logger] = {}
+
+
+class MemoryUsageFilter(logging.Filter):
+    """Attach RAM and VRAM usage information to log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        try:
+            process = psutil.Process(os.getpid())
+            record.ram = human_bytes(process.memory_info().rss)
+        except Exception:
+            record.ram = "n/a"
+
+        if torch is not None and torch.cuda.is_available():
+            try:
+                record.vram = human_bytes(int(torch.cuda.memory_allocated()))
+            except Exception:
+                record.vram = "n/a"
+        else:
+            record.vram = "n/a"
+        return True
 
 
 def _build_colour_formatter() -> logging.Formatter:
@@ -70,7 +93,10 @@ def _build_colour_formatter() -> logging.Formatter:
             msg = super().format(record).replace("-", "-").replace("–", "-")  # CP949 우회
             return f"{prefix} {msg}"
 
-    return _AnsiFormatter("%(asctime)s | %(name)s | %(message)s", "%Y-%m-%d %H:%M:%S")
+    return _AnsiFormatter(
+        "%(asctime)s | %(name)s | RAM %(ram)s | VRAM %(vram)s | %(message)s",
+        "%Y-%m-%d %H:%M:%S",
+    )
 
 
 def get_logger(name: str = "robust‑mg", level: int = logging.INFO) -> logging.Logger:  # noqa: D401
@@ -83,6 +109,7 @@ def get_logger(name: str = "robust‑mg", level: int = logging.INFO) -> logging.
     logger.propagate = False  # avoid double messages if root also configured
 
     handler = logging.StreamHandler(sys.stdout)
+    handler.addFilter(MemoryUsageFilter())
     handler.setFormatter(_build_colour_formatter())
     logger.addHandler(handler)
 
@@ -377,6 +404,7 @@ __all__ = [
     "get_device",
     "get_logger",
     "human_bytes",
+    "MemoryUsageFilter",
     "filter_state_dict",
     "set_random_seed",
     "sha256sum",

--- a/tests/test_logger_memory.py
+++ b/tests/test_logger_memory.py
@@ -1,0 +1,10 @@
+import logging
+
+from src.common.utils import get_logger
+
+
+def test_logger_adds_memory_usage(caplog):
+    logger = get_logger("test_mem")
+    caplog.set_level("INFO", logger=logger.name)
+    logger.info("hello")
+    assert "RAM" in caplog.text and "VRAM" in caplog.text


### PR DESCRIPTION
## Summary
- extend `get_logger` to include RAM/VRAM usage in all log messages
- expose `MemoryUsageFilter` to attach the usage info
- test that logger output includes RAM and VRAM

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e7d39dd40832e976538ed1be6b372