### PR TITLE
Disable mmap when loading embeds

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -183,7 +183,7 @@ loads torch_geometric ``Data``/``HeteroData`` pickles from ``root``."""
         if not isinstance(g, HeteroData) or NodeType.TOKEN.value not in g.node_types:
             return g
         try:
-            feat = load_tensor(sha, self.embed_dir)
+            feat = load_tensor(sha, self.embed_dir, mmap=False)
         except Exception as exc:  # pragma: no cover - unexpected I/O errors
             warnings.warn(f"failed to load embed for {sha}: {exc}")
             return g

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -389,7 +389,7 @@ class GraphDataset(Dataset):
         if not isinstance(g, HeteroData) or "token" not in g.node_types:
             return g
         try:
-            feat = load_tensor(sha, self.embed_dir)
+            feat = load_tensor(sha, self.embed_dir, mmap=False)
         except Exception as exc:  # pragma: no cover - unexpected I/O errors
             warnings.warn(f"failed to load embed for {sha}: {exc}")
             return g

--- a/tests/test_graph_dataset_embeds.py
+++ b/tests/test_graph_dataset_embeds.py
@@ -33,3 +33,22 @@ def test_dataset_disable_embeds(tmp_path):
     ds = GraphDataset(tmp_path, split="train", label_file=None, load_embeds=False)
     g, _, _ = ds[0]
     assert not hasattr(g["token"], "x")
+
+
+def test_dataset_loads_embeds_no_mmap(tmp_path, monkeypatch):
+    feat = _setup(tmp_path)
+
+    called = {}
+
+    def fake_load_tensor(name, dir_, *, mmap=True):
+        called['mmap'] = mmap
+        return feat
+
+    monkeypatch.setattr(
+        "src.graphs.dataset.graph_dataset.load_tensor", fake_load_tensor
+    )
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    g, _, _ = ds[0]
+    assert torch.allclose(g["token"].x, feat)
+    assert called.get('mmap') is False

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -346,6 +346,36 @@ def test_disable_embeds(tmp_path, monkeypatch):
     assert not hasattr(data["token"], "x")
 
 
+def test_load_embeds_no_mmap(tmp_path, monkeypatch):
+    graph_dir = tmp_path / "graphs"
+    graph_dir.mkdir()
+
+    g = HeteroData()
+    g["token"].num_nodes = 2
+    torch.save(g, graph_dir / "a.pt")
+
+    feat = torch.randn(2, 3)
+    save_tensor("a", feat, tmp_path / "embeds")
+
+    vocab_path = tmp_path / "vocab.json"
+    monkeypatch.setattr(HeteroGraphDiskDataset, "VOCAB_PATH", vocab_path)
+
+    called = {}
+
+    def fake_load_tensor(name, dir_, *, mmap=True):
+        called['mmap'] = mmap
+        return feat
+
+    monkeypatch.setattr("src.cli.pretrain_selfgcl.load_tensor", fake_load_tensor)
+
+    ds = HeteroGraphDiskDataset(
+        graph_dir, load_embeds=True, embed_dir=tmp_path / "embeds"
+    )
+    data = ds[0]
+    assert torch.allclose(data["token"].x, feat)
+    assert called.get('mmap') is False
+
+
 def test_empty_api_num_nodes(tmp_path, monkeypatch, caplog):
     graph_dir = tmp_path / "graphs"
     graph_dir.mkdir()


### PR DESCRIPTION
## Summary
- disable mmap for SelfGraphCL training dataset
- disable mmap for GraphDataset embed loading
- check mmap flag in embed tests for GraphDataset and SelfGraphCL dataset

## Testing
- `pytest -q tests/test_graph_dataset_embeds.py tests/test_selfgcl_dataset.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686e821ff524832eb443e4439b043601