### PR TITLE
Add PyTorch/PyG version logging

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -51,6 +51,7 @@ import torch
 from torch.serialization import add_safe_globals
 from torch.utils.data import DataLoader, Dataset
 from torch_geometric.data import Data, HeteroData, InMemoryDataset, Batch
+import torch_geometric
 import torch.nn.functional as F
 from torch_geometric.loader import DataLoader as PyGLoader
 
@@ -770,6 +771,8 @@ def main():
         f"cuda:{args.gpu}" if args.gpu >= 0 and torch.cuda.is_available() else "cpu"
     )
     LOGGER.info("Using device: %s", device)
+    LOGGER.info("PyTorch version: %s", torch.__version__)
+    LOGGER.info("PyG version: %s", getattr(torch_geometric, "__version__", "n/a"))
 
     # --------------------------------------------------------------------- #
     # Dataset & Loader


### PR DESCRIPTION
## Summary
- log the installed PyTorch and PyG versions when starting pretraining

## Testing
- `pytest tests/test_split_generator.py::test_time_split_generator -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686e81f3e390832eb698920f5dbed8d9