### PR TITLE
Support DataListLoader for selfGCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ python -m cli.pretrain_selfgcl data/hetero \
     --output models/gnn/encoder.pt \
     --plot-path results/train_plot.png
 
+# DataLoader 충돌이 발생한다면 --list-loader 옵션을 사용해 보세요.
+# PyG의 DataListLoader를 사용하여 개별 그래프를 리스트로 처리합니다.
+
 # 위 명령을 실행하면 encoder.pt와 함께 그래프 메타데이터가
 # models/gnn/encoder.meta.pkl로 저장됩니다. 이 파일에는
 # `node_types`, `edge_types`, `in_dims`, `num_relations` 외에도

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -53,7 +53,7 @@ from torch.utils.data import DataLoader, Dataset
 from torch_geometric.data import Data, HeteroData, InMemoryDataset, Batch
 import torch_geometric
 import torch.nn.functional as F
-from torch_geometric.loader import DataLoader as PyGLoader
+from torch_geometric.loader import DataLoader as PyGLoader, DataListLoader
 
 # Project internal imports ----------------------------------------------------
 from common.utils import set_random_seed, get_logger, ensure_dir
@@ -636,22 +636,20 @@ def train_epoch(
     LOGGER.info(f"--- train_epoch {epoch} started ---")
     for step, batch_data in enumerate(loader):
         LOGGER.info(f"Batch {step}: Loaded from DataLoader.")
-        
-        # Ensure batch_data is a Batch object
+
         if isinstance(batch_data, list):
-            batch = Batch.from_data_list(batch_data)
+            graphs = batch_data
         else:
             batch = batch_data
-
-        if not isinstance(batch, (Data, HeteroData)):
-             # If it's in a dict, extract it
-            if isinstance(batch, dict) and "graph" in batch:
-                batch = batch["graph"]
-            else:
-                LOGGER.error(f"Batch {step}: Unexpected data type from loader: {type(batch)}")
-                continue
-
-        graphs = batch.to_data_list()
+            if not isinstance(batch, (Data, HeteroData)):
+                if isinstance(batch, dict) and "graph" in batch:
+                    batch = batch["graph"]
+                else:
+                    LOGGER.error(
+                        f"Batch {step}: Unexpected data type from loader: {type(batch)}"
+                    )
+                    continue
+            graphs = batch.to_data_list()
         sha = getattr(graphs[0], 'sha256', f'unknown_sha_at_step_{step}')
         LOGGER.info(f"Batch {step}: Processing graph {sha}. Applying transforms...")
 
@@ -729,6 +727,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--gpu", type=int, default=0, help="CUDA device id (1 CPU)")
     p.add_argument("--num-workers", type=int, default=4)
+    p.add_argument(
+        "--list-loader",
+        action="store_true",
+        help="Use DataListLoader instead of PyGLoader (workaround for batch crashes)",
+    )
     p.add_argument(
         "--embed-dir",
         type=Path,
@@ -831,7 +834,8 @@ def main():
 
     LOGGER.info("Step 4: Creating DataLoader...")
     try:
-        train_loader = PyGLoader(
+        loader_cls = DataListLoader if args.list_loader else PyGLoader
+        train_loader = loader_cls(
             train_ds,
             batch_size=args.batch_size,
             shuffle=True,
@@ -895,7 +899,8 @@ def main():
         train_ds.transform = transform
         
         # Re-create loader to apply new transform
-        train_loader = PyGLoader(
+        loader_cls = DataListLoader if args.list_loader else PyGLoader
+        train_loader = loader_cls(
             train_ds,
             batch_size=args.batch_size,
             shuffle=True,


### PR DESCRIPTION
## Summary
- add `--list-loader` to pretrain_selfgcl CLI
- handle DataListLoader batches in `train_epoch`
- instantiate DataListLoader when the flag is used
- document the option in README

## Testing
- `pytest -k selfgcl_dataset -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_686e97d6ebe4832ea4fb5f5c4ac4a17f