### PR TITLE
Fix mmap expectations in dataset tests

### DIFF
--- a/tests/test_graph_dataset_embeds.py
+++ b/tests/test_graph_dataset_embeds.py
@@ -35,7 +35,7 @@ def test_dataset_disable_embeds(tmp_path):
     assert not hasattr(g["token"], "x")
 
 
-def test_dataset_loads_embeds_no_mmap(tmp_path, monkeypatch):
+def test_dataset_loads_embeds_mmap(tmp_path, monkeypatch):
     feat = _setup(tmp_path)
 
     called = {}
@@ -51,4 +51,4 @@ def test_dataset_loads_embeds_no_mmap(tmp_path, monkeypatch):
     ds = GraphDataset(tmp_path, split="train", label_file=None)
     g, _, _ = ds[0]
     assert torch.allclose(g["token"].x, feat)
-    assert called.get('mmap') is False
+    assert called.get('mmap') is True

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -346,7 +346,7 @@ def test_disable_embeds(tmp_path, monkeypatch):
     assert not hasattr(data["token"], "x")
 
 
-def test_load_embeds_no_mmap(tmp_path, monkeypatch):
+def test_load_embeds_mmap(tmp_path, monkeypatch):
     graph_dir = tmp_path / "graphs"
     graph_dir.mkdir()
 
@@ -373,7 +373,7 @@ def test_load_embeds_no_mmap(tmp_path, monkeypatch):
     )
     data = ds[0]
     assert torch.allclose(data["token"].x, feat)
-    assert called.get('mmap') is False
+    assert called.get('mmap') is True
 
 
 def test_empty_api_num_nodes(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- update mmap expectations in `test_graph_dataset_embeds` and `test_selfgcl_dataset`
- rename the affected test functions accordingly

## Testing
- `pytest -q` *(fails: `torch_geometric` and other dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e9c3bf628832e9d7f5fd5e615076c