### PR TITLE
Enable mmap for embed loading

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -183,8 +183,10 @@ loads torch_geometric ``Data``/``HeteroData`` pickles from ``root``."""
             return g
         if not isinstance(g, HeteroData) or NodeType.TOKEN.value not in g.node_types:
             return g
+        # ``load_tensor`` uses memory mapping by default for faster feature
+        # retrieval.
         try:
-            feat = load_tensor(sha, self.embed_dir, mmap=False)
+            feat = load_tensor(sha, self.embed_dir)
         except Exception as exc:  # pragma: no cover - unexpected I/O errors
             warnings.warn(f"failed to load embed for {sha}: {exc}")
             return g

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -388,8 +388,9 @@ class GraphDataset(Dataset):
             return g
         if not isinstance(g, HeteroData) or "token" not in g.node_types:
             return g
+        # ``load_tensor`` memory-maps feature files by default for efficient I/O.
         try:
-            feat = load_tensor(sha, self.embed_dir, mmap=False)
+            feat = load_tensor(sha, self.embed_dir)
         except Exception as exc:  # pragma: no cover - unexpected I/O errors
             warnings.warn(f"failed to load embed for {sha}: {exc}")
             return g

--- a/tests/test_graph_dataset_embeds.py
+++ b/tests/test_graph_dataset_embeds.py
@@ -35,7 +35,7 @@ def test_dataset_disable_embeds(tmp_path):
     assert not hasattr(g["token"], "x")
 
 
-def test_dataset_loads_embeds_no_mmap(tmp_path, monkeypatch):
+def test_dataset_loads_embeds_mmap(tmp_path, monkeypatch):
     feat = _setup(tmp_path)
 
     called = {}
@@ -51,4 +51,5 @@ def test_dataset_loads_embeds_no_mmap(tmp_path, monkeypatch):
     ds = GraphDataset(tmp_path, split="train", label_file=None)
     g, _, _ = ds[0]
     assert torch.allclose(g["token"].x, feat)
-    assert called.get('mmap') is False
+    # Embedding tensors should be loaded using memory mapping by default
+    assert called.get('mmap') is True

--- a/tests/test_selfgcl_dataset.py
+++ b/tests/test_selfgcl_dataset.py
@@ -346,7 +346,7 @@ def test_disable_embeds(tmp_path, monkeypatch):
     assert not hasattr(data["token"], "x")
 
 
-def test_load_embeds_no_mmap(tmp_path, monkeypatch):
+def test_load_embeds_mmap(tmp_path, monkeypatch):
     graph_dir = tmp_path / "graphs"
     graph_dir.mkdir()
 
@@ -373,7 +373,8 @@ def test_load_embeds_no_mmap(tmp_path, monkeypatch):
     )
     data = ds[0]
     assert torch.allclose(data["token"].x, feat)
-    assert called.get('mmap') is False
+    # ``load_tensor`` should default to memory mapping
+    assert called.get('mmap') is True
 
 
 def test_empty_api_num_nodes(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- memory-map embedding files in graph loaders
- update tests for mmap default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_686e9c33ea70832e993b8d3ecf391b85