### PR TITLE
Set spawn start method for pretrain_selfgcl

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -48,6 +48,7 @@ import gc
 import numpy as np
 
 import torch
+import torch.multiprocessing as mp
 from torch.serialization import add_safe_globals
 from torch.utils.data import DataLoader, Dataset
 from torch_geometric.data import Data, HeteroData, InMemoryDataset, Batch
@@ -762,6 +763,8 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
+    # PyArrow can segfault with fork; ensure safer spawn start method
+    mp.set_start_method("spawn", force=True)
     set_random_seed(args.seed)
 
     # --------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- ensure `spawn` multiprocessing start method in pretraining CLI for PyArrow safety

## Testing
- `pytest tests/test_selfgcl_dataset.py -q`
- `pytest -q` *(fails: ImportError: augment registry, archinfo, omegaconf not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ea10694c8832e9e5405b2feeadc3c