### PR TITLE
Fix unpicklable RNG in augment ops

### DIFF
--- a/src/augment/domain/obfusc_patch.py
+++ b/src/augment/domain/obfusc_patch.py
@@ -51,7 +51,7 @@ class ObfuscPatch(SimpleAug, AugmentBase):
         self.insert_ratio = float(insert_ratio)
         self.remove_original = bool(remove_original)
         self.junk_feat_dim = junk_feat_dim
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
         super().__init__(
             insert_ratio=self.insert_ratio,
             remove_original=self.remove_original,

--- a/src/augment/domain/syscall_shuffle.py
+++ b/src/augment/domain/syscall_shuffle.py
@@ -56,7 +56,7 @@ class SysCallShuffle(SimpleAug, AugmentBase[HeteroData]):
         self.prob = float(prob)
         self.seq_key = seq_key
         self.tid_key = tid_key
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
 
         super().__init__(
             win=self.win,

--- a/src/augment/ops/attr_mask.py
+++ b/src/augment/ops/attr_mask.py
@@ -56,7 +56,7 @@ class AttrMask(SimpleAug, AugmentBase):
             raise ValueError("p must be a float in [0, 1]")
         self.p: float = float(p)
         self.cols: List[str] | None = list(cols) if cols else None
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
 
         # SimpleAug → name / hyperparams() 자동 제공
         super().__init__(p=self.p, cols=self.cols, seed=seed, **kwargs)

--- a/src/augment/ops/drop_edge.py
+++ b/src/augment/ops/drop_edge.py
@@ -59,7 +59,7 @@ class EdgeDrop(SimpleAug, AugmentBase):
                     raise ValueError("keep_prob dict values must be in [0, 1]")
 
         self.keep_prob: Dict[str, float] = dict(keep_prob)
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
 
         super().__init__(keep_prob=self.keep_prob, seed=seed, **kwargs)
 

--- a/src/augment/ops/drop_node.py
+++ b/src/augment/ops/drop_node.py
@@ -73,7 +73,7 @@ class NodeDrop(SimpleAug, AugmentBase):
 
         self.keep_prob: Dict[str, float] = dict(keep_prob)
         self.target_node = target_node
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
 
         super().__init__(keep_prob=self.keep_prob, seed=seed, target_node=target_node, **kwargs)
 

--- a/src/augment/ops/inject_call.py
+++ b/src/augment/ops/inject_call.py
@@ -80,7 +80,7 @@ class InjectAPICall(SimpleAug, AugmentBase):
         self.api_vocab = api_vocab or self._DEFAULT_API_VOCAB
         self.k = int(k)
         self.attach_strategy = attach_strategy
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
         self.feat_dim = int(feat_dim)
 
         super().__init__(

--- a/src/augment/ops/swap_block.py
+++ b/src/augment/ops/swap_block.py
@@ -42,7 +42,7 @@ class CodeBlockSwap(SimpleAug, AugmentBase):
         if not isinstance(prob_pair, numbers.Real) or not 0.0 <= prob_pair <= 1.0:
             raise ValueError("prob_pair must be a float in [0, 1]")
         self.prob_pair: float = float(prob_pair)
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
 
         super().__init__(prob_pair=self.prob_pair, seed=seed, **kwargs)
 

--- a/src/augment/view_generators/random_pair.py
+++ b/src/augment/view_generators/random_pair.py
@@ -67,7 +67,7 @@ class RandomPair(ViewGenerator):
         self.k = int(k)
         self.replace = bool(replace)
         self.unique = bool(unique)
-        self._rng = np.random.RandomState(seed) if seed is not None else np.random
+        self._rng = np.random.RandomState(seed)
 
     # ------------------------------------------------------------------ #
     # 내부: 시퀀스 샘플링


### PR DESCRIPTION
## Summary
- use `np.random.RandomState(seed)` across augment ops

This ensures augment operations can be pickled for multi-processing dataloaders.

## Testing
- `pip install psutil numpy torch`
- `pytest -q` *(fails: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ea3de2928832e8cae0a37fedb0ae2