### PR TITLE
Fix open file issue by disabling mmap

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -322,7 +322,8 @@ def _attach_embeddings(graph: HeteroData, sha: str, embed_dir: Path) -> None:
         embed_file = embed_dir / f"{sha}.ftr"
         if embed_file.is_file():
             try:
-                graph["token"].x = load_tensor(sha, embed_dir)
+                # Disable memory mapping to avoid excessive open file handles
+                graph["token"].x = load_tensor(sha, embed_dir, mmap=False)
             except Exception as e:
                 LOGGER.warning(f"Could not attach embedding for {sha}: {e}")
 

--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -185,9 +185,9 @@ loads torch_geometric ``Data``/``HeteroData`` pickles from ``root``."""
         if not isinstance(g, HeteroData) or NodeType.TOKEN.value not in g.node_types:
             return g
         # ``load_tensor`` uses memory mapping by default for faster feature
-        # retrieval.
+        # retrieval. Disable mmap to avoid hitting OS file descriptor limits.
         try:
-            feat = load_tensor(sha, self.embed_dir)
+            feat = load_tensor(sha, self.embed_dir, mmap=False)
         except Exception as exc:  # pragma: no cover - unexpected I/O errors
             warnings.warn(f"failed to load embed for {sha}: {exc}")
             return g

--- a/src/explain/train_selector.py
+++ b/src/explain/train_selector.py
@@ -100,7 +100,9 @@ def main():
     if sha and "token" in graph.node_types:
         embed_file = args.embed_dir / f"{sha}.ftr"
         if embed_file.is_file():
-            graph["token"].x = load_tensor(sha, args.embed_dir)
+            # Use mmap=False to prevent "Too many open files" errors in
+            # environments with limited file descriptors.
+            graph["token"].x = load_tensor(sha, args.embed_dir, mmap=False)
 
     graph = GraphDataset._ensure_num_nodes(graph)
     graph = GraphDataset._ensure_x(graph)

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -389,8 +389,10 @@ class GraphDataset(Dataset):
         if not isinstance(g, HeteroData) or "token" not in g.node_types:
             return g
         # ``load_tensor`` memory-maps feature files by default for efficient I/O.
+        # For environments with low file descriptor limits this may lead to
+        # "Too many open files" errors, so we explicitly disable mmap here.
         try:
-            feat = load_tensor(sha, self.embed_dir)
+            feat = load_tensor(sha, self.embed_dir, mmap=False)
         except Exception as exc:  # pragma: no cover - unexpected I/O errors
             warnings.warn(f"failed to load embed for {sha}: {exc}")
             return g


### PR DESCRIPTION
## Summary
- avoid mmap when attaching embeddings in `GraphDataset`
- disable mmap for embeddings in `explainer_train` CLI
- disable mmap for embeddings in `pretrain_selfgcl` CLI
- disable mmap for embeddings in explainer `train_selector`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ead156bb0832e9dfa18652f8f3c58