### PR TITLE
Call clear_memory_cache during SelfGraphCL pretraining

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -58,7 +58,7 @@ from torch_geometric.loader import DataLoader as PyGLoader, DataListLoader
 
 # Project internal imports ----------------------------------------------------
 from common.utils import set_random_seed, get_logger, ensure_dir
-from graphs.features.cache import load_tensor
+from graphs.features.cache import load_tensor, clear_memory_cache
 from src.graphs.normalizers.schema import NodeType, EdgeRel, NODE_ATTRS
 from augment.ops.inject_call import InjectAPICall
 from augment import auto_aug  # noqa: F401 (registers policies)
@@ -697,6 +697,7 @@ def train_epoch(
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        clear_memory_cache()
         if (step + 1) % log_interval == 0:
             LOGGER.info(
                 "Epoch %d | Step %d/%d | Loss %.4f",
@@ -705,6 +706,7 @@ def train_epoch(
                 len(loader),
                 total_loss / (step + 1),
             )
+    clear_memory_cache()
     avg = total_loss / len(loader)
     return avg, {"alignment": align.compute(), "uniformity": uni.compute()}
 


### PR DESCRIPTION
## Summary
- free feature cache regularly in `pretrain_selfgcl`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686eb98b61dc832e892ca0f3e7928825