### PR TITLE
Fix train_epoch parsing of batch data

### DIFF
--- a/src/cli/pretrain_selfgcl.py
+++ b/src/cli/pretrain_selfgcl.py
@@ -640,8 +640,24 @@ def train_epoch(
     for step, batch_data in enumerate(loader):
         LOGGER.info(f"Batch {step}: Loaded from DataLoader.")
 
+        graphs: list[Data | HeteroData] = []
+        first_item = batch_data[0] if isinstance(batch_data, list) else batch_data
+
         if isinstance(batch_data, list):
-            graphs = batch_data
+            for itm in batch_data:
+                if isinstance(itm, (Data, HeteroData)):
+                    graphs.append(itm)
+                elif isinstance(itm, (tuple, list)) and len(itm) == 3:
+                    graphs.append(itm[0])
+                elif isinstance(itm, dict) and "graph" in itm:
+                    graphs.append(itm["graph"])
+                else:
+                    LOGGER.warning(
+                        "Batch %d: Unexpected item type %s; skipping", step, type(itm)
+                    )
+            if not graphs:
+                LOGGER.warning("Batch %d: No valid graphs found, skipping", step)
+                continue
         else:
             batch = batch_data
             if not isinstance(batch, (Data, HeteroData)):
@@ -653,7 +669,19 @@ def train_epoch(
                     )
                     continue
             graphs = batch.to_data_list()
-        sha = getattr(graphs[0], 'sha256', f'unknown_sha_at_step_{step}')
+
+        sha = None
+        if isinstance(first_item, (tuple, list)) and len(first_item) == 3:
+            sha = first_item[2]
+        elif isinstance(first_item, dict):
+            if "ids" in first_item and isinstance(first_item["ids"], Sequence):
+                sha = first_item["ids"][0]
+            elif "sha256" in first_item:
+                sha = first_item["sha256"]
+        if sha is None and hasattr(graphs[0], "sha256"):
+            sha = getattr(graphs[0], "sha256")
+        if sha is None:
+            sha = f"unknown_sha_at_step_{step}"
         LOGGER.info(f"Batch {step}: Processing graph {sha}. Applying transforms...")
 
         view1_list = []


### PR DESCRIPTION
## Summary
- handle `(graph, label, sha)` entries in `train_epoch`
- ensure SHA extraction from original items

## Testing
- `pytest -q` *(fails: missing optional dependencies such as pyarrow, matplotlib, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ec30697d4832eb5d060c40b68fe9d