### PR TITLE
Fix removal of batch fields in GraphDataset

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -165,6 +165,7 @@ class GraphDataset(Dataset):
     def __getitem__(self, idx: int) -> Tuple[GraphT, int | None, str]:
         sha = self.samples[idx]
         g = self._load_graph(sha)
+        g = GraphDataset._remove_batch(g)
         
         if isinstance(g, HeteroData):
             for node_type in g.node_types:
@@ -210,7 +211,7 @@ class GraphDataset(Dataset):
         """
 
         graphs, labels, ids = zip(*batch)
-
+        graphs = [GraphDataset._remove_batch(g) for g in graphs]
         # ensure num_nodes metadata is present for all graphs and
         # populate missing 'x' tensors consistently
         graphs = [GraphDataset._ensure_num_nodes(g) for g in graphs]
@@ -403,6 +404,20 @@ class GraphDataset(Dataset):
             store.feat = feat
         else:
             store.x = feat
+        return g
+
+    # --------------------------------------------------------------
+    @staticmethod
+    def _remove_batch(g: GraphT) -> GraphT:
+        """Remove ``batch`` attributes from node stores."""
+
+        if isinstance(g, HeteroData):
+            for ntype in g.node_types:
+                if hasattr(g[ntype], "batch"):
+                    delattr(g[ntype], "batch")
+        elif isinstance(g, Data):
+            if hasattr(g, "batch"):
+                delattr(g, "batch")
         return g
 
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `_remove_batch` helper
- ensure loaded graphs and collated graphs are cleared of `batch` attributes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686ecd36b8b8832e9befeb4306a0a25c