### PR TITLE
Add edge-type specific support to PGExplainer

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1207,6 +1207,7 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
 def train_batch(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
     model = _load_model(args, device)
+
     _train_batch_impl(args, model, device)
 
 
@@ -1381,6 +1382,15 @@ def train_global(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
     model = _load_model(args, device)
 
+    meta_path = args.model.with_suffix(".meta.pkl")
+    from src.graphs.normalizers.schema import NodeType
+    from torch.serialization import add_safe_globals
+
+    add_safe_globals([NodeType])
+    meta_info = torch.load(meta_path, weights_only=False)
+    edge_types = [tuple(map(lambda x: getattr(x, "value", x), et)) for et in meta_info["edge_types"]]
+    in_dims = {getattr(k, "value", k): int(v) for k, v in meta_info["in_dims"].items()}
+
     graph_paths = sorted(Path(args.graph_dir).glob("*.pt"))
     if not graph_paths:
         raise ValueError(f"No graphs found in {args.graph_dir}")
@@ -1403,6 +1413,8 @@ def train_global(args: argparse.Namespace) -> None:
     explainer = PGExplainer(
         model=model,
         embed_dim=model.encoder.out_proj.in_features,
+        in_dims=in_dims,
+        edge_types=edge_types,
         view=args.view,
         device=device,
     )

--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -8,7 +8,7 @@
 # --------------------------------------------------------------------------- #
 from __future__ import annotations
 
-from typing import Dict, Mapping
+from typing import Dict, Mapping, Iterable
 
 import torch
 import torch.nn as nn
@@ -16,18 +16,24 @@ import torch.nn.functional as F
 from torch_geometric.data import Data, HeteroData
 
 from .cfg_explainer.selector import gumbel_sigmoid, iter_edge_types, edge_mask_to_global
+from .utils.hetero import EdgeType
 
 
 class PGExplainer(nn.Module):
-    """Simple PGExplainer for heterogeneous graphs.
+    """Simple PGExplainer for (heterogeneous) graphs.
 
-    ``view`` may be ``None`` to operate on the full graph.
+    ``view`` may be ``None`` to operate on the full graph.  Edge scoring MLPs
+    are created per ``edge_type`` based on the provided ``in_dims`` mapping.
+    Homogeneous :class:`~torch_geometric.data.Data` graphs fall back to the
+    ``"default"`` MLP.
     """
 
     def __init__(
         self,
         model: nn.Module,
         embed_dim: int,
+        in_dims: Dict[str, int],
+        edge_types: Iterable[EdgeType],
         *,
         hidden_dim: int = 64,
         num_layers: int = 2,
@@ -41,7 +47,13 @@ class PGExplainer(nn.Module):
         model : nn.Module
             GNN model being explained.
         embed_dim : int
-            Dimension of node embeddings provided to ``forward``.
+            Dimension of node embeddings provided to ``forward`` when operating
+            on a homogeneous :class:`~torch_geometric.data.Data` graph.
+        in_dims : Dict[str, int]
+            Mapping of node types to embedding dimensions. Used to size the
+            per-edge-type MLPs for heterogeneous graphs.
+        edge_types : Iterable[EdgeType]
+            Iterable of edge types for which edge scoring MLPs are created.
         hidden_dim : int, optional
             Hidden size for the edge scoring MLP.
         num_layers : int, optional
@@ -55,14 +67,21 @@ class PGExplainer(nn.Module):
         self.model = model
         self.view = view
 
-        layers = []
-        in_dim = embed_dim * 2
-        dim_list = [in_dim] + [hidden_dim] * (num_layers - 1) + [1]
-        for d_in, d_out in zip(dim_list[:-2], dim_list[1:-1]):
-            layers.append(nn.Linear(d_in, d_out))
-            layers.append(nn.ReLU())
-        layers.append(nn.Linear(dim_list[-2], dim_list[-1]))
-        self.edge_mlp = nn.Sequential(*layers)
+        def _make_mlp(in_dim: int) -> nn.Sequential:
+            layers = []
+            dim_list = [in_dim] + [hidden_dim] * (num_layers - 1) + [1]
+            for d_in, d_out in zip(dim_list[:-2], dim_list[1:-1]):
+                layers.append(nn.Linear(d_in, d_out))
+                layers.append(nn.ReLU())
+            layers.append(nn.Linear(dim_list[-2], dim_list[-1]))
+            return nn.Sequential(*layers)
+
+        self.edge_mlps = nn.ModuleDict()
+        self.edge_mlps["default"] = _make_mlp(embed_dim * 2)
+        for (src_t, rel, dst_t) in edge_types:
+            in_dim = in_dims[src_t] + in_dims[dst_t]
+            key = f"{src_t}_{rel}_{dst_t}"
+            self.edge_mlps[key] = _make_mlp(in_dim)
 
         self.register_buffer("tau", torch.tensor(1.0))
         self.to(device or "cpu")
@@ -86,7 +105,7 @@ class PGExplainer(nn.Module):
             x = embeddings if embeddings is not None else graph.x
             src, dst = graph.edge_index
             h = torch.cat([x[src], x[dst]], dim=-1)
-            logits = self.edge_mlp(h).view(-1)
+            logits = self.edge_mlps["default"](h).view(-1)
             return gumbel_sigmoid(logits, τ, hard)
 
         x_dict: Dict[str, torch.Tensor]
@@ -99,9 +118,12 @@ class PGExplainer(nn.Module):
 
         masks: Dict[str, torch.Tensor] = {}
         for etype in iter_edge_types(graph, self.view):
+            src_type, rel, dst_type = etype
             src, dst = graph[etype].edge_index
-            h = torch.cat([x_dict[etype[0]][src], x_dict[etype[2]][dst]], dim=-1)
-            logits = self.edge_mlp(h).view(-1)
+            h = torch.cat([x_dict[src_type][src], x_dict[dst_type][dst]], dim=-1)
+            key = f"{src_type}_{rel}_{dst_type}"
+            mlp = self.edge_mlps[key]
+            logits = mlp(h).view(-1)
             masks[str(etype)] = gumbel_sigmoid(logits, τ, hard)
         return edge_mask_to_global(graph, masks, self.view)
 


### PR DESCRIPTION
## Summary
- expand `PGExplainer` to build MLPs per edge type
- update forward pass to select MLP by edge type
- adapt CLI `train_global` to pass required metadata

## Testing
- `pytest -k pg_explainer -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_686fb06d16d0832ea850960930b516ed