### PR TITLE
Support per-edge-type MLPs in PGExplainer

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -314,7 +314,7 @@ def _load_model(args: argparse.Namespace, device: torch.device):
 
     # LOGGER.info("Model loaded and re-assembled successfully.")
     _log_memory_usage(device, "After model load")
-    return model
+    return model, meta_info
 
 
 def _attach_embeddings(graph: HeteroData, sha: str, embed_dir: Path) -> None:
@@ -328,7 +328,9 @@ def _attach_embeddings(graph: HeteroData, sha: str, embed_dir: Path) -> None:
                 LOGGER.warning(f"Could not attach embedding for {sha}: {e}")
 
 
-def _reinit_input_proj(graph: HeteroData, model: RESGCLClassifier, device: torch.device) -> None:
+def _reinit_input_proj(
+    graph: HeteroData, model: RESGCLClassifier, device: torch.device
+) -> None:
     """Dynamically re-initializes the model's input projection layers to match the
     feature dimensions of the provided graph. This is necessary when running the
     explainer on graphs with features (e.g., high-dimensional embeddings) that
@@ -337,28 +339,30 @@ def _reinit_input_proj(graph: HeteroData, model: RESGCLClassifier, device: torch
     in_dims = {}
     # Calculate actual feature dimensions from the graph object for each node type.
     for nt in graph.node_types:
-        if not hasattr(graph[nt], 'x'):
+        if not hasattr(graph[nt], "x"):
             continue  # Skip node types without features
 
         # Start with the dimension of the .x attribute
         dim = graph[nt].x.shape[1]
-        
+
         # Add dimensions of attribute embeddings if they are used by the encoder
         if model.encoder.attr_names and nt in model.encoder.attr_names:
             dim += len(model.encoder.attr_names[nt]) * model.encoder.attr_dim
-        
+
         in_dims[nt] = dim
 
     # Re-initialize layers where dimensions don't match
     for nt, proj in model.encoder.input_proj.items():
         if nt not in in_dims:
             continue
-        
+
         actual_dim = in_dims.get(nt)
         if actual_dim and proj.in_features != actual_dim:
             # LOGGER.info(f"Re-initializing input_proj for node type '{nt}': {proj.in_features} -> {actual_dim}")
             out_features = proj.out_features
-            model.encoder.input_proj[nt] = torch.nn.Linear(actual_dim, out_features).to(device)
+            model.encoder.input_proj[nt] = torch.nn.Linear(actual_dim, out_features).to(
+                device
+            )
 
 
 def _mine_tokens(graph: HeteroData, model, device: torch.device) -> list[str]:
@@ -941,16 +945,22 @@ def _train_selector_for_graph(
             )
 
         # --- Subgraph Verification (Before Copy) ---
-        LOGGER.info(f"--- Subgraph Verification (Epoch {epoch+1}/{args.epochs} - Before Copy) ---")
+        LOGGER.info(
+            f"--- Subgraph Verification (Epoch {epoch+1}/{args.epochs} - Before Copy) ---"
+        )
         LOGGER.info(f"[{sha}] Sampled Subgraph Node Types: {sub.node_types}")
         for nt in sub.node_types:
             num_nodes = sub[nt].num_nodes
             feature_shape = "N/A"
-            if hasattr(sub[nt], 'x'):
+            if hasattr(sub[nt], "x"):
                 feature_shape = sub[nt].x.shape
-            LOGGER.info(f"[{sha}]   - Node Type '{nt}': num_nodes={num_nodes}, feature_shape={feature_shape}")
-        if 'token' not in sub.node_types:
-            LOGGER.warning(f"[{sha}] 'token' node type is MISSING in this subgraph (Before Copy).")
+            LOGGER.info(
+                f"[{sha}]   - Node Type '{nt}': num_nodes={num_nodes}, feature_shape={feature_shape}"
+            )
+        if "token" not in sub.node_types:
+            LOGGER.warning(
+                f"[{sha}] 'token' node type is MISSING in this subgraph (Before Copy)."
+            )
         # --- End Verification ---
 
         # --- BEGIN MODIFICATION ---
@@ -960,37 +970,47 @@ def _train_selector_for_graph(
         # needed by the RGCNEncoder.
         for nt in graph.node_types:
             if nt not in sub.node_types:
-                sub.node_stores[sub.node_type_to_key[nt]] = graph.node_stores[graph.node_type_to_key[nt]].clone()
+                sub.node_stores[sub.node_type_to_key[nt]] = graph.node_stores[
+                    graph.node_type_to_key[nt]
+                ].clone()
                 continue
 
-            if hasattr(sub[nt], 'n_id'):
+            if hasattr(sub[nt], "n_id"):
                 original_node_indices = sub[nt].n_id
                 if original_node_indices.numel() > 0:
                     # Copy the main node features
-                    if hasattr(graph[nt], 'x'):
+                    if hasattr(graph[nt], "x"):
                         sub[nt].x = graph[nt].x[original_node_indices]
-                    
+
                     # Copy all required '_id' attributes that the encoder uses
                     if model.encoder.attr_names and nt in model.encoder.attr_names:
                         for attr_name in model.encoder.attr_names[nt]:
                             attr_id_key = f"{attr_name}_id"
                             if hasattr(graph[nt], attr_id_key):
-                                sub[nt][attr_id_key] = graph[nt][attr_id_key][original_node_indices]
+                                sub[nt][attr_id_key] = graph[nt][attr_id_key][
+                                    original_node_indices
+                                ]
         # --- END MODIFICATION ---
 
         # --- Subgraph Verification (After Copy) ---
-        LOGGER.info(f"--- Subgraph Verification (Epoch {epoch+1}/{args.epochs} - After Copy) ---")
+        LOGGER.info(
+            f"--- Subgraph Verification (Epoch {epoch+1}/{args.epochs} - After Copy) ---"
+        )
         LOGGER.info(f"[{sha}] Corrected Subgraph Node Types: {sub.node_types}")
         for nt in sub.node_types:
             num_nodes = sub[nt].num_nodes
             feature_shape = "N/A"
-            if hasattr(sub[nt], 'x'):
+            if hasattr(sub[nt], "x"):
                 feature_shape = sub[nt].x.shape
-            LOGGER.info(f"[{sha}]   - Node Type '{nt}': num_nodes={num_nodes}, feature_shape={feature_shape}")
-        if 'token' not in sub.node_types:
-            LOGGER.warning(f"[{sha}] 'token' node type is MISSING in this subgraph (After Copy).")
+            LOGGER.info(
+                f"[{sha}]   - Node Type '{nt}': num_nodes={num_nodes}, feature_shape={feature_shape}"
+            )
+        if "token" not in sub.node_types:
+            LOGGER.warning(
+                f"[{sha}] 'token' node type is MISSING in this subgraph (After Copy)."
+            )
         # --- End Verification ---
-        
+
         if has_cluster:
             builder = HeteroGraphBuilder()
             builder.add_view(sub, view_name)
@@ -1070,7 +1090,7 @@ def _train_selector_for_graph(
 def _train_batch_impl(args, model, device: torch.device) -> None:
     LOGGER.info("Starting batch training process.")
     _log_memory_usage(device, "Start of _train_batch_impl")
-    
+
     # --- BEGIN MODIFICATION ---
     # Initialize GraphDataset with a dummy path first, then override
     # the necessary attributes directly from the command-line arguments.
@@ -1081,7 +1101,7 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
         # The dummy path might not exist, which is fine. Create a placeholder.
         ds = object().__new__(GraphDataset)
         ds.root = Path(args.graph_dir).parent
-        ds.labels = {} # Initialize labels to prevent errors
+        ds.labels = {}  # Initialize labels to prevent errors
         ds.transform = None
         ds.id_col = "sha256"
         ds.label_col = "label"
@@ -1123,7 +1143,7 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
 
         # Reload model if it was deleted in the previous iteration's finally block.
         if "model" not in locals() or model is None:
-            model = _load_model(args, device)
+            model, _ = _load_model(args, device)
 
         _log_memory_usage(device, f"Before processing {sha}")
         graph_data, _, _ = ds[idx]
@@ -1131,9 +1151,13 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
         # --- LOGGING START ---
         LOGGER.info(f"--- Processing {sha} ---")
         if "token" in graph_data.node_types and hasattr(graph_data["token"], "x"):
-            LOGGER.info(f"[{sha}] After GraphDataset: 'token' features shape: {graph_data['token'].x.shape}")
+            LOGGER.info(
+                f"[{sha}] After GraphDataset: 'token' features shape: {graph_data['token'].x.shape}"
+            )
         else:
-            LOGGER.warning(f"[{sha}] After GraphDataset: 'token' nodes or features are MISSING or have no .x attribute.")
+            LOGGER.warning(
+                f"[{sha}] After GraphDataset: 'token' nodes or features are MISSING or have no .x attribute."
+            )
         # --- LOGGING END ---
 
         graph = None
@@ -1206,13 +1230,13 @@ def _train_batch_impl(args, model, device: torch.device) -> None:
 
 def train_batch(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
-    model = _load_model(args, device)
+    model, _ = _load_model(args, device)
     _train_batch_impl(args, model, device)
 
 
 def train_single(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
-    model = _load_model(args, device)
+    model, _ = _load_model(args, device)
 
     if args.ast or args.cfg or args.fcg or args.syscall:
         sha = args.cfg_graph.stem
@@ -1282,28 +1306,44 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
         x_dict[nt] = encoder.input_proj[nt](node_feat)
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
         # Ensure all node types have the same embedding dimension as actual_hidden_dim
         if x_dict[nt].shape[-1] != actual_hidden_dim:
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
     for conv in encoder.convs:
         x_dict = conv(x_dict, graph.edge_index_dict)
         # Ensure the output of conv is passed through activation and dropout
@@ -1322,17 +1362,21 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
         if x_dict[nt].shape[-1] != actual_hidden_dim:
             # This should ideally not happen if the encoder is correctly initialized
             # but as a safeguard, we can project it to the correct dimension
-            LOGGER.warning(f"Node type {nt} embedding dimension mismatch in _compute_node_embeddings. Expected {actual_hidden_dim}, got {x_dict[nt].shape[-1]}. Projecting...")
-            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(x_dict[nt].device)(x_dict[nt])
+            LOGGER.warning(
+                f"Node type {nt} embedding dimension mismatch in _compute_node_embeddings. Expected {actual_hidden_dim}, got {x_dict[nt].shape[-1]}. Projecting..."
+            )
+            x_dict[nt] = torch.nn.Linear(x_dict[nt].shape[-1], actual_hidden_dim).to(
+                x_dict[nt].device
+            )(x_dict[nt])
 
     if not x_dict:
         LOGGER.warning("x_dict is empty after computing node embeddings.")
         return {}
 
-    LOGGER.info(f"DEBUG (_compute_node_embeddings): Output x_dict dimensions: {{nt: x_dict[nt].shape for nt in x_dict}}")
+    LOGGER.info(
+        f"DEBUG (_compute_node_embeddings): Output x_dict dimensions: {{nt: x_dict[nt].shape for nt in x_dict}}"
+    )
     return x_dict
-
-
 
 
 def _masked_score(
@@ -1432,7 +1476,7 @@ def _evaluate_global(
 
 def train_global(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
-    model = _load_model(args, device)
+    model, meta_info = _load_model(args, device)
 
     graph_paths = sorted(Path(args.graph_dir).glob("*.pt"))
     if not graph_paths:
@@ -1456,6 +1500,8 @@ def train_global(args: argparse.Namespace) -> None:
     explainer = PGExplainer(
         model=model,
         embed_dim=model.encoder.out_proj.in_features,
+        in_dims=meta_info["in_dims"],
+        edge_types=meta_info["edge_types"],
         view=args.view,
         device=device,
     )
@@ -1479,9 +1525,7 @@ def train_global(args: argparse.Namespace) -> None:
                 g = GraphDataset._ensure_num_nodes(g)
                 g = GraphDataset._ensure_x(g)
                 g = GraphDataset._ensure_meta_ids(g, model.encoder.attr_names)
-                view_name = (
-                    Path(args.view).name if args.view is not None else None
-                )
+                view_name = Path(args.view).name if args.view is not None else None
                 if view_name is not None:
                     g = filter_view(g, view_name)
                 for nt in g.node_types:

--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -8,7 +8,7 @@
 # --------------------------------------------------------------------------- #
 from __future__ import annotations
 
-from typing import Dict, Mapping
+from typing import Dict, Iterable, Mapping
 
 import torch
 import torch.nn as nn
@@ -16,6 +16,7 @@ import torch.nn.functional as F
 from torch_geometric.data import Data, HeteroData
 
 from .cfg_explainer.selector import gumbel_sigmoid, iter_edge_types, edge_mask_to_global
+from .utils.hetero import EdgeType
 
 
 from src.common.utils import get_logger
@@ -26,7 +27,10 @@ LOGGER = get_logger(__name__)
 class PGExplainer(nn.Module):
     """Simple PGExplainer for heterogeneous graphs.
 
-    ``view`` may be ``None`` to operate on the full graph.
+    ``view`` may be ``None`` to operate on the full graph.  Edge scoring MLPs
+    are created per edge type from ``in_dims`` and ``edge_types``.  When
+    explaining a plain :class:`~torch_geometric.data.Data` graph the MLP stored
+    under the ``"default"`` key is used.
     """
 
     def __init__(
@@ -34,6 +38,8 @@ class PGExplainer(nn.Module):
         model: nn.Module,
         embed_dim: int,
         *,
+        in_dims: Dict[str, int],
+        edge_types: Iterable[EdgeType],
         hidden_dim: int = 64,
         num_layers: int = 2,
         view: str | None = "cfg",
@@ -47,6 +53,10 @@ class PGExplainer(nn.Module):
             GNN model being explained.
         embed_dim : int
             Dimension of node embeddings provided to ``forward``.
+        in_dims : Dict[str, int]
+            Input dimension per node type.
+        edge_types : Iterable[EdgeType]
+            Edge types present in the graphs to be explained.
         hidden_dim : int, optional
             Hidden size for the edge scoring MLP.
         num_layers : int, optional
@@ -60,14 +70,21 @@ class PGExplainer(nn.Module):
         self.model = model
         self.view = view
 
-        layers = []
-        in_dim = embed_dim * 2
-        dim_list = [in_dim] + [hidden_dim] * (num_layers - 1) + [1]
-        for d_in, d_out in zip(dim_list[:-2], dim_list[1:-1]):
-            layers.append(nn.Linear(d_in, d_out))
-            layers.append(nn.ReLU())
-        layers.append(nn.Linear(dim_list[-2], dim_list[-1]))
-        self.edge_mlp = nn.Sequential(*layers)
+        def build_mlp(in_dim: int) -> nn.Sequential:
+            layers: list[nn.Module] = []
+            dim_list = [in_dim] + [hidden_dim] * (num_layers - 1) + [1]
+            for d_in, d_out in zip(dim_list[:-2], dim_list[1:-1]):
+                layers.append(nn.Linear(d_in, d_out))
+                layers.append(nn.ReLU())
+            layers.append(nn.Linear(dim_list[-2], dim_list[-1]))
+            return nn.Sequential(*layers)
+
+        self.edge_mlps = nn.ModuleDict()
+        self.edge_mlps["default"] = build_mlp(embed_dim * 2)
+        for src_t, rel, dst_t in edge_types:
+            key = f"{src_t}_{rel}_{dst_t}"
+            mlp_in = in_dims[src_t] + in_dims[dst_t]
+            self.edge_mlps[key] = build_mlp(mlp_in)
 
         self.register_buffer("tau", torch.tensor(1.0))
         self.to(device or "cpu")
@@ -91,7 +108,7 @@ class PGExplainer(nn.Module):
             x = embeddings if embeddings is not None else graph.x
             src, dst = graph.edge_index
             h = torch.cat([x[src], x[dst]], dim=-1)
-            logits = self.edge_mlp(h).view(-1)
+            logits = self.edge_mlps["default"](h).view(-1)
             return gumbel_sigmoid(logits, τ, hard)
 
         x_dict: Dict[str, torch.Tensor]
@@ -104,25 +121,36 @@ class PGExplainer(nn.Module):
 
         if not x_dict:
             LOGGER.warning("x_dict is empty in PGExplainer.forward.")
-            return torch.empty(0, device=self.device) # Return empty tensor if no embeddings
+            return torch.empty(
+                0, device=self.device
+            )  # Return empty tensor if no embeddings
 
-        LOGGER.info(f"DEBUG (PGExplainer.forward): x_dict dimensions: {{nt: x_dict[nt].shape for nt in x_dict}}")
+        LOGGER.info(
+            f"DEBUG (PGExplainer.forward): x_dict dimensions: {{nt: x_dict[nt].shape for nt in x_dict}}"
+        )
 
         masks: Dict[str, torch.Tensor] = {}
         for etype in iter_edge_types(graph, self.view):
             src, dst = graph[etype].edge_index
-            
+
             # Ensure node features exist for source and destination node types
             if etype[0] not in x_dict or etype[2] not in x_dict:
-                LOGGER.warning(f"Missing node features for edge type {etype} in PGExplainer.forward. Skipping.")
+                LOGGER.warning(
+                    f"Missing node features for edge type {etype} in PGExplainer.forward. Skipping."
+                )
                 continue
 
-            LOGGER.info(f"DEBUG (PGExplainer.forward): x_dict[{etype[0]}] shape: {x_dict[etype[0]].shape}")
-            LOGGER.info(f"DEBUG (PGExplainer.forward): x_dict[{etype[2]}] shape: {x_dict[etype[2]].shape}")
+            LOGGER.info(
+                f"DEBUG (PGExplainer.forward): x_dict[{etype[0]}] shape: {x_dict[etype[0]].shape}"
+            )
+            LOGGER.info(
+                f"DEBUG (PGExplainer.forward): x_dict[{etype[2]}] shape: {x_dict[etype[2]].shape}"
+            )
 
             h = torch.cat([x_dict[etype[0]][src], x_dict[etype[2]][dst]], dim=-1)
             LOGGER.info(f"DEBUG (PGExplainer.forward): h dimension: {h.shape}")
-            logits = self.edge_mlp(h).view(-1)
+            mlp = self.edge_mlps[f"{etype[0]}_{etype[1]}_{etype[2]}"]
+            logits = mlp(h).view(-1)
             masks[str(etype)] = gumbel_sigmoid(logits, τ, hard)
         return edge_mask_to_global(graph, masks, self.view)
 
@@ -160,7 +188,11 @@ class PGExplainer(nn.Module):
         If ``self.view`` is ``None`` saliency is aggregated over all edge types.
         """
         if isinstance(graph, Data):
-            mask = mask_prob if isinstance(mask_prob, torch.Tensor) else next(iter(mask_prob.values()))
+            mask = (
+                mask_prob
+                if isinstance(mask_prob, torch.Tensor)
+                else next(iter(mask_prob.values()))
+            )
             score = torch.zeros(graph.num_nodes, device=mask.device)
             src, dst = graph.edge_index
             score.index_add_(0, src, mask)
@@ -178,7 +210,12 @@ class PGExplainer(nn.Module):
         else:
             masks = mask_prob
 
-        scores = {ntype: torch.zeros(graph[ntype].num_nodes, device=next(iter(masks.values())).device) for ntype in graph.node_types}
+        scores = {
+            ntype: torch.zeros(
+                graph[ntype].num_nodes, device=next(iter(masks.values())).device
+            )
+            for ntype in graph.node_types
+        }
         for et in iter_edge_types(graph, self.view):
             mask = masks[str(et)]
             src, dst = graph[et].edge_index


### PR DESCRIPTION
## Summary
- allow PGExplainer to build an MLP for every edge type
- update forward pass to pick the right MLP
- return metadata from `_load_model` and pass node dims/edge types when creating the explainer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_686fb39d8c34832eb4e02f513cf193ee