### PR TITLE
Update PGExplainer initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ python -m cli.explainer_train batch \
         # halves feature precision when enabled
         --full-cpu \
         [--no-embeds] [--no-full-score]
+# PGExplainer global 학습 예시
+python -m cli.explainer_train global \
+       --graph-dir data/splits/train/graphs \
+       --model models/gnn/res_gcl.pt \
+       --output models/pgexplainer.pt \
+       --epochs 200
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from contextlib import nullcontext
 from functools import partial
 import logging
+from typing import Dict
 
 import psutil
 
@@ -211,7 +212,10 @@ def build_parser() -> argparse.ArgumentParser:
     b.set_defaults(func=train_batch)
 
     # --- global PGExplainer ---
-    g = sub.add_parser("global", help="Train PGExplainer on multiple graphs")
+    g = sub.add_parser(
+        "global",
+        help="Train PGExplainer on multiple graphs (node dims inferred)",
+    )
     g.add_argument(
         "--graph-dir", type=Path, required=True, help="Directory containing *.pt graphs"
     )
@@ -330,13 +334,13 @@ def _attach_embeddings(graph: HeteroData, sha: str, embed_dir: Path) -> None:
 
 def _reinit_input_proj(
     graph: HeteroData, model: RESGCLClassifier, device: torch.device
-) -> None:
+) -> Dict[str, int]:
     """Dynamically re-initializes the model's input projection layers to match the
     feature dimensions of the provided graph. This is necessary when running the
     explainer on graphs with features (e.g., high-dimensional embeddings) that
     differ from the ones used during the original model training.
     """
-    in_dims = {}
+    in_dims: Dict[str, int] = {}
     # Calculate actual feature dimensions from the graph object for each node type.
     for nt in graph.node_types:
         if not hasattr(graph[nt], "x"):
@@ -363,6 +367,8 @@ def _reinit_input_proj(
             model.encoder.input_proj[nt] = torch.nn.Linear(actual_dim, out_features).to(
                 device
             )
+
+    return in_dims
 
 
 def _mine_tokens(graph: HeteroData, model, device: torch.device) -> list[str]:
@@ -471,7 +477,7 @@ def _train_selector_for_graph(
     # Re-initialize model's input layers to match the actual feature dimensions of the graph.
     # This is crucial because the explainer might be using graphs with different features
     # (e.g., with loaded embeddings) than the original trained model.
-    _reinit_input_proj(graph, model, device)
+    _ = _reinit_input_proj(graph, model, device)
 
     _log_memory_usage(device, f"Before adding batch attribute for {sha}")
     for nt in graph.node_types:
@@ -846,7 +852,7 @@ def _train_selector_for_graph(
         # Ensure the model's input layers are compatible with the subgraph's features.
         # This is critical as subgraphs from a sampler might have different feature
         # structures than the full graph.
-        _reinit_input_proj(sub, model, device)
+        _ = _reinit_input_proj(sub, model, device)
         _cast_graph_dtype(sub, param_dtype)
         masks = []
         optim.zero_grad()
@@ -1449,7 +1455,7 @@ def _evaluate_global(
             g = filter_view(g, view_name)
         for nt in g.node_types:
             g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
-        _reinit_input_proj(g, model, device)
+        _ = _reinit_input_proj(g, model, device)
         _cast_graph_dtype(g, param_dtype)
         g = g.to(device)
 
@@ -1476,7 +1482,7 @@ def _evaluate_global(
 
 def train_global(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
-    model, meta_info = _load_model(args, device)
+    model, _ = _load_model(args, device)
 
     graph_paths = sorted(Path(args.graph_dir).glob("*.pt"))
     if not graph_paths:
@@ -1497,11 +1503,24 @@ def train_global(args: argparse.Namespace) -> None:
         except Exception as e:
             LOGGER.warning(f"Failed to read val meta CSV: {e}")
 
+    class _TempDS:
+        def __init__(self, paths):
+            self.paths = paths
+
+        def __len__(self):
+            return len(self.paths)
+
+        def __getitem__(self, idx):
+            return torch.load(self.paths[idx], map_location="cpu", weights_only=False)
+
+    _, in_dims, _, _ = collect_dataset_metadata(
+        _TempDS(graph_paths), attr_dim=model.encoder.attr_dim
+    )
+
     explainer = PGExplainer(
         model=model,
-        embed_dim=model.encoder.out_proj.in_features,
-        in_dims=meta_info["in_dims"],
-        edge_types=meta_info["edge_types"],
+        in_dims=in_dims,
+        edge_types=model.encoder.metadata[1],
         view=args.view,
         device=device,
     )
@@ -1530,7 +1549,7 @@ def train_global(args: argparse.Namespace) -> None:
                     g = filter_view(g, view_name)
                 for nt in g.node_types:
                     g[nt].batch = torch.zeros(g[nt].num_nodes, dtype=torch.long)
-                _reinit_input_proj(g, model, device)
+                _ = _reinit_input_proj(g, model, device)
                 _cast_graph_dtype(g, param_dtype)
                 g = g.to(device)
 

--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -36,7 +36,7 @@ class PGExplainer(nn.Module):
     def __init__(
         self,
         model: nn.Module,
-        embed_dim: int,
+        embed_dim: int | None = None,
         *,
         in_dims: Dict[str, int],
         edge_types: Iterable[EdgeType],
@@ -51,8 +51,10 @@ class PGExplainer(nn.Module):
         ----------
         model : nn.Module
             GNN model being explained.
-        embed_dim : int
+        embed_dim : int, optional
             Dimension of node embeddings provided to ``forward``.
+            If ``None`` it defaults to ``model.encoder.out_proj.in_features``
+            when available.
         in_dims : Dict[str, int]
             Input dimension per node type.
         edge_types : Iterable[EdgeType]
@@ -69,6 +71,15 @@ class PGExplainer(nn.Module):
         super().__init__()
         self.model = model
         self.view = view
+
+        if embed_dim is None:
+            enc = getattr(model, "encoder", None)
+            if enc is not None and isinstance(
+                getattr(enc, "out_proj", None), nn.Linear
+            ):
+                embed_dim = enc.out_proj.in_features
+            else:
+                embed_dim = max(in_dims.values(), default=0)
 
         def build_mlp(in_dim: int) -> nn.Sequential:
             layers: list[nn.Module] = []


### PR DESCRIPTION
## Summary
- detect node feature dimensions via `collect_dataset_metadata`
- pass new `in_dims` and `edge_types` when constructing PGExplainer
- make `embed_dim` optional in PGExplainer
- expose new global training CLI help and example

## Testing
- `black src/explain/pg_explainer.py src/cli/explainer_train.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686fb5a70aac832ea31dc597620de366