### PR TITLE
Fix dataset metadata collection call

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1514,7 +1514,7 @@ def train_global(args: argparse.Namespace) -> None:
             return torch.load(self.paths[idx], map_location="cpu", weights_only=False)
 
     _, in_dims, _, _ = collect_dataset_metadata(
-        _TempDS(graph_paths), attr_dim=model.encoder.attr_dim
+        [_TempDS(graph_paths)], attr_dim=model.encoder.attr_dim
     )
 
     explainer = PGExplainer(

--- a/src/explain/train_selector.py
+++ b/src/explain/train_selector.py
@@ -121,7 +121,7 @@ def main():
             return self.graph
 
     _, in_dims, _, _ = collect_dataset_metadata(
-        SingleGraphDataset(graph), attr_dim=model.encoder.attr_dim
+        [SingleGraphDataset(graph)], attr_dim=model.encoder.attr_dim
     )
     for nt, proj in model.encoder.input_proj.items():
         act_dim = in_dims.get(nt)


### PR DESCRIPTION
## Summary
- wrap dataset objects in lists when collecting metadata for explainers

## Testing
- `pytest -k 'ast_loader' -q` *(fails: ModuleNotFoundError: No module named 'augment')*

------
https://chatgpt.com/codex/tasks/task_e_686fbb6c9ea0832e8d8b23abe2171217