### PR TITLE
Store metadata on RGCNEncoder

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -47,7 +47,9 @@ class RGCNEncoder(nn.Module):
     def __init__(self, *, metadata, in_dims: Dict[str, int], attr_names: Dict[str, list[str]] | None = None, vocab_size: int = 0, attr_dim: int = 32, hidden_dim: int = 128, num_layers: int = 2, out_dim: int = 256, dropout: float = 0.1, residual: bool = True, target_node: Optional[str] = None):
         super().__init__()
         node_types, edge_types = metadata
+        self.metadata = (list(node_types), list(edge_types))
         self.node_types = list(node_types)
+        self.edge_types = list(edge_types)
         self.target_node = target_node or self.node_types[0]
         
         self.input_proj = nn.ModuleDict()


### PR DESCRIPTION
## Summary
- preserve `metadata` argument on `RGCNEncoder`
- keep edge types separately on `self.edge_types`

## Testing
- `pytest -q tests/test_encoder_load.py tests/test_rgcn_edge_index_check.py tests/test_rgcn_edge_type_check.py`

------
https://chatgpt.com/codex/tasks/task_e_686fbf1097fc832eac85714e7e69a8b4