### PR TITLE
Fix edge index sanitation ordering

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -169,6 +169,7 @@ class GraphDataset(Dataset):
         sha = self.samples[idx]
         g = self._load_graph(sha)
         g = GraphDataset._remove_batch(g)
+        g = GraphDataset._sanitize_edges(g)
         
         if isinstance(g, HeteroData):
             for node_type in g.node_types:
@@ -355,92 +356,30 @@ class GraphDataset(Dataset):
 
         batch_graph = Batch.from_data_list(padded_graphs)
 
-        # Explicitly update num_nodes_dict for each node type in the batched graph
+        batch_graph = GraphDataset._sanitize_edges(batch_graph)
+
         if isinstance(batch_graph, HeteroData):
+            batch_graph.num_nodes_dict = {}
             for node_type in batch_graph.node_types:
-                max_node_idx = -1
-                # Check max index from edge_index
+                max_idx = -1
                 for edge_type in batch_graph.edge_types:
                     src_type, _, dst_type = edge_type
                     if src_type == node_type and batch_graph[edge_type].edge_index.numel() > 0:
-                        max_node_idx = max(max_node_idx, int(batch_graph[edge_type].edge_index[0].max()))
+                        max_idx = max(max_idx, int(batch_graph[edge_type].edge_index[0].max()))
                     if dst_type == node_type and batch_graph[edge_type].edge_index.numel() > 0:
-                        max_node_idx = max(max_node_idx, int(batch_graph[edge_type].edge_index[1].max()))
-                
-                # Check max index from node features (x)
-                if hasattr(batch_graph[node_type], 'x') and batch_graph[node_type].x is not None:
-                    max_node_idx = max(max_node_idx, batch_graph[node_type].x.size(0) - 1)
+                        max_idx = max(max_idx, int(batch_graph[edge_type].edge_index[1].max()))
 
-                # Update num_nodes_dict
-                if max_node_idx != -1:
-                    batch_graph.num_nodes_dict[node_type] = max_node_idx + 1
-                elif node_type not in batch_graph.num_nodes_dict: # If no edges or features, ensure it's at least 0
-                    batch_graph.num_nodes_dict[node_type] = 0
+                if hasattr(batch_graph[node_type], "x") and batch_graph[node_type].x is not None:
+                    max_idx = max(max_idx, batch_graph[node_type].x.size(0) - 1)
 
-            # Ensure individual node type num_nodes are consistent with num_nodes_dict
-            for node_type in batch_graph.node_types:
-                if node_type in batch_graph.num_nodes_dict:
-                    batch_graph[node_type].num_nodes = batch_graph.num_nodes_dict[node_type]
+                batch_graph.num_nodes_dict[node_type] = max(max_idx + 1, 0) if max_idx != -1 else 0
+                batch_graph[node_type].num_nodes = batch_graph.num_nodes_dict[node_type]
 
-        # Explicitly sanitize edge_index based on updated num_nodes_dict before final _sanitize_edges
-        if isinstance(batch_graph, HeteroData):
-            for etype in batch_graph.edge_types:
-                src_t, _, dst_t = etype
-                src_n = batch_graph.num_nodes_dict.get(src_t, 0)
-                dst_n = batch_graph.num_nodes_dict.get(dst_t, 0)
-                
-                # Only sanitize if num_nodes is valid (not 0)
-                if src_n > 0 and dst_n > 0:
-                    GraphDataset._sanitize_edge_index(batch_graph[etype], src_nodes=src_n, dst_nodes=dst_n)
-                else:
-                    # If num_nodes is 0, ensure edge_index is empty
-                    if batch_graph[etype].edge_index.numel() > 0:
-                        _LOG.warning(f"Edge type {etype} has non-empty edge_index but source/destination num_nodes is 0. Emptying edge_index.")
-                        batch_graph[etype].edge_index = torch.empty((2, 0), dtype=torch.long, device=batch_graph[etype].edge_index.device)
-
-        # Add this new block here to explicitly sanitize edge_index based on updated num_nodes_dict
-        if isinstance(batch_graph, HeteroData):
-            for etype in batch_graph.edge_types:
-                src_t, _, dst_t = etype
-                src_n = batch_graph.num_nodes_dict.get(src_t, 0)
-                dst_n = batch_graph.num_nodes_dict.get(dst_t, 0)
-                
-                # Only sanitize if num_nodes is valid (not 0)
-                if src_n > 0 and dst_n > 0:
-                    GraphDataset._sanitize_edge_index(batch_graph[etype], src_nodes=src_n, dst_nodes=dst_n)
-                else:
-                    # If num_nodes is 0, ensure edge_index is empty
-                    if batch_graph[etype].edge_index.numel() > 0:
-                        _LOG.warning(f"Edge type {etype} has non-empty edge_index but source/destination num_nodes is 0. Emptying edge_index.")
-                        batch_graph[etype].edge_index = torch.empty((2, 0), dtype=torch.long, device=batch_graph[etype].edge_index.device)
-
-        batch_graph = GraphDataset._sanitize_edges(batch_graph) # This line remains
-
-        # Ensure num_nodes_dict is correctly set for the batched heterogeneous graph
-        if isinstance(batch_graph, HeteroData):
-            # Add missing edge types with empty tensors if schema is provided
             if edge_types_schema:
                 for et in edge_types_schema:
                     if et not in batch_graph.edge_index_dict:
                         batch_graph[et].edge_index = torch.empty((2, 0), dtype=torch.long, device=batch_graph.x_dict[et[0]].device if et[0] in batch_graph.x_dict else "cpu")
                         _LOG.debug(f"Added missing edge type {et} with empty tensor to batch_graph.")
-
-            for node_type in batch_graph.node_types:
-                max_node_id = 0
-                # Iterate through all edge types where this node_type is either source or destination
-                for edge_type in batch_graph.edge_types:
-                    src_type, _, dst_type = edge_type
-                    if src_type == node_type and batch_graph[edge_type].edge_index.numel() > 0:
-                        max_node_id = max(max_node_id, int(batch_graph[edge_type].edge_index[0].max()))
-                    if dst_type == node_type and batch_graph[edge_type].edge_index.numel() > 0:
-                        max_node_id = max(max_node_id, int(batch_graph[edge_type].edge_index[1].max()))
-                
-                # Update num_nodes for the node type if the max_node_id is larger
-                # This handles cases where num_nodes might be underestimated by Batch.from_data_list
-                if node_type in batch_graph.num_nodes_dict and batch_graph.num_nodes_dict[node_type] < max_node_id + 1:
-                    batch_graph.num_nodes_dict[node_type] = max_node_id + 1
-                elif node_type not in batch_graph.num_nodes_dict: # If num_nodes_dict doesn't have this node type
-                    batch_graph.num_nodes_dict[node_type] = max_node_id + 1
 
         labels_t = torch.tensor(labels, dtype=torch.long) if None not in labels else None
         return {"graph": batch_graph, "label": labels_t, "ids": ids}
@@ -702,6 +641,11 @@ class GraphDataset(Dataset):
             return
         num_e = edge_index.size(1)
         src, dst = edge_index
+
+        # Clamp node counts by available feature rows when possible
+        if hasattr(store, "x") and isinstance(store.x, torch.Tensor):
+            src_nodes = min(src_nodes, store.x.size(0))
+            dst_nodes = min(dst_nodes, store.x.size(0))
 
         if (src < 0).any() or (dst < 0).any():
             _LOG.error(f"Negative index found in edge_index! src_nodes={src_nodes}, dst_nodes={dst_nodes}, edge_index={edge_index}")


### PR DESCRIPTION
## Summary
- sanitize edges immediately after loading a graph in `__getitem__`
- clamp edge index ranges in `_sanitize_edge_index`
- sanitize batched graphs then recompute `num_nodes_dict`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*
- `python src/cli/pretrain_selfgcl.py --help` *(fails: cannot import name 'add_safe_globals')*
- `python src/cli/train_res_gcl.py --help` *(fails: cannot import name 'add_safe_globals')*

------
https://chatgpt.com/codex/tasks/task_e_6872dc7f1f44832e944451be2f33a341