### PR TITLE
Fix node count estimation and edge sanitization

### DIFF
--- a/src/graphs/builders/hetero_builder.py
+++ b/src/graphs/builders/hetero_builder.py
@@ -259,12 +259,13 @@ def _guess_num_nodes(store: Data | HeteroData) -> int:
     if n is not None:
         return int(n)
 
-    candidates = []
-
+    # Prefer explicit feature length when present
     for attr in ("x", "feat"):
         val = getattr(store, attr, None)
         if isinstance(val, torch.Tensor):
-            candidates.append(int(val.size(0)))
+            return int(val.size(0))
+
+    candidates = []
 
     for attr in ("addr", "inst_cnt", "name", "api_name"):
         val = getattr(store, attr, None)

--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -678,11 +678,20 @@ class GraphDataset(Dataset):
         if isinstance(g, HeteroData):
             for etype in g.edge_types:
                 src_t, _, dst_t = etype
-                src_n = g[src_t].num_nodes or 0
-                dst_n = g[dst_t].num_nodes or 0
-                GraphDataset._sanitize_edge_index(g[etype], src_nodes=src_n, dst_nodes=dst_n)
+                src_feat_len = (
+                    g[src_t].x.size(0) if hasattr(g[src_t], "x") else g[src_t].num_nodes or 0
+                )
+                dst_feat_len = (
+                    g[dst_t].x.size(0) if hasattr(g[dst_t], "x") else g[dst_t].num_nodes or 0
+                )
+                src_n = min(g[src_t].num_nodes or 0, src_feat_len)
+                dst_n = min(g[dst_t].num_nodes or 0, dst_feat_len)
+                GraphDataset._sanitize_edge_index(
+                    g[etype], src_nodes=src_n, dst_nodes=dst_n
+                )
         else:
-            n = g.num_nodes or 0
+            feat_len = g.x.size(0) if hasattr(g, "x") else g.num_nodes or 0
+            n = min(g.num_nodes or 0, feat_len)
             GraphDataset._sanitize_edge_index(g, src_nodes=n, dst_nodes=n)
         return g
 


### PR DESCRIPTION
## Summary
- prefer feature row count when guessing `num_nodes`
- clamp edge sanitization using actual feature length

## Testing
- `pytest tests/test_graph_dataset_sanitize.py tests/test_utils_sanitize_edge_index.py tests/test_hetero_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e2fbf20c832eaf9d4efd8723551a