### PR TITLE
Fix PGExplainer mse loss

### DIFF
--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -218,7 +218,10 @@ class PGExplainer(nn.Module):
                 masked_score, torch.sigmoid(full_score.detach())
             )
         elif loss_type == "mse":
-            fidelity = F.mse_loss(masked_score, full_score.detach())
+            fidelity = F.mse_loss(
+                torch.sigmoid(masked_score),
+                torch.sigmoid(full_score.detach())
+            )
         elif loss_type == "smooth_l1":
             fidelity = F.smooth_l1_loss(masked_score, full_score.detach())
         else:


### PR DESCRIPTION
## Summary
- fix `loss_type == "mse"` branch in `PGExplainer.loss`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'augment')*

------
https://chatgpt.com/codex/tasks/task_e_6878f26cf540832e996b322809358cc3