### PR TITLE
Fix PGExplainer BCE targets

### DIFF
--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -214,9 +214,8 @@ class PGExplainer(nn.Module):
     ) -> torch.Tensor:
         """Information bottleneck style loss."""
         if loss_type == "bce":
-            fidelity = F.binary_cross_entropy_with_logits(
-                masked_score, torch.sigmoid(full_score.detach())
-            )
+            target_prob = torch.sigmoid(full_score.detach()).clamp(1e-4, 1 - 1e-4)
+            fidelity = F.binary_cross_entropy_with_logits(masked_score, target_prob)
         elif loss_type == "mse":
             fidelity = F.mse_loss(
                 torch.sigmoid(masked_score),


### PR DESCRIPTION
## Summary
- clamp target probabilities for BCE in PGExplainer

## Testing
- `pytest -k pg_explainer -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6878f47639a0832eb8fa824247305e31