### PR TITLE
Add entropy regularization to PGExplainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ python -m cli.explainer_train global \
        --graph-dir data/splits/train/graphs \
        --model models/gnn/res_gcl.pt \
        --output models/pgexplainer.pt \
-       --epochs 200
+       --epochs 200 \
+       --gamma 0.1  # entropy weight
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -110,6 +110,7 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--lr", type=float, default=2e-3)
         pp.add_argument("--alpha", type=float, default=1.0)
         pp.add_argument("--beta", type=float, default=2e-2)
+        pp.add_argument("--gamma", type=float, default=0.0, help="Entropy weight")
         pp.add_argument("--batch-size", type=int, default=2048)
         pp.add_argument(
             "--num-workers", type=int, default=0, help="DataLoader worker processes"
@@ -1579,7 +1580,12 @@ def train_global(args: argparse.Namespace) -> None:
                     continue
                 masked = _masked_score(g, mask_prob, args.view, model)
                 loss = explainer.loss(
-                    full_score, masked, mask_prob, alpha=args.alpha, beta=args.beta
+                    full_score,
+                    masked,
+                    mask_prob,
+                    alpha=args.alpha,
+                    beta=args.beta,
+                    gamma=args.gamma,
                 )
 
                 optim.zero_grad()

--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -210,6 +210,7 @@ class PGExplainer(nn.Module):
         *,
         alpha: float = 1.0,
         beta: float = 2e-2,
+        gamma: float = 0.0,
         loss_type: str = "bce",
     ) -> torch.Tensor:
         """Information bottleneck style loss."""
@@ -226,7 +227,9 @@ class PGExplainer(nn.Module):
         else:
             raise ValueError("loss_type must be 'bce', 'mse', or 'smooth_l1'")
         sparsity = mask_prob.mean()
-        return alpha * fidelity + beta * sparsity
+        mask = mask_prob.clamp(1e-6, 1 - 1e-6)
+        entropy = -(mask * mask.log() + (1 - mask) * (1 - mask).log()).mean()
+        return alpha * fidelity + beta * sparsity + gamma * entropy
 
     # ------------------------------------------------------------------ #
     def get_node_saliency(


### PR DESCRIPTION
## Summary
- update PGExplainer.loss to support entropy regularization
- expose `--gamma` entropy weight in explainer training CLI
- document new option in README

## Testing
- `pytest tests/test_explainer_train_global_cli.py -k test_global_cli_invokes -q` *(fails: skipped due to missing torch)*
- `pip install torch==2.6.0 -q` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6878f5dc9dcc832eb950acc42cc3f65d