### PR TITLE
Add init bias option to PGExplainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ python -m cli.explainer_train global \
        --model models/gnn/res_gcl.pt \
        --output models/pgexplainer.pt \
        --epochs 200 \
-       --gamma 0.1  # entropy weight
+       --gamma 0.1 \
+       --init-bias 1.0  # entropy weight and bias init
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -234,6 +234,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     g.add_argument("--tau-decay", type=float, default=0.995, help="Temperature decay")
     g.add_argument("--tau-min", type=float, default=0.5, help="Minimum temperature")
+    g.add_argument(
+        "--init-bias",
+        type=float,
+        default=1.0,
+        help="Initial bias value for PGExplainer MLPs",
+    )
     add_common(g)
     g.set_defaults(func=train_global)
 
@@ -1532,6 +1538,7 @@ def train_global(args: argparse.Namespace) -> None:
         node_types=final_node_types,
         edge_types=final_edge_types,
         view=args.view,
+        init_bias=args.init_bias,
         device=device,
     )
     optim = torch.optim.Adam(explainer.parameters(), lr=args.lr)

--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -48,6 +48,7 @@ class PGExplainer(nn.Module):
         num_layers: int = 2,
         view: str | None = "cfg",
         device: str | torch.device | None = None,
+        init_bias: float = 1.0,
     ) -> None:
         """Initialize the explainer.
 
@@ -74,10 +75,13 @@ class PGExplainer(nn.Module):
             Edge relation to explain. ``None`` uses all edge types.
         device : str | torch.device | None, optional
             Device for parameters and buffers.
+        init_bias : float, optional
+            Initial bias value for the last ``nn.Linear`` layer in each MLP.
         """
         super().__init__()
         self.model = model
         self.view = view
+        self.init_bias = init_bias
 
         if embed_dim is None:
             enc = getattr(model, "encoder", None)
@@ -108,6 +112,7 @@ class PGExplainer(nn.Module):
                 layers.append(nn.Linear(d_in, d_out))
                 layers.append(nn.ReLU())
             layers.append(nn.Linear(dim_list[-2], dim_list[-1]))
+            nn.init.constant_(layers[-1].bias, init_bias)
             return nn.Sequential(*layers)
 
         self.edge_mlps = nn.ModuleDict()

--- a/tests/test_explainer_train_global_cli.py
+++ b/tests/test_explainer_train_global_cli.py
@@ -28,7 +28,19 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
     def fake_train(args):
         captured["graph_dir"] = args.graph_dir
         captured["output"] = args.output
+        captured["init_bias"] = args.init_bias
 
+    import torch.serialization
+    monkeypatch.setattr(
+        torch.serialization,
+        "add_safe_globals",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+    import types, sys
+    for mod in ["gensim", "gensim.downloader", "sentencepiece"]:
+        if mod not in sys.modules:
+            sys.modules[mod] = types.ModuleType(mod)
     monkeypatch.setattr("src.cli.explainer_train.train_global", fake_train)
     mod = importlib.import_module("src.cli.explainer_train")
 
@@ -45,3 +57,4 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
 
     assert captured["graph_dir"] == gdir
     assert captured["output"] == out
+    assert captured["init_bias"] == 1.0


### PR DESCRIPTION
## Summary
- allow constant bias initialisation for PGExplainer MLPs
- expose `--init-bias` option for `train_global` CLI
- document new option in README
- update CLI test

## Testing
- `pytest tests/test_explainer_train_global_cli.py -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*

------
https://chatgpt.com/codex/tasks/task_e_6878f7b1f9d4832eadd1bb7dc3ff964b