### PR TITLE
Add tau_start option for PGExplainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ python -m cli.explainer_train global \
        --output models/pgexplainer.pt \
        --epochs 200 \
        --gamma 0.1 \
+       --tau-start 1.0 \
        --init-bias 1.0  # entropy weight and bias init
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -235,6 +235,12 @@ def build_parser() -> argparse.ArgumentParser:
     g.add_argument("--tau-decay", type=float, default=0.995, help="Temperature decay")
     g.add_argument("--tau-min", type=float, default=0.5, help="Minimum temperature")
     g.add_argument(
+        "--tau-start",
+        type=float,
+        default=1.0,
+        help="Initial temperature value",
+    )
+    g.add_argument(
         "--init-bias",
         type=float,
         default=1.0,
@@ -1539,6 +1545,7 @@ def train_global(args: argparse.Namespace) -> None:
         edge_types=final_edge_types,
         view=args.view,
         init_bias=args.init_bias,
+        tau_start=args.tau_start,
         device=device,
     )
     optim = torch.optim.Adam(explainer.parameters(), lr=args.lr)

--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -49,6 +49,7 @@ class PGExplainer(nn.Module):
         view: str | None = "cfg",
         device: str | torch.device | None = None,
         init_bias: float = 1.0,
+        tau_start: float = 1.0,
     ) -> None:
         """Initialize the explainer.
 
@@ -77,6 +78,8 @@ class PGExplainer(nn.Module):
             Device for parameters and buffers.
         init_bias : float, optional
             Initial bias value for the last ``nn.Linear`` layer in each MLP.
+        tau_start : float, optional
+            Initial value for the temperature ``tau``.
         """
         super().__init__()
         self.model = model
@@ -132,7 +135,7 @@ class PGExplainer(nn.Module):
             self.edge_mlps[key] = build_mlp(mlp_in)
             LOGGER.debug(f"DEBUG (PGExplainer.__init__): Created MLP for key: '{key}' with input dim: {mlp_in}")
 
-        self.register_buffer("tau", torch.tensor(1.0))
+        self.register_buffer("tau", torch.tensor(tau_start))
         self.to(device or "cpu")
 
     # ------------------------------------------------------------------ #

--- a/tests/test_explainer_train_global_cli.py
+++ b/tests/test_explainer_train_global_cli.py
@@ -29,6 +29,7 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
         captured["graph_dir"] = args.graph_dir
         captured["output"] = args.output
         captured["init_bias"] = args.init_bias
+        captured["tau_start"] = args.tau_start
 
     import torch.serialization
     monkeypatch.setattr(
@@ -58,3 +59,4 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
     assert captured["graph_dir"] == gdir
     assert captured["output"] == out
     assert captured["init_bias"] == 1.0
+    assert captured["tau_start"] == 1.0


### PR DESCRIPTION
## Summary
- add `tau_start` parameter to `PGExplainer`
- expose `--tau-start` CLI argument
- forward this value in `train_global`
- document the new option in the README
- update tests to check CLI forwards the parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6878fc31ec00832e9bd23a8ff82318d8