### PR TITLE
Fix embedding concat in explainer CLI

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -401,7 +401,22 @@ def _attach_embeddings(graph: HeteroData, sha: str, embed_dir: Path) -> None:
         if embed_file.is_file():
             try:
                 # Disable memory mapping to avoid excessive open file handles
-                graph["token"].x = load_tensor(sha, embed_dir, mmap=False)
+                feat = load_tensor(sha, embed_dir, mmap=False)
+                store = graph["token"]
+
+                # track original feature dimension to avoid duplicating embeds
+                if not hasattr(store, "_orig_feat_dim"):
+                    if hasattr(store, "x") and store.x is not None:
+                        store._orig_feat_dim = store.x.size(-1)
+                    else:
+                        store._orig_feat_dim = 0
+
+                if hasattr(store, "x") and store.x is not None:
+                    if store.x.size(1) >= store._orig_feat_dim + feat.size(1):
+                        return
+                    store.x = torch.cat([store.x, feat], dim=-1)
+                else:
+                    store.x = feat
             except Exception as e:
                 LOGGER.warning(f"Could not attach embedding for {sha}: {e}")
 


### PR DESCRIPTION
## Summary
- concatenate token embeddings instead of overwriting in `explainer_train`
- prevent duplicate embedding concatenation

## Testing
- `pre-commit run --files src/cli/explainer_train.py`
- `pytest tests/test_explainer_train_cli.py::test_cli_invokes_train_selector -q` *(fails: ImportError: Cannot import 'augment.registry')*

------
https://chatgpt.com/codex/tasks/task_e_687a3a791a60832e8c462fbff2dea654