### PR TITLE
Implement soft mask training

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ python -m cli.explainer_train global \
        --gamma 0.1 \
        --tau-start 1.0 \
        --init-bias 1.0  # entropy weight and bias init
+       --soft-mask-epochs 0  # use soft masks for the first N epochs (0 disables)
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1530,6 +1530,35 @@ def _masked_score(
     return out
 
 
+def _soft_masked_score(
+    graph: HeteroData, mask_prob: torch.Tensor, view: str | None, model
+) -> torch.Tensor:
+    """Return logits for ``graph`` with ``mask_prob`` stored as ``edge_weight``."""
+    ptr = 0
+    original: dict[str, torch.Tensor | None] = {}
+    for et in iter_edge_types(graph, view):
+        store = graph[et]
+        num_e = store.edge_index.size(1)
+        mask = mask_prob[ptr : ptr + num_e]
+        ptr += num_e
+        if num_e == 0:
+            continue
+        original[str(et)] = getattr(store, "edge_weight", None)
+        store.edge_weight = mask
+
+    out = model(graph, return_logits=True).squeeze()
+
+    for et in iter_edge_types(graph, view):
+        backup = original.get(str(et))
+        if backup is None:
+            if hasattr(graph[et], "edge_weight"):
+                del graph[et].edge_weight
+        else:
+            graph[et].edge_weight = backup
+
+    return out
+
+
 def _ensure_fallback_features(
     g: HeteroData,
     all_node_types: list[str],
@@ -1868,7 +1897,10 @@ def train_global(args: argparse.Namespace) -> None:
                     if mask_prob.numel() == 0:
                         skipped_count += 1
                         continue
-                    masked = _masked_score(g, mask_prob, args.view, model)
+                    if use_hard_mask:
+                        masked = _masked_score(g, mask_prob, args.view, model)
+                    else:
+                        masked = _soft_masked_score(g, mask_prob, args.view, model)
                     loss = explainer.loss(
                         full_score,
                         masked,

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -72,6 +72,8 @@ class MemoryUsageFilter(logging.Filter):
                 record.vram = "n/a"
         else:
             record.vram = "n/a"
+        if "RAM" not in record.getMessage():
+            record.msg = f"RAM {record.ram} | VRAM {record.vram} | {record.getMessage()}"
         return True
 
 
@@ -106,7 +108,6 @@ def get_logger(name: str = "robust‑mg", level: int = logging.INFO) -> logging.
 
     logger = logging.getLogger(name)
     logger.setLevel(level)
-    # logger.propagate = False  # avoid double messages if root also configured
 
     handler = logging.StreamHandler(sys.stdout)
     handler.addFilter(MemoryUsageFilter())

--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -189,7 +189,19 @@ class RGCNEncoder(nn.Module):
 
         for i, conv in enumerate(self.convs):
             try:
-                x_dict = conv(x_dict, data.edge_index_dict)
+                edge_weight_dict = {
+                    et: data[et].edge_weight
+                    for et in data.edge_types
+                    if hasattr(data[et], "edge_weight")
+                }
+                if edge_weight_dict:
+                    x_dict = conv(
+                        x_dict,
+                        data.edge_index_dict,
+                        edge_weight_dict=edge_weight_dict,
+                    )
+                else:
+                    x_dict = conv(x_dict, data.edge_index_dict)
             except Exception as e:
                 LOGGER.info(f"오류 발생: conv 레이어 {i} 실행 중 에러가 발생했습니다: {e}")
                 LOGGER.info("오류 발생 시점의 데이터 정보:")

--- a/tests/test_soft_mask_mode.py
+++ b/tests/test_soft_mask_mode.py
@@ -1,0 +1,161 @@
+import importlib
+import types
+from pathlib import Path
+import sys
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+aug = importlib.import_module("src.augment")
+sys.modules.setdefault("augment", aug)
+for name, module in list(sys.modules.items()):
+    if name.startswith("src.augment"):
+        sys.modules.setdefault(name.replace("src.", "", 1), module)
+del module, name, aug
+exp = importlib.import_module("src.explain")
+sys.modules.setdefault("explain", exp)
+for name, module in list(sys.modules.items()):
+    if name.startswith("src.explain"):
+        sys.modules.setdefault(name.replace("src.", "", 1), module)
+del module, name, exp
+for mod_name in ["gensim", "gensim.downloader", "sentencepiece"]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+if "pandas" not in sys.modules:
+    sys.modules["pandas"] = types.ModuleType("pandas")
+if "pyarrow" not in sys.modules:
+    pa = types.ModuleType("pyarrow")
+    sys.modules["pyarrow"] = pa
+    sys.modules["pyarrow.feather"] = types.ModuleType("pyarrow.feather")
+    sys.modules["pyarrow.parquet"] = types.ModuleType("pyarrow.parquet")
+sys.modules.setdefault("gensim.models", types.ModuleType("gensim.models"))
+sys.modules["gensim.models"].Word2Vec = object
+for mod in ["pefile", "lief", "capstone", "r2pipe", "ghidra_bridge", "angr", "archinfo"]:
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+mod = importlib.import_module("src.cli.explainer_train")
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        enc = types.SimpleNamespace(
+            metadata=(["n"], [("n", "r", "n")]),
+            attr_names={"n": []},
+            target_node="n",
+            input_proj={},
+            out_proj=types.SimpleNamespace(in_features=1),
+        )
+        self.encoder = enc
+        self.p = torch.nn.Parameter(torch.zeros(1))
+
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+    def forward(self, graph, return_logits=False):
+        # return sum of edge weights if present
+        store = graph[("n", "r", "n")]
+        w = getattr(store, "edge_weight", torch.zeros(store.edge_index.size(1)))
+        return w.sum().unsqueeze(0)
+
+
+def dummy_load_model(args, device):
+    return DummyModel(), {"hidden_dim": 1}
+
+
+class DummyExplainer:
+    def __init__(self, *a, **kw):
+        self.p = torch.nn.Parameter(torch.zeros(1))
+        self.tau = torch.tensor(1.0)
+
+    def parameters(self):
+        return [self.p]
+
+    def to(self, device):
+        return self
+
+    def train(self):
+        pass
+
+    def eval(self):
+        pass
+
+    def __call__(self, graph, embeddings=None, hard=False):
+        # return a mask for two edges
+        return torch.tensor([0.3, 0.7])
+
+    def loss(self, *a, **kw):
+        return torch.tensor(0.0, requires_grad=True)
+
+
+def dummy_embeddings(g, encoder):
+    return {"n": torch.zeros(g["n"].num_nodes, 1)}
+
+
+class DummyScaler:
+    def __init__(self, enabled=True):
+        pass
+
+    class _Obj:
+        def backward(self):
+            pass
+
+    def scale(self, loss):
+        return self._Obj()
+
+    def step(self, optim):
+        pass
+
+    def update(self):
+        pass
+
+    def unscale_(self, optim):
+        pass
+
+
+def test_soft_mask_switch(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["n"].x = torch.zeros(2, 1)
+    g["n"].num_nodes = 2
+    g[("n", "r", "n")].edge_index = torch.tensor([[0, 1], [1, 0]])
+    graphs = tmp_path / "graphs"
+    graphs.mkdir()
+    torch.save(g, graphs / "g.pt")
+    (tmp_path / "model.pt").write_text("stub")
+
+    monkeypatch.setattr(mod, "_load_model", dummy_load_model)
+    monkeypatch.setattr(mod, "_compute_node_embeddings", dummy_embeddings)
+    monkeypatch.setattr(mod, "PGExplainer", DummyExplainer)
+    monkeypatch.setattr(mod.torch.cuda.amp, "GradScaler", DummyScaler)
+
+    calls = []
+    monkeypatch.setattr(mod, "_soft_masked_score", lambda *a, **k: calls.append("soft") or torch.tensor(0.0))
+    monkeypatch.setattr(mod, "_masked_score", lambda *a, **k: calls.append("hard") or torch.tensor(0.0))
+
+    parser = mod.build_parser()
+    args = parser.parse_args([
+        "global",
+        "--graph-dir",
+        str(graphs),
+        "--model",
+        str(tmp_path / "model.pt"),
+        "--output",
+        str(tmp_path / "out.pt"),
+        "--epochs",
+        "2",
+        "--soft-mask-epochs",
+        "1",
+    ])
+    args.device = "cpu"
+
+    mod.train_global(args)
+
+    assert calls[0] == "soft"
+    assert calls[-1] == "hard"


### PR DESCRIPTION
## Summary
- implement `_soft_masked_score` in explainer training
- switch to soft mask mode for initial epochs
- support edge weights in `RGCNEncoder`
- document `--soft-mask-epochs` default
- add regression test for the new mode

## Testing
- `pytest tests/test_soft_mask_mode.py -q`
- `pytest tests/test_logger_memory.py::test_logger_adds_memory_usage -q`


------
https://chatgpt.com/codex/tasks/task_e_687bd069fff8832ea07eeaf4af6fb35e