### PR TITLE
Update gamma defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,14 @@ python -m cli.explainer_train global \
        --model models/gnn/res_gcl.pt \
        --output models/pgexplainer.pt \
        --epochs 200 \
-       --gamma 0.1 \
+       --gamma 0.01 \
        --tau-start 1.0 \
        --init-bias 1.0  # entropy weight and bias init
        --soft-mask-epochs 0  # use soft masks for the first N epochs (0 disables)
+#
+# `gamma`는 마스크 확률의 엔트로피에 곱해지는 가중치로, 0보다 크게 설정하면
+# 탐색을 유도하는 항이 손실 함수에 추가됩니다. 기본값은 0.01이며 값이 너무
+# 크면 희소성 학습이 어려워질 수 있습니다.
 # 특징 추출만 별도로 실행할 경우
 python -m cli.explainer_train feature-mine \
        --model-path models/gnn/res_gcl.pt \

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -111,7 +111,12 @@ def build_parser() -> argparse.ArgumentParser:
         pp.add_argument("--lr", type=float, default=2e-3)
         pp.add_argument("--alpha", type=float, default=1.0)
         pp.add_argument("--beta", type=float, default=2e-2)
-        pp.add_argument("--gamma", type=float, default=0.0, help="Entropy weight")
+        pp.add_argument(
+            "--gamma",
+            type=float,
+            default=0.01,
+            help="Entropy weight (nonzero enables exploration)",
+        )
         pp.add_argument(
             "--loss-type",
             choices=["bce", "mse", "smooth_l1"],


### PR DESCRIPTION
## Summary
- set default `--gamma` to `0.01` in `explainer_train` CLI
- document gamma usage and adjust PGExplainer example in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687bd5295a08832eafe057b6a89537ba