### PR TITLE
Enable default beta scheduling for explainer training

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ python -m cli.explainer_train global \
        --gamma 0.01 \
        --tau-start 1.0 \
        --init-bias 1.0  # entropy weight and bias init
+       --beta 0.1  # target sparsity weight
+       # beta will increase from 1e-4 to this value during training
        --soft-mask-epochs 0  # use soft masks for the first N epochs (0 disables)
 #
 # `gamma`는 마스크 확률의 엔트로피에 곱해지는 가중치로, 0보다 크게 설정하면

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -346,10 +346,25 @@ def build_parser() -> argparse.ArgumentParser:
         default=0.1,
         help="Initial learning rate factor for warmup (lr * start_factor).",
     )
-    g.add_argument(
+    beta_grp = g.add_mutually_exclusive_group()
+    beta_grp.add_argument(
         "--beta-schedule",
+        dest="beta_schedule",
         action="store_true",
+        default=True,
         help="Enable beta scheduling to gradually increase sparsity pressure.",
+    )
+    beta_grp.add_argument(
+        "--no-beta-schedule",
+        dest="beta_schedule",
+        action="store_false",
+        help="Disable beta scheduling.",
+    )
+    g.add_argument(
+        "--beta-start",
+        type=float,
+        default=1e-4,
+        help="Initial beta value when scheduling is enabled.",
     )
     g.add_argument(
         "--beta-schedule-factor",
@@ -366,8 +381,8 @@ def build_parser() -> argparse.ArgumentParser:
     g.add_argument(
         "--beta-max",
         type=float,
-        default=1.0,
-        help="Maximum value for beta under the schedule.",
+        default=None,
+        help="Maximum value for beta under the schedule. Defaults to --beta.",
     )
     add_common(g)
     g.set_defaults(func=train_global)
@@ -1669,6 +1684,12 @@ def _evaluate_global(
     return total_loss / count, total_fid / count, total_spars / count
 
 
+def _schedule_beta(current: float, args: argparse.Namespace, cap: float) -> float:
+    """Return the next beta value according to the schedule."""
+    new_beta = current * args.beta_schedule_factor
+    return min(new_beta, cap)
+
+
 import matplotlib.pyplot as plt
 
 
@@ -1847,13 +1868,14 @@ def train_global(args: argparse.Namespace) -> None:
 
     scaler = torch.cuda.amp.GradScaler(enabled=(args.amp and device.type == "cuda"))
 
-    current_beta = args.beta
+    beta_cap = args.beta if args.beta_max is None else args.beta_max
+    current_beta = args.beta_start if args.beta_schedule else args.beta
     if args.beta_schedule:
         LOGGER.info(
-            f"Beta scheduling enabled: start={args.beta}, "
+            f"Beta scheduling enabled: start={args.beta_start}, "
             f"factor={args.beta_schedule_factor}, "
             f"epochs_per_step={args.beta_schedule_epochs}, "
-            f"max={args.beta_max}"
+            f"target={beta_cap}"
         )
 
     with logging_redirect_tqdm():
@@ -1986,9 +2008,10 @@ def train_global(args: argparse.Namespace) -> None:
                 )
 
             if args.beta_schedule and (epoch + 1) % args.beta_schedule_epochs == 0:
-                new_beta = current_beta * args.beta_schedule_factor
-                current_beta = min(new_beta, args.beta_max)
-                LOGGER.info(f"Beta scheduled update: new beta is {current_beta:.6f}")
+                current_beta = _schedule_beta(current_beta, args, beta_cap)
+                LOGGER.info(
+                    f"Beta scheduled update: new beta is {current_beta:.6f}"
+                )
 
             # Decay tau at the end of the epoch
             if epoch < args.epochs - 1:  # No decay on the last epoch

--- a/tests/test_beta_schedule.py
+++ b/tests/test_beta_schedule.py
@@ -1,0 +1,31 @@
+import ast
+import pathlib
+import argparse
+import pytest
+
+# Load the _schedule_beta function from the source without importing heavy deps
+src = pathlib.Path('src/cli/explainer_train.py').read_text()
+module = ast.parse(src)
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name == '_schedule_beta':
+        code = ast.get_source_segment(src, node)
+        break
+else:
+    raise AssertionError('_schedule_beta not found')
+namespace = {'argparse': argparse}
+exec(code, namespace)
+_schedule_beta = namespace['_schedule_beta']
+
+def test_schedule_beta_reaches_target():
+    args = argparse.Namespace(
+        beta=0.1,
+        beta_schedule=True,
+        beta_schedule_factor=10.0,
+        beta_schedule_epochs=1,
+    )
+    cap = args.beta
+    beta = 1e-4
+    for _ in range(3):
+        beta = _schedule_beta(beta, args, cap)
+    assert beta == pytest.approx(args.beta)
+


### PR DESCRIPTION
## Summary
- enable beta scheduling by default and add disable flag
- start beta from 1e-4 and gradually grow to target
- add helper `_schedule_beta` and test its behaviour
- document default scheduling behaviour in README

## Testing
- `pytest tests/test_logger_memory.py tests/test_beta_schedule.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd77c3890832e9d28e13c271a5bcc