### PR TITLE
Use straight-through masks during explainer training

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ python -m cli.explainer_train global \
        --init-bias 1.0  # entropy weight and bias init
        --beta 0.1  # target sparsity weight
        # beta will increase from 1e-4 to this value during training
-       --soft-mask-epochs 0  # use soft masks for the first N epochs (0 disables)
+       --soft-mask-epochs 5  # train with soft masks for the first N epochs
+       --hard-mask-mode weight  # use straight-through weighted masking
 #
 # `gamma`는 마스크 확률의 엔트로피에 곱해지는 가중치로, 0보다 크게 설정하면
 # 탐색을 유도하는 항이 손실 함수에 추가됩니다. 기본값은 0.01이며 값이 너무

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -272,8 +272,14 @@ def build_parser() -> argparse.ArgumentParser:
     g.add_argument(
         "--soft-mask-epochs",
         type=int,
-        default=0,
+        default=5,
         help="Number of initial epochs to train with soft masks before switching to hard masks.",
+    )
+    g.add_argument(
+        "--hard-mask-mode",
+        choices=["weight", "delete"],
+        default="weight",
+        help="How to apply hard masks: 'weight' uses edge weights (straight-through), 'delete' removes edges.",
     )
     g.add_argument(
         "--clip-grad-norm",
@@ -1514,6 +1520,38 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
 def _masked_score(
     graph: HeteroData, mask_prob: torch.Tensor, view: str | None, model
 ) -> torch.Tensor:
+    """Return logits with straight-through hard masking via ``edge_weight``."""
+    ptr = 0
+    original: dict[str, torch.Tensor | None] = {}
+    for et in iter_edge_types(graph, view):
+        store = graph[et]
+        num_e = store.edge_index.size(1)
+        mask = mask_prob[ptr : ptr + num_e]
+        ptr += num_e
+        if num_e == 0:
+            continue
+        mask_hard = (mask > 0.5).float()
+        st_mask = mask_hard + (mask - mask_hard).detach()
+        original[str(et)] = getattr(store, "edge_weight", None)
+        store.edge_weight = st_mask
+
+    out = model(graph, return_logits=True).squeeze()
+
+    for et in iter_edge_types(graph, view):
+        backup = original.get(str(et))
+        if backup is None:
+            if hasattr(graph[et], "edge_weight"):
+                del graph[et].edge_weight
+        else:
+            graph[et].edge_weight = backup
+
+    return out
+
+
+def _delete_masked_score(
+    graph: HeteroData, mask_prob: torch.Tensor, view: str | None, model
+) -> torch.Tensor:
+    """Return logits for ``graph`` after deleting edges with mask<0.5."""
     ptr = 0
     original: dict[str, dict[str, torch.Tensor]] = {}
     for et in iter_edge_types(graph, view):
@@ -1649,7 +1687,10 @@ def _evaluate_global(
                 mask_prob = explainer(g, embeddings=embeds, hard=True)
                 if mask_prob.numel() == 0:
                     continue
-                masked_score = _masked_score(g, mask_prob, args.view, model)
+                if args.hard_mask_mode == "delete":
+                    masked_score = _delete_masked_score(g, mask_prob, args.view, model)
+                else:
+                    masked_score = _masked_score(g, mask_prob, args.view, model)
 
                 target_prob = torch.sigmoid(full_score.detach()).clamp(1e-4, 1 - 1e-4)
                 fidelity = F.binary_cross_entropy_with_logits(
@@ -1925,7 +1966,10 @@ def train_global(args: argparse.Namespace) -> None:
                         skipped_count += 1
                         continue
                     if use_hard_mask:
-                        masked = _masked_score(g, mask_prob, args.view, model)
+                        if args.hard_mask_mode == "delete":
+                            masked = _delete_masked_score(g, mask_prob, args.view, model)
+                        else:
+                            masked = _masked_score(g, mask_prob, args.view, model)
                     else:
                         masked = _soft_masked_score(g, mask_prob, args.view, model)
                     loss = explainer.loss(


### PR DESCRIPTION
## Summary
- apply straight-through hard mask using `edge_weight`
- keep option for deletion-based masking via `--hard-mask-mode`
- default to 5 soft-mask epochs and document new setting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric.data')*


------
https://chatgpt.com/codex/tasks/task_e_687bda699390832e8a71c9de250d37bc