### PR TITLE
Add noise option to PGExplainer training

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -276,6 +276,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of initial epochs to train with soft masks before switching to hard masks.",
     )
     g.add_argument(
+        "--noise-epochs",
+        type=int,
+        default=0,
+        help="Number of initial epochs to add Gaussian noise to mask probabilities.",
+    )
+    g.add_argument(
+        "--noise-std",
+        type=float,
+        default=0.05,
+        help="Standard deviation of the added Gaussian noise.",
+    )
+    g.add_argument(
         "--hard-mask-mode",
         choices=["weight", "delete"],
         default="weight",
@@ -1962,6 +1974,9 @@ def train_global(args: argparse.Namespace) -> None:
 
                     use_hard_mask = epoch >= args.soft_mask_epochs
                     mask_prob = explainer(g, embeddings=embeds, hard=use_hard_mask)
+                    if epoch < args.noise_epochs:
+                        mask_prob = mask_prob + torch.randn_like(mask_prob) * args.noise_std
+                        mask_prob.clamp_(0, 1)
                     if mask_prob.numel() == 0:
                         skipped_count += 1
                         continue


### PR DESCRIPTION
## Summary
- allow adding Gaussian noise to edge mask probabilities in PGExplainer training
- expose `--noise-epochs` and `--noise-std` CLI parameters to control noise amount

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch'; more missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687bdfee7984832eb061985f998b7750