### PR TITLE
Fix loss averaging and BCE reduction

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1933,7 +1933,7 @@ def train_global(args: argparse.Namespace) -> None:
 
     with logging_redirect_tqdm():
         for epoch in range(args.epochs):
-            total_loss = 0
+            total_loss = 0.0
             graph_count = 0
             skipped_count = 0
 

--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -220,7 +220,11 @@ class PGExplainer(nn.Module):
         """Information bottleneck style loss."""
         if loss_type == "bce":
             target_prob = torch.sigmoid(full_score.detach()).clamp(1e-4, 1 - 1e-4)
-            fidelity = F.binary_cross_entropy_with_logits(masked_score, target_prob)
+            fidelity = F.binary_cross_entropy_with_logits(
+                masked_score,
+                target_prob,
+                reduction="mean",
+            )
         elif loss_type == "mse":
             fidelity = F.mse_loss(
                 torch.sigmoid(masked_score),


### PR DESCRIPTION
## Summary
- make train loop start `total_loss` as float
- keep per-graph loss accumulation
- use explicit reduction="mean" in PGExplainer loss

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'archinfo', 'matplotlib', 'pandas', 'sklearn', 'sentencepiece')*

------
https://chatgpt.com/codex/tasks/task_e_687be37501e8832e90de41d1ba5f6877