### PR TITLE
Handle edge weights in RGCNEncoder forward

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -133,16 +133,20 @@ class RGCNEncoder(nn.Module):
         nn.init.zeros_(self.out_proj.bias)
         self.out_dim = out_dim
 
-    def forward(self, data: HeteroData) -> Tensor:
+    def forward(
+        self,
+        g: HeteroData,
+        edge_weight_dict: dict[str, Tensor] | None = None,
+    ) -> Tensor:
         x_dict = {}
-        for nt in data.node_types:
+        for nt in g.node_types:
             # --- [파이프라인 재설계] forward의 역할 단순화 ---
             # forward는 .x 특징과 메타데이터 임베딩을 조합하여 최종 특징 텐서를 만들고,
             # 준비된 프로젝션 계층에 전달하는 역할만 수행합니다.
             
             # 1. 베이스 특징(.x)을 가져옵니다. GraphDataset에서 이미 모든 특징이 통합되었습니다.
-            if hasattr(data[nt], "x") and data[nt].x is not None:
-                feats_to_combine = [data[nt].x]
+            if hasattr(g[nt], "x") and g[nt].x is not None:
+                feats_to_combine = [g[nt].x]
             else:
                 LOGGER.warning(f"[RGCNEncoder.forward] 경고: 노드 타입 '{nt}'에 '.x' 특징이 없습니다. 건너뜁니다.")
                 continue
@@ -151,12 +155,12 @@ class RGCNEncoder(nn.Module):
             if self.meta_embed:
                 for name in self.attr_names.get(nt, []):
                     attr_key = f"{name}_id"
-                    attr = getattr(data[nt], attr_key, None)
+                    attr = getattr(g[nt], attr_key, None)
                     if attr is not None and attr.numel() > 0:
                         feats_to_combine.append(self.meta_embed(attr))
                     else:
                         # ID가 없는 경우, 0으로 채워진 임베딩을 추가하여 차원을 맞춥니다.
-                        num_nodes = data[nt].num_nodes
+                        num_nodes = g[nt].num_nodes
                         padding_indices = torch.zeros(num_nodes, dtype=torch.long, device=feats_to_combine[0].device)
                         feats_to_combine.append(self.meta_embed(padding_indices))
 
@@ -189,19 +193,23 @@ class RGCNEncoder(nn.Module):
 
         for i, conv in enumerate(self.convs):
             try:
-                edge_weight_dict = {
-                    et: data[et].edge_weight
-                    for et in data.edge_types
-                    if hasattr(data[et], "edge_weight")
-                }
-                if edge_weight_dict:
+                if edge_weight_dict is None:
+                    collected_weights = {
+                        et: g[et].edge_weight
+                        for et in g.edge_types
+                        if hasattr(g[et], "edge_weight")
+                    }
+                else:
+                    collected_weights = edge_weight_dict
+
+                if collected_weights:
                     x_dict = conv(
                         x_dict,
-                        data.edge_index_dict,
-                        edge_weight_dict=edge_weight_dict,
+                        g.edge_index_dict,
+                        edge_weight_dict=collected_weights,
                     )
                 else:
-                    x_dict = conv(x_dict, data.edge_index_dict)
+                    x_dict = conv(x_dict, g.edge_index_dict)
             except Exception as e:
                 LOGGER.info(f"오류 발생: conv 레이어 {i} 실행 중 에러가 발생했습니다: {e}")
                 LOGGER.info("오류 발생 시점의 데이터 정보:")
@@ -211,14 +219,14 @@ class RGCNEncoder(nn.Module):
                     LOGGER.info(f"  - 노드 타입: {nt_err}, 특징 텐서 shape: {x_err.shape}")
                 
                 LOGGER.info("\ndata.edge_index_dict 정보 (엣지 타입별 인덱스):")
-                for et, edge_index in data.edge_index_dict.items():
+                for et, edge_index in g.edge_index_dict.items():
                     try:
                         edge_index_cpu = edge_index.cpu()
                         min_idx = edge_index_cpu.min().item() if edge_index_cpu.numel() > 0 else 'N/A'
                         max_idx = edge_index_cpu.max().item() if edge_index_cpu.numel() > 0 else 'N/A'
                         src_node_type, _, dst_node_type = et
-                        src_num_nodes = data.num_nodes_dict.get(src_node_type, 'N/A')
-                        dst_num_nodes = data.num_nodes_dict.get(dst_node_type, 'N/A')
+                        src_num_nodes = g.num_nodes_dict.get(src_node_type, 'N/A')
+                        dst_num_nodes = g.num_nodes_dict.get(dst_node_type, 'N/A')
 
                         LOGGER.info(f"  - 엣지 타입: {et}")
                         LOGGER.info(f"    - shape: {edge_index.shape}")
@@ -236,7 +244,7 @@ class RGCNEncoder(nn.Module):
                         LOGGER.info(f"    - edge_index shape: {edge_index.shape if hasattr(edge_index, 'shape') else 'N/A'}")
 
                 LOGGER.info("\ndata.num_nodes_dict 정보 (노드 타입별 노드 수):")
-                LOGGER.info(f"  {data.num_nodes_dict}")
+                LOGGER.info(f"  {g.num_nodes_dict}")
                 LOGGER.info("========================================")
                 LOGGER.info("오류 로깅을 마치고 학습을 중단합니다.")
                 raise e
@@ -244,15 +252,15 @@ class RGCNEncoder(nn.Module):
 
         target_feats = x_dict.get(self.target_node)
         if target_feats is None:
-            num_graphs = data.num_graphs if hasattr(data, 'num_graphs') else 1
+            num_graphs = g.num_graphs if hasattr(g, 'num_graphs') else 1
             if not x_dict:
                  device = next(self.parameters()).device
                  return torch.zeros((num_graphs, self.out_dim), device=device)
             return x_dict[list(x_dict.keys())[0]].new_zeros((num_graphs, self.out_dim))
 
-        batch_vec = data[self.target_node].batch if hasattr(data[self.target_node], 'batch') else None
-        
-        g_emb = global_mean_pool(target_feats, batch_vec, size=data.num_graphs if hasattr(data, 'num_graphs') else None)
+        batch_vec = g[self.target_node].batch if hasattr(g[self.target_node], 'batch') else None
+
+        g_emb = global_mean_pool(target_feats, batch_vec, size=g.num_graphs if hasattr(g, 'num_graphs') else None)
         
         return self.out_proj(g_emb)
     


### PR DESCRIPTION
## Summary
- update `RGCNEncoder.forward` to accept optional `edge_weight_dict`
- pass collected or provided weights through `HeteroConv`

## Testing
- `pytest tests/test_rgcn_edge_index_check.py::test_forward_raises_on_invalid_edge_index -q` *(fails: Regex pattern did not match)*
- `pytest tests/test_rgcn_edge_index_check.py::test_forward_raises_on_negative_edge_index -q` *(fails: DID NOT RAISE <class 'ValueError'>)*

------
https://chatgpt.com/codex/tasks/task_e_687be39623f8832eb0d394b38b925654