### PR TITLE
Refactor soft mask handling

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1603,9 +1603,9 @@ def _delete_masked_score(
 def _soft_masked_score(
     graph: HeteroData, mask_prob: torch.Tensor, view: str | None, model
 ) -> torch.Tensor:
-    """Return logits for ``graph`` with ``mask_prob`` stored as ``edge_weight``."""
+    """Return logits for ``graph`` with ``mask_prob`` passed via ``edge_weight_dict``."""
     ptr = 0
-    original: dict[str, torch.Tensor | None] = {}
+    edge_weight_dict: dict[tuple[str, str, str], torch.Tensor] = {}
     for et in iter_edge_types(graph, view):
         store = graph[et]
         num_e = store.edge_index.size(1)
@@ -1613,18 +1613,9 @@ def _soft_masked_score(
         ptr += num_e
         if num_e == 0:
             continue
-        original[str(et)] = getattr(store, "edge_weight", None)
-        store.edge_weight = mask
+        edge_weight_dict[et] = mask
 
-    out = model(graph, return_logits=True).squeeze()
-
-    for et in iter_edge_types(graph, view):
-        backup = original.get(str(et))
-        if backup is None:
-            if hasattr(graph[et], "edge_weight"):
-                del graph[et].edge_weight
-        else:
-            graph[et].edge_weight = backup
+    out = model(graph, edge_weight_dict=edge_weight_dict, return_logits=True).squeeze()
 
     return out
 

--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -105,7 +105,12 @@ class RESGCLClassifier(nn.Module):
 
     # ------------------------------------------------------------------ #
     def forward(
-        self, data, *, return_logits: bool = False, checkpoint_layers: bool = False
+        self,
+        data,
+        *,
+        return_logits: bool = False,
+        checkpoint_layers: bool = False,
+        edge_weight_dict: dict[str, Tensor] | None = None,
     ) -> Tensor:
         """Single forward pass with edge‑drop when in training mode."""
         # apply edge‑drop only during training
@@ -119,9 +124,9 @@ class RESGCLClassifier(nn.Module):
         #             data[etype].edge_attr = ea
 
         if checkpoint_layers:
-            emb = checkpoint(self.encoder, data)      # (B, D)
+            emb = checkpoint(self.encoder, data, edge_weight_dict)  # (B, D)
         else:
-            emb = self.encoder(data)                  # (B, D)
+            emb = self.encoder(data, edge_weight_dict=edge_weight_dict)  # (B, D)
         if emb is None:
             return None
         


### PR DESCRIPTION
## Summary
- rework `_soft_masked_score` to build an `edge_weight_dict` and pass it to the model
- update `RESGCLClassifier.forward` to accept `edge_weight_dict`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687be63393d8832eac100f3ea0e6c80a