### PR TITLE
Add text field support in feature miner

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -245,7 +245,7 @@ class FeatureMiner:
         """
         alias_map = {
             "name": ["name", "api"],
-            "value": ["value", "string"],
+            "value": ["value", "string", "text"],
             "import": ["import", "import_"],
             "bytes": ["bytes"],
             "syscall": ["syscall", "syscall_name"],

--- a/tests/test_feature_miner_text_field.py
+++ b/tests/test_feature_miner_text_field.py
@@ -1,0 +1,17 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_miner_accepts_text_field():
+    g = HeteroData()
+    g["token"].x = torch.zeros(1, 1)
+    g["token"].text = ["example"]
+    sal = torch.tensor([1.0])
+    feats = FeatureMiner(top_k=1)(g, sal)
+    assert "\"example\" wide ascii nocase" in feats


### PR DESCRIPTION
## Summary
- map token `text` metadata to `value` for feature extraction
- add regression test for text-field handling

## Testing
- `pytest tests/test_feature_miner* -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6be64a10832ea1eb40d73ccda868