### PR TITLE
Add meta fallback in FeatureMiner

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -61,7 +61,7 @@ class FeatureMiner:
     # ──────────────────────────────────────────────────────────
     # regex pre‑compilation (성능 ↑, 재사용 ↑)
     _WS = r"[ \t\r\n]+"  # whitespace
-    _API_RX = re.compile(rf"[A-Za-z0-9_#!?@\[\]\-\.+]{3,}")
+    _API_RX = re.compile(r"[A-Za-z0-9_#!?@\[\]\-\.+]{3,}")
     _STRING_FILTER = re.compile(r"[\x00-\x1F]")  # control chars
     _HEX_RX = re.compile(r"[0-9A-Fa-f]{2}")
 
@@ -300,6 +300,10 @@ class FeatureMiner:
             keys = alias_map.get(attr, [attr])
             for key in keys:
                 x = meta.get(key, None)
+                if x is None:
+                    meta_dict = getattr(meta, "meta", {})
+                    if isinstance(meta_dict, dict):
+                        x = meta_dict.get(key)
                 if x is None:
                     continue
                 # StringTensor 또는 List[str]일 수 있음

--- a/tests/test_feature_miner_safe_get.py
+++ b/tests/test_feature_miner_safe_get.py
@@ -30,3 +30,15 @@ def test_feature_miner_resolves_alias_fields():
     miner = FeatureMiner(top_k=1)
     feats = miner(g, sal)
     assert "import:WS2_32.dll" in feats
+
+
+def test_feature_miner_reads_from_meta_dict():
+    g = HeteroData()
+    g["func"].num_nodes = 1
+    g["func"].x = torch.zeros(1, 1)
+    g["func"].meta = {"name": ["CreateFileW"]}
+
+    sal = torch.tensor([1.0])
+    miner = FeatureMiner(top_k=1)
+    feats = miner(g, sal)
+    assert "call:CreateFileW" in feats


### PR DESCRIPTION
## Summary
- extend `_get` helper in `FeatureMiner` to look up attributes in `meta.meta`
- correct API regex compilation
- test fallback via new unit test

## Testing
- `pytest -q tests/test_feature_miner_additional_fields.py tests/test_feature_miner_alt_fields.py tests/test_feature_miner_safe_get.py tests/test_feature_miner_text_field.py`

------
https://chatgpt.com/codex/tasks/task_e_687c70600be4832e82d00995b57240a9