### PR TITLE
Improve feature miner meta lookup

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -254,13 +254,23 @@ class FeatureMiner:
             "reg": ["reg", "key", "registry"],
         }
         
+        def _lookup(m, key):
+            x = getattr(m, key, None)
+            if x is None and hasattr(m, "meta"):
+                meta_dict = getattr(m, "meta")
+                if isinstance(meta_dict, dict):
+                    x = meta_dict.get(key)
+            return x
+
         # One-time, very detailed debug log for the first selected node.
         if not hasattr(self, '_has_logged_detailed_meta'):
             _LOG.info("="*50)
-            _LOG.info(f"DEBUG: Detailed inspection of first selected node (ntype='{ntype}', local_idx={local_idx}).")
+            _LOG.info(
+                f"DEBUG: Detailed inspection of first selected node (ntype='{ntype}', local_idx={local_idx})."
+            )
             _LOG.info(f"DEBUG: All available keys in `meta` object: {list(meta.keys())}")
-            
-            meta_content = meta.get('meta')
+
+            meta_content = _lookup(meta, 'meta')
             if meta_content is not None and isinstance(meta_content, (list, tuple)) and local_idx < len(meta_content):
                 _LOG.info(f"DEBUG: Content of `meta.meta` field: {meta_content[local_idx]}")
             else:
@@ -270,7 +280,7 @@ class FeatureMiner:
             def _get_for_debug(attr: str):
                 keys = alias_map.get(attr, [attr])
                 for key in keys:
-                    x = meta.get(key, None)
+                    x = _lookup(meta, key)
                     if x is None: continue
                     if isinstance(x, (list, tuple)):
                         if local_idx < len(x): return x[local_idx]
@@ -299,11 +309,7 @@ class FeatureMiner:
         def _get(attr: str):
             keys = alias_map.get(attr, [attr])
             for key in keys:
-                x = meta.get(key, None)
-                if x is None:
-                    meta_dict = getattr(meta, "meta", {})
-                    if isinstance(meta_dict, dict):
-                        x = meta_dict.get(key)
+                x = _lookup(meta, key)
                 if x is None:
                     continue
                 # StringTensor 또는 List[str]일 수 있음
@@ -423,7 +429,7 @@ class FeatureMiner:
                     nbr_meta = data[dst]
                     nbr_name = None
                     for key in ["name", "api"]:
-                        val = nbr_meta.get(key)
+                        val = _lookup(nbr_meta, key)
                         if val is None:
                             continue
                         if isinstance(val, (list, tuple)) and nbr_local < len(val):


### PR DESCRIPTION
## Summary
- enhance metadata access in `FeatureMiner` for better compatibility
- use the same lookup logic in debug helper and feature extractor

## Testing
- `pytest -q tests/test_feature_miner_safe_get.py tests/test_feature_miner_additional_fields.py`

------
https://chatgpt.com/codex/tasks/task_e_687c73c4fe78832ea18bf86e2f61c5bf