### PR TITLE
Add validation interval to PPO training

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -445,11 +445,49 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         # backward compatibility with older API in tests
         agent = rulegen.load_agent(env=env)
     log_interval = int(cfg.get("checkpoint", {}).get("save_every_updates", 10_000))
-    history = agent.train(
-        total_timesteps=total_steps,
-        log_interval=log_interval,
-        save_path=args.checkpoint,
-    )
+
+    def _evaluate_agent(agent: PPORuleAgent, env: rulegen.RuleGenEnv, n_rules: int) -> dict:
+        builder = YaraBuilder() if env.rule_type == "yara" else CapaBuilder()
+        f1_c = f1_d = r_sum = 0.0
+        rules = agent.sample_rules(n=n_rules)
+        for toks in rules:
+            rule_text = builder.build(toks)
+            reward, metrics, _ = env._compute_reward(rule_text, update_stats=False)
+            f1_c += float(metrics.get("f1_clean", 0.0))
+            f1_d += float(metrics.get("f1_dummy", 0.0))
+            r_sum += float(reward)
+        n = max(len(rules), 1)
+        return {
+            "f1_clean": f1_c / n,
+            "f1_dummy": f1_d / n,
+            "reward": r_sum / n,
+        }
+
+    eval_interval = int(getattr(args, "eval_interval", total_steps))
+    n_eval_rules = int(getattr(args, "num_eval_rules", 5))
+    history: list[tuple[int, float]] = []
+    val_history: list[tuple[int, float, float, float]] = []
+
+    for step in range(0, total_steps, eval_interval):
+        seg = min(eval_interval, total_steps - step)
+        history.extend(
+            agent.train(
+                total_timesteps=seg,
+                log_interval=log_interval,
+                save_path=args.checkpoint,
+            )
+        )
+        metrics = _evaluate_agent(agent, env, n_eval_rules)
+        val_history.append(
+            (step + seg, metrics["f1_clean"], metrics["f1_dummy"], metrics["reward"])
+        )
+        logger.info(
+            "Validation @%d: f1_clean=%.4f f1_dummy=%.4f reward=%.4f",
+            step + seg,
+            metrics["f1_clean"],
+            metrics["f1_dummy"],
+            metrics["reward"],
+        )
 
     if args.plot_path:
         steps, rets = zip(*history) if history else ([], [])
@@ -712,6 +750,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Policy network architecture: 'gru', 'attn' or GPT model name",
     )
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")
+    pt.add_argument(
+        "--eval-interval",
+        type=int,
+        default=10_000,
+        help="Number of steps between validations",
+    )
+    pt.add_argument(
+        "--num-eval-rules",
+        type=int,
+        default=5,
+        help="How many rules to sample for validation",
+    )
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
     pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")
     pt.add_argument("--cpu", action="store_true", help="Force CPU even if CUDA available")


### PR DESCRIPTION
## Summary
- extend the `ppo-train` parser with `--eval-interval` and `--num-eval-rules`
- split training into segments and evaluate after each segment
- track validation results in `val_history`
- add helper for evaluating a sampled rule batch

## Testing
- `python -m py_compile src/cli/rulegen_cli.py`
- `PYTHONPATH=src pytest tests/test_ppo_train_cli.py::test_ppo_train_checks_dataset -q` *(fails: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_687c7cec45e4832e93b4ebba303633d8