### PR TITLE
Add checkpoint save after validation

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -511,6 +511,16 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         )
         _plot_history()
 
+        if args.checkpoint:
+            ckpt_path = Path(args.checkpoint)
+            ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+            agent.save(ckpt_path)
+            step_path = ckpt_path.with_name(
+                f"{ckpt_path.stem}_step{step + seg:04d}{ckpt_path.suffix}"
+            )
+            agent.save(step_path)
+            logger.info("Checkpoint saved → %s", step_path)
+
     _plot_history()
 
     if args.checkpoint:


### PR DESCRIPTION
## Summary
- persist PPO agent checkpoint after each validation round
- create step-specific checkpoint copies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric.data')*

------
https://chatgpt.com/codex/tasks/task_e_687c7fd5c220832e9bb0981f82417760