### PR TITLE
Fix GRUPolicy forward contiguity

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -135,6 +135,9 @@ class GRUPolicy(nn.Module):
         mask = obs != 0  # PAD=0
         if mask.ndim == 1:
             mask = mask.unsqueeze(0)
+            obs = obs.unsqueeze(0)
+            if hint is not None and hint.ndim == 1:
+                hint = hint.unsqueeze(0)
         x = self.embed(obs)  # (B,L,E)
         x = self.ln(x)
         lengths = mask.sum(dim=1).clamp(min=1)
@@ -161,7 +164,7 @@ class GRUPolicy(nn.Module):
                 hint_vec = self.hint_proj(hint_input)
 
             hint_seq = hint_vec.unsqueeze(1).expand(-1, x.size(1), -1)
-            x = torch.cat([x, hint_seq], dim=2)
+            x = torch.cat([x, hint_seq], dim=2).contiguous()
 
         x_packed = nn.utils.rnn.pack_padded_sequence(
             x, lengths.cpu(), batch_first=True, enforce_sorted=False


### PR DESCRIPTION
## Summary
- handle 1D input tensors in `GRUPolicy.forward`
- ensure tensors are contiguous before GRU by calling `torch.cat(...).contiguous()`

## Testing
- `pytest tests/test_gru_policy_hint.py -q`
- `PYTHONPATH=$PWD/src python -m src.cli.rulegen_cli ppo-train --train-features /tmp/train.json --dataset-dir /tmp/ds --epochs 1 --cpu --classifier-ckpt /tmp/ds/clf.pt --checkpoint /tmp/agent.pt` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_687c87ee5438832e902e6c4af618f3b0