### PR TITLE
Fix GRU flattening on forward and load

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -132,6 +132,7 @@ class GRUPolicy(nn.Module):
         logits : (B, vocab_size)
         value  : (B, 1)
         """
+        self.gru.flatten_parameters()
         mask = obs != 0  # PAD=0
         if mask.ndim == 1:
             mask = mask.unsqueeze(0)
@@ -285,6 +286,7 @@ class PPORuleAgent:
                             new_vec = torch.matmul(proj_w, vec)
                         with torch.no_grad():
                             self.policy.embed.weight[tid] = new_vec
+            self.policy.gru.flatten_parameters()
         elif policy_net.lower() == "attn":
             from models.attn_policy import AttnPolicy
 
@@ -565,6 +567,8 @@ class PPORuleAgent:
         self.policy.load_state_dict(
             torch.load(path, map_location=self.device, weights_only=False)
         )
+        if hasattr(self.policy, "gru"):
+            self.policy.gru.flatten_parameters()
         _LOG.info("Loaded PPO policy ← %s", path)
 
     @torch.no_grad()


### PR DESCRIPTION
## Summary
- ensure GRU parameters are flattened before each forward pass
- flatten GRU params on agent init and checkpoint load to avoid runtime errors

## Testing
- `pytest tests/test_gru_policy_hint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c8b02bbc4832ea0cad435f0da33f1