### PR TITLE
Add pad_id param in policies and tests

### DIFF
--- a/src/models/attn_policy.py
+++ b/src/models/attn_policy.py
@@ -20,11 +20,13 @@ class AttnPolicy(nn.Module):
         *,
         use_hint: bool = False,
         hint_size: int | None = None,
+        pad_id: int = 0,
     ) -> None:
         super().__init__()
         self.use_hint = use_hint
         self.hint_size = hint_size
-        self.embed = nn.Embedding(vocab_size, embed_dim, padding_idx=0)
+        self.pad_id = pad_id
+        self.embed = nn.Embedding(vocab_size, embed_dim, padding_idx=pad_id)
         self.attn = nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
         self.gru = nn.GRU(
             input_size=embed_dim * (2 if use_hint else 1),
@@ -49,7 +51,7 @@ class AttnPolicy(nn.Module):
     def forward(
         self, obs: torch.Tensor, hint: torch.Tensor | None = None
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        mask = obs != 0
+        mask = obs != self.pad_id
         if mask.ndim == 1:
             mask = mask.unsqueeze(0)
         x = self.embed(obs)

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -90,9 +90,11 @@ class GRUPolicy(nn.Module):
         gru_layers: int = 1,
         use_hint: bool = False,
         hint_size: int | None = None,
+        pad_id: int = 0,
     ):
         super().__init__()
-        self.embed = nn.Embedding(vocab_size, embed_dim, padding_idx=0)
+        self.pad_id = pad_id
+        self.embed = nn.Embedding(vocab_size, embed_dim, padding_idx=pad_id)
         self.ln = nn.LayerNorm(embed_dim)
         self.use_hint = use_hint
         self.hint_size = hint_size
@@ -133,7 +135,7 @@ class GRUPolicy(nn.Module):
         value  : (B, 1)
         """
         self.gru.flatten_parameters()
-        mask = obs != 0  # PAD=0
+        mask = obs != self.pad_id
         if mask.ndim == 1:
             mask = mask.unsqueeze(0)
             obs = obs.unsqueeze(0)
@@ -260,6 +262,7 @@ class PPORuleAgent:
                 embed_dim=128,
                 hidden_size=256,
                 use_hint=use_hint,
+                pad_id=env.token2id[env.PAD],
             ).to(self.device)
             # --------------------------------------------------------------
             # Optional: initialise embeddings from classifier encoder
@@ -295,6 +298,7 @@ class PPORuleAgent:
                 embed_dim=128,
                 hidden_size=256,
                 use_hint=use_hint,
+                pad_id=env.token2id[env.PAD],
             ).to(self.device)
         else:
             _LOG.info("Using GPT policy: %s", policy_net)

--- a/tests/test_gru_policy_hint.py
+++ b/tests/test_gru_policy_hint.py
@@ -16,7 +16,9 @@ from src.rulegen.rl_agent import GRUPolicy
 
 
 def test_policy_no_hint():
-    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=False)
+    policy = GRUPolicy(
+        vocab_size=10, embed_dim=8, hidden_size=16, use_hint=False, pad_id=0
+    )
     obs = torch.tensor([[1, 2, 0], [3, 0, 0]], dtype=torch.long)
     logits, value = policy(obs)
     assert logits.shape == (2, 10)
@@ -24,7 +26,9 @@ def test_policy_no_hint():
 
 
 def test_policy_with_hint():
-    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True)
+    policy = GRUPolicy(
+        vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True, pad_id=0
+    )
     obs = torch.tensor([[1, 2, 0], [3, 4, 0]], dtype=torch.long)
     hint = torch.tensor([[5, 6], [7, 8]], dtype=torch.long)
     logits, value = policy(obs, hint)
@@ -33,7 +37,9 @@ def test_policy_with_hint():
 
 
 def test_policy_hint_none():
-    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True)
+    policy = GRUPolicy(
+        vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True, pad_id=0
+    )
     obs = torch.tensor([[1, 0, 0]], dtype=torch.long)
     logits, value = policy(obs)
     assert logits.shape == (1, 10)
@@ -41,7 +47,9 @@ def test_policy_hint_none():
 
 
 def test_policy_single_dim_inputs():
-    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True)
+    policy = GRUPolicy(
+        vocab_size=10, embed_dim=8, hidden_size=16, use_hint=True, pad_id=0
+    )
     obs = torch.tensor([1, 2, 0], dtype=torch.long)
     hint = torch.tensor([5, 6], dtype=torch.long)
     logits, value = policy(obs, hint)
@@ -56,9 +64,18 @@ def test_policy_vector_hint():
         hidden_size=16,
         use_hint=True,
         hint_size=4,
+        pad_id=0,
     )
     obs = torch.tensor([[1, 2, 0]], dtype=torch.long)
     hint = torch.randn(1, 4)
     logits, value = policy(obs, hint)
+    assert logits.shape == (1, 10)
+    assert value.shape == (1,)
+
+
+def test_policy_custom_pad_id():
+    policy = GRUPolicy(vocab_size=10, embed_dim=8, hidden_size=16, pad_id=1)
+    obs = torch.tensor([[1, 2, 1, 1]], dtype=torch.long)
+    logits, value = policy(obs)
     assert logits.shape == (1, 10)
     assert value.shape == (1,)

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -47,6 +47,7 @@ def test_env_instantiates(tmp_path):
     )
 
     assert env.action_space.n == len(env.token2id)
+    assert env.token2id[env.PAD] != 0
 
 
 def test_reset_with_hints(tmp_path):
@@ -151,3 +152,25 @@ def test_action_mask_length(tmp_path):
 def test_rule_tokenize_subtokens():
     result = RuleGenEnv._rule_tokenize("CreateFileW")
     assert result == ["Create", "File", "W"]
+
+
+def test_pad_index_nonzero(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 5, "<END>": 6}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_ckpt=tmp_path / "clf.pt",
+        device="cpu",
+    )
+
+    obs, _ = env.reset()
+    assert (obs == env.token2id[env.PAD]).sum() > 0


### PR DESCRIPTION
## Summary
- add `pad_id` constructor arg to `GRUPolicy` and `AttnPolicy`
- use environment pad index when creating policies in `PPORuleAgent`
- update related tests and add coverage for custom pad id

## Testing
- `pytest tests/test_gru_policy_hint.py tests/test_rl_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c8e633348832eaa95cccd0e2278da