### PR TITLE
Handle unmatched delimiters in YaraBuilder

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -273,6 +273,17 @@ class YaraBuilder:
             return feat
         if feat.startswith('"') and feat.endswith('"'):
             return feat
+        # handle unmatched quote/braces/regex delimiters
+        if feat.count('"') == 1:
+            feat = feat.replace('"', '')
+        if feat.startswith('{') and not feat.endswith('}'):
+            feat = feat.lstrip('{')
+        elif feat.endswith('}') and not feat.startswith('{'):
+            feat = feat.rstrip('}')
+        if feat.startswith('/') and not feat.endswith('/'):
+            feat = feat.lstrip('/')
+        elif feat.endswith('/') and not feat.startswith('/'):
+            feat = feat.rstrip('/')
         # 기본: ASCII+nocase
         escaped = feat.replace("\\", r"\\").replace('"', r"\"")
         return f"\"{escaped}\" nocase ascii"

--- a/tests/test_yara_builder_quotes.py
+++ b/tests/test_yara_builder_quotes.py
@@ -1,0 +1,21 @@
+import pytest
+from src.rulegen.yara_builder import YaraBuilder
+
+
+@pytest.mark.parametrize(
+    "feat",
+    [
+        '"foo',    # leading quote only
+        'foo"',    # trailing quote only
+        '{AA BB',  # missing closing brace
+        'AA BB}',  # missing opening brace
+        '/abc',    # missing closing slash
+        'abc/',    # missing opening slash
+    ],
+)
+def test_unbalanced_delimiters_compile(feat):
+    builder = YaraBuilder()
+    rule = builder.build([feat])
+    ok, err = builder.validate(rule)
+    assert ok, f"Failed to validate YARA rule for {feat}: {err}"
+


### PR DESCRIPTION
## Summary
- improve `_to_yara_string` to sanitize unmatched quotes, braces, or regex slashes
- add tests ensuring YARA compilation succeeds with unbalanced delimiters

## Testing
- `pytest -q tests/test_yara_builder_quotes.py`

------
https://chatgpt.com/codex/tasks/task_e_687c9db728c0832ebd023f36f0459d1c