### PR TITLE
Fix training mode toggle in rule sampling

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -598,6 +598,7 @@ class PPORuleAgent:
         max_len : optional max token length (defaults to env max_len)
         """
 
+        was_training = self.policy.training
         self.policy.eval()
         max_len = max_len or self.env.max_len
         rules: List[List[str]] = []
@@ -638,6 +639,8 @@ class PPORuleAgent:
             ]
             rules.append(rule_tokens)
 
+        if was_training:
+            self.policy.train()
         return rules
 
 


### PR DESCRIPTION
## Summary
- ensure `sample_rules()` restores model mode after generation

## Testing
- `pytest tests/test_gru_policy_hint.py -q`
- `pytest -k rl_agent -q` *(fails: missing torch_geometric)*

------
https://chatgpt.com/codex/tasks/task_e_687cb9925014832e8a8b02f54a8c4706