### PR TITLE
Add PPO max-vocab option

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -130,6 +130,7 @@ The final stages of the pipeline, involving the explainer and RL-based feature m
     ```bash
     python -m src.cli.rulegen_cli ppo-train --train-features features.json --dataset-dir data/rulegen_dataset --epochs 5 --checkpoint models/rulegen/ppo_agent.pt
     ```
+    You can limit the vocabulary with `--max-vocab N` to keep only the top-N tokens from hints.
 -   **YARA Rule Generation:** The `cli.rulegen_cli generate` command now correctly loads the trained agent and generates meaningful YARA rules.
     ```bash
     python -m src.cli.rulegen_cli generate --agent-checkpoint models/rulegen/ppo_agent.pt --n-rules 200 --out models/rulegen/yara/generated_rules.yar

--- a/README.md
+++ b/README.md
@@ -208,11 +208,14 @@ python -m cli.rulegen_cli build-dataset \
 # 강화학습용 feature 추출
 
 python -m cli.rulegen_cli ppo-train \
-          --train-features features.json \
-          --val-features val_features.json \
-          --hint-features hints.json \
-          --config configs/rulegen/ppo.yaml \
-          --checkpoint models/rulegen/ppo_agent.pt
+       --train-features features.json \
+       --val-features val_features.json \
+       --hint-features hints.json \
+       --max-vocab 500 \
+       --config configs/rulegen/ppo.yaml \
+       --checkpoint models/rulegen/ppo_agent.pt
+# Use `--max-vocab` to keep only the N most frequent tokens when
+# building the vocabulary from hint features.
 # `--val-features` can point to a JSONL or JSON array.  When provided,
 # these features are loaded via `_read_json_lines` and used as hints when
 # sampling validation rules.

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -408,7 +408,9 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         hint_feats = [f for f in feats if not (f in seen or seen.add(f))]
 
     # Collect token vocabulary from hint features
-    token_set: set[str] = set()
+    from collections import Counter
+
+    token_counter: Counter[str] = Counter()
     try:
         rule_tokenize = rulegen.rl_env.RuleGenEnv._rule_tokenize  # type: ignore[attr-defined]
     except AttributeError:  # fallback in tests where rulegen.rl_env is stubbed
@@ -417,15 +419,17 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
 
     for f in hint_feats or []:
         for tok in rule_tokenize(str(f)):
-            token_set.add(tok)
+            token_counter[tok] += 1
             tok_lower = tok.lower()
             if "file" in tok_lower:
-                token_set.add("<FileOp>")
+                token_counter["<FileOp>"] += 1
             if "reg" in tok_lower:
-                token_set.add("<RegistryOp>")
+                token_counter["<RegistryOp>"] += 1
 
-    token_list = sorted(token_set)
-    token2id = {tok: idx for idx, tok in enumerate(token_list)}
+    if args.max_vocab:
+        token_list = [t for t, _ in token_counter.most_common(args.max_vocab)]
+    else:
+        token_list = sorted(token_counter)
     hint_tokens = token_list
 
 
@@ -436,7 +440,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         dataset_dir=dataset_dir,
         device=device,
         hint_features=hint_tokens,
-        classifier_checkpoint=args.classifier_checkpoint,
+        classifier_ckpt=args.classifier_checkpoint,
         seed=args.seed,
     )
     sched_cfg = cfg.get("scheduler", {})
@@ -816,6 +820,11 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=5,
         help="How many rules to sample for validation",
+    )
+    pt.add_argument(
+        "--max-vocab",
+        type=int,
+        help="Keep only the N most frequent tokens from hints",
     )
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
     pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")


### PR DESCRIPTION
## Summary
- add `--max-vocab` CLI option to limit RL vocab size
- keep only top-N hint tokens in `ppo-train`
- pass classifier checkpoint under legacy alias
- document the new option in README and GEMINI

## Testing
- `python - <<'PY'
import sys, types
stub = types.ModuleType('torch_geometric');
data_mod = types.ModuleType('torch_geometric.data');
data_mod.Data = type('Data', (), {}); data_mod.HeteroData = type('HeteroData', (), {});
stub.data = data_mod
sys.modules['torch_geometric'] = stub; sys.modules['torch_geometric.data'] = data_mod
import pytest
ret = pytest.main(['tests/test_ppo_train_cli.py', '-q']); sys.exit(ret)
PY

------
https://chatgpt.com/codex/tasks/task_e_687cea3aee88832ea32defb8e412a03d