### PR TITLE
Add penalty for invalid rule evaluation

### DIFF
--- a/src/evaluation/rule_evaluator.py
+++ b/src/evaluation/rule_evaluator.py
@@ -85,7 +85,7 @@ class RuleEvaluator:
 
         except Exception as exc:
             log.warning("Rule compilation failed: %s", exc)
-            return 0.0, 0.0, 0.0
+            return 0.0, 0.0, -1.0
 
         TP = FP = FN = TN = 0
 
@@ -135,4 +135,4 @@ class RuleEvaluator:
             return f1_clean, f1_dummy, certified_r
         except Exception as exc:  # pragma: no cover - unexpected evaluation errors
             log.warning("rule evaluation failed: %s", exc)
-            return 0.0, 0.0, 0.0
+            return 0.0, 0.0, -1.0

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -453,6 +453,8 @@ class RuleGenEnv(gym.Env):
             dummy_set,
         )
 
+        invalid_rule = certified_r < 0
+
         rule_len = len(self._rule_tokenize(rule_text))
 
         reward = (
@@ -461,6 +463,9 @@ class RuleGenEnv(gym.Env):
             - 0.05 * rule_len
             + (0.05 if certified_r >= 2 else 0.0)
         )
+
+        if invalid_rule:
+            reward -= 1.0
 
         used_tokens = self._rule_tokenize(rule_text)
         if used_tokens:
@@ -473,6 +478,7 @@ class RuleGenEnv(gym.Env):
             f1_dummy=f1_dummy,
             rule_len=rule_len,
             certified_r=certified_r,
+            invalid_rule=invalid_rule,
             saliency_bonus=bonus,
             reward=reward,
         )

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -42,7 +42,7 @@ def test_env_instantiates(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=8,
-        classifier_ckpt=tmp_path / "clf.pt",
+        classifier_checkpoint=tmp_path / "clf.pt",
         device="cpu",
     )
 
@@ -64,7 +64,7 @@ def test_reset_with_hints(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=4,
-        classifier_ckpt=tmp_path / "clf.pt",
+        classifier_checkpoint=tmp_path / "clf.pt",
         device="cpu",
         hint_features=["A"],
     )
@@ -87,7 +87,7 @@ def test_reset_multiple_hints(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=4,
-        classifier_ckpt=tmp_path / "clf.pt",
+        classifier_checkpoint=tmp_path / "clf.pt",
         device="cpu",
         hint_features=["A", "B"],
     )
@@ -111,7 +111,7 @@ def test_action_mask_parentheses(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=4,
-        classifier_ckpt=tmp_path / "clf.pt",
+        classifier_checkpoint=tmp_path / "clf.pt",
         device="cpu",
     )
 
@@ -138,7 +138,7 @@ def test_action_mask_length(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=2,
-        classifier_ckpt=tmp_path / "clf.pt",
+        classifier_checkpoint=tmp_path / "clf.pt",
         device="cpu",
     )
 
@@ -168,9 +168,33 @@ def test_pad_index_nonzero(tmp_path):
         vocab_file=vocab_file,
         dataset_dir=tmp_path,
         max_len=4,
-        classifier_ckpt=tmp_path / "clf.pt",
+        classifier_checkpoint=tmp_path / "clf.pt",
         device="cpu",
     )
 
     obs, _ = env.reset()
     assert (obs == env.token2id[env.PAD]).sum() > 0
+
+def test_compute_reward_penalizes_invalid_rule(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+    )
+
+    monkeypatch.setattr(env.evaluator, "evaluate_rule", lambda *args, **kwargs: (0.0, 0.0, -1.0))
+    reward, metrics, _ = env._compute_reward("", update_stats=False)
+    assert metrics["invalid_rule"]
+    assert reward <= -1.0
+

--- a/tests/test_rule_evaluator.py
+++ b/tests/test_rule_evaluator.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+from src.evaluation.rule_evaluator import RuleEvaluator
+
+
+class DummyClf(torch.nn.Module):
+    def forward(self, data):
+        return torch.zeros(len(data), dtype=torch.float)
+
+
+def test_evaluate_rule_failure_returns_negative(tmp_path):
+    evaluator = RuleEvaluator(clf=DummyClf())
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    f1_clean, f1_dummy, certified_r = evaluator.evaluate_rule(
+        "rule foo { condition: true }", clean, dummy
+    )
+    assert (f1_clean, f1_dummy) == (0.0, 0.0)
+    assert certified_r < 0


### PR DESCRIPTION
## Summary
- return a negative radius on rule evaluation failure
- penalize invalid rules in PPO reward computation
- adjust RL environment tests for new parameter name
- add unit test for evaluation failure sentinel

## Testing
- `PYTHONPATH=src pytest tests/test_rule_evaluator.py tests/test_rl_env.py::test_compute_reward_penalizes_invalid_rule -q`

------
https://chatgpt.com/codex/tasks/task_e_687cec5ff298832e8ad315b6c97a5151