### PR TITLE
Improve RLEnv token masking

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -129,11 +129,17 @@ class RuleGenEnv(gym.Env):
         # ── Vocabulary & tokenizer ────────────────────────────
         if vocab_file is None:
             if hint_features:
-                self.token2id = {tok: i for i, tok in enumerate(sorted(set(hint_features)))}
+                self.token2id = {
+                    tok: i for i, tok in enumerate(sorted(set(hint_features)))
+                }
                 vocab_file = Path(dataset_dir) / "rule_vocab.json"
                 with open(vocab_file, "w") as f:
                     json.dump(self.token2id, f, ensure_ascii=False, indent=2)
-                _LOG.info("Saved vocab (%d tokens) from hint_features → %s", len(self.token2id), vocab_file)
+                _LOG.info(
+                    "Saved vocab (%d tokens) from hint_features → %s",
+                    len(self.token2id),
+                    vocab_file,
+                )
             else:
                 _LOG.info("Vocab file not provided → mining from train split …")
                 vocab_file = self._build_vocab(Path(dataset_dir) / "train")
@@ -150,6 +156,30 @@ class RuleGenEnv(gym.Env):
 
         self.vocab_size = len(self.token2id)
         self.max_len = max_len
+
+        # categorize tokens for action masking
+        self._colon_id = self.token2id.get(":")
+        self._string_token_ids = {
+            tid
+            for tok, tid in self.token2id.items()
+            if (
+                len(tok) >= 2
+                and (
+                    (tok[0] == '"' and tok[-1] == '"')
+                    or (tok[0] == "'" and tok[-1] == "'")
+                )
+            )
+        }
+        self._number_token_ids = {
+            tid
+            for tok, tid in self.token2id.items()
+            if re.fullmatch(r"[0-9A-Fa-f]+", tok)
+        }
+        _punct = {":", ".", ",", ";", "(", ")", "[", "]", "{", "}"}
+        self._punct_token_ids = {
+            tid for tok, tid in self.token2id.items() if tok in _punct
+        }
+        self._number_token_strings = {self.id2token[i] for i in self._number_token_ids}
 
         # token saliency weights
         self.token_saliency = token_saliency or {}
@@ -272,7 +302,9 @@ class RuleGenEnv(gym.Env):
         shaping = 0.0
         metrics = {}
         if compute_reward:
-            final_r, metrics, shaping = self._compute_reward(rule_text, update_stats=done)
+            final_r, metrics, shaping = self._compute_reward(
+                rule_text, update_stats=done
+            )
             if done:
                 if self.normalize_reward:
                     std = self.running_stats.std or 1.0
@@ -331,8 +363,12 @@ class RuleGenEnv(gym.Env):
         • 각 텐서는 복수 HeteroData 리스트
         """
         ds_dir = Path(dataset_dir)
-        self.clean_set: List[HeteroData] = torch.load(ds_dir / "clean.pt", weights_only=False)
-        self.dummy_set: List[HeteroData] = torch.load(ds_dir / "dummy.pt", weights_only=False)
+        self.clean_set: List[HeteroData] = torch.load(
+            ds_dir / "clean.pt", weights_only=False
+        )
+        self.dummy_set: List[HeteroData] = torch.load(
+            ds_dir / "dummy.pt", weights_only=False
+        )
         _LOG.info(
             "Loaded dataset — clean:%d, dummy:%d",
             len(self.clean_set),
@@ -377,9 +413,10 @@ class RuleGenEnv(gym.Env):
     def _pad_obs(self, toks: Sequence[int]) -> np.ndarray:
         obs_len = self.observation_space.shape[0]
         arr = np.full((obs_len,), fill_value=self.token2id[self.PAD], dtype=np.int32)
-        n = min(len(toks), obs_len)
+        all_toks = list(self._hint_tokens) + list(toks)
+        n = min(len(all_toks), obs_len)
         if n:
-            arr[:n] = list(toks)[:n]
+            arr[:n] = all_toks[:n]
         return arr
 
     def get_action_mask(
@@ -419,6 +456,31 @@ class RuleGenEnv(gym.Env):
             if opens <= closes:
                 mask[close_tok] = 0
 
+        # ':' usage rules
+        if self._colon_id is not None:
+            if not toks:
+                mask[self._colon_id] = 0
+            else:
+                prev = self.id2token[toks[-1]]
+                if prev in {":", "(", "[", "{", ",", "."}:
+                    mask[self._colon_id] = 0
+
+        # string/number token placement
+        if toks:
+            prev = self.id2token[toks[-1]]
+            if prev != ":":
+                for tid in self._string_token_ids:
+                    mask[tid] = 0
+            if prev != ":" and prev not in self._number_token_strings:
+                for tid in self._number_token_ids:
+                    mask[tid] = 0
+            if prev == ":":
+                for tid in self._punct_token_ids:
+                    mask[tid] = 0
+        else:
+            for tid in self._string_token_ids | self._number_token_ids:
+                mask[tid] = 0
+
         return mask
 
     # token → string → rule
@@ -440,7 +502,9 @@ class RuleGenEnv(gym.Env):
 
     # reward
     @torch.inference_mode()
-    def _compute_reward(self, rule_text: str, *, update_stats: bool = True) -> Tuple[float, dict, float]:
+    def _compute_reward(
+        self, rule_text: str, *, update_stats: bool = True
+    ) -> Tuple[float, dict, float]:
         clean_set = self.clean_set
         dummy_set = self.dummy_set
         if self.use_adv_perturb:
@@ -469,7 +533,9 @@ class RuleGenEnv(gym.Env):
 
         used_tokens = self._rule_tokenize(rule_text)
         if used_tokens:
-            bonus = 0.02 * np.mean([self.token_saliency.get(t, 0.0) for t in used_tokens])
+            bonus = 0.02 * np.mean(
+                [self.token_saliency.get(t, 0.0) for t in used_tokens]
+            )
         else:
             bonus = 0.0
         reward += bonus
@@ -497,10 +563,7 @@ class RuleGenEnv(gym.Env):
     @staticmethod
     def _rule_tokenize(text: str) -> List[str]:
         tokens = (
-            text.replace("(", " ( ")
-            .replace(")", " ) ")
-            .replace(":", " : ")
-            .split()
+            text.replace("(", " ( ").replace(")", " ) ").replace(":", " : ").split()
         )
         out: List[str] = []
         for tok in tokens:

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -7,10 +7,15 @@ pytest.importorskip("torch_geometric")
 pytest.importorskip("gymnasium")
 
 import src.evaluation as evaluation
+
 sys.modules.setdefault("evaluation", evaluation)
 
 import torch
 from torch_geometric.data import HeteroData
+
+# older PyTorch versions may miss this helper
+if not hasattr(torch.serialization, "add_safe_globals"):
+    setattr(torch.serialization, "add_safe_globals", lambda *a, **k: None)
 
 from src.rulegen.rl_env import RuleGenEnv
 import src.models.gnn.res_wrapper as res_wrapper
@@ -21,11 +26,14 @@ class DummyClf(torch.nn.Module):
     def forward(self, data):
         return torch.zeros(len(data), dtype=torch.float)
 
+
 dummy_clf = DummyClf()
 res_wrapper.RESGCLClassifier.load_pretrained = classmethod(
     lambda cls, path, map_location=None: dummy_clf
 )
-res_wrapper_pkg.RESGCLClassifier.load_pretrained = res_wrapper.RESGCLClassifier.load_pretrained
+res_wrapper_pkg.RESGCLClassifier.load_pretrained = (
+    res_wrapper.RESGCLClassifier.load_pretrained
+)
 
 
 def test_env_instantiates(tmp_path):
@@ -175,6 +183,7 @@ def test_pad_index_nonzero(tmp_path):
     obs, _ = env.reset()
     assert (obs == env.token2id[env.PAD]).sum() > 0
 
+
 def test_compute_reward_penalizes_invalid_rule(tmp_path, monkeypatch):
     clean = [HeteroData()]
     dummy = [HeteroData()]
@@ -193,8 +202,67 @@ def test_compute_reward_penalizes_invalid_rule(tmp_path, monkeypatch):
         device="cpu",
     )
 
-    monkeypatch.setattr(env.evaluator, "evaluate_rule", lambda *args, **kwargs: (0.0, 0.0, -1.0))
+    monkeypatch.setattr(
+        env.evaluator, "evaluate_rule", lambda *args, **kwargs: (0.0, 0.0, -1.0)
+    )
     reward, metrics, _ = env._compute_reward("", update_stats=False)
     assert metrics["invalid_rule"]
     assert reward <= -1.0
 
+
+def _build_env_for_mask(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab = {
+        "call": 0,
+        ":": 1,
+        "foo": 2,
+        '"BAR"': 3,
+        "42": 4,
+        "(": 5,
+        ")": 6,
+        "<PAD>": 7,
+        "<END>": 8,
+    }
+    vocab_file = tmp_path / "vocab.json"
+    json.dump(vocab, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=6,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+    )
+    env.reset()
+    return env
+
+
+def test_action_mask_colon_and_strings(tmp_path):
+    env = _build_env_for_mask(tmp_path)
+
+    mask = env.get_action_mask()
+    assert mask[env.token2id[":"]] == 0
+    assert mask[env.token2id['"BAR"']] == 0
+    assert mask[env.token2id["42"]] == 0
+
+    env._tokens = [env.token2id["call"]]
+    mask = env.get_action_mask()
+    assert mask[env.token2id[":"]] == 1
+
+    env._tokens = [env.token2id["("]]
+    mask = env.get_action_mask()
+    assert mask[env.token2id[":"]] == 0
+
+    env._tokens = [env.token2id["call"], env.token2id[":"]]
+    mask = env.get_action_mask()
+    assert mask[env.token2id['"BAR"']] == 1
+    assert mask[env.token2id["42"]] == 1
+
+    env._tokens = [env.token2id["call"], env.token2id[":"], env.token2id["42"]]
+    mask = env.get_action_mask()
+    assert mask[env.token2id["42"]] == 1


### PR DESCRIPTION
## Summary
- enhance token classification in `RuleGenEnv` for masking
- refine `_pad_obs` to include hint tokens
- apply context-aware rules in `get_action_mask`
- test colon, string, and number masking behaviour

## Testing
- `PYTHONPATH=src pytest -q tests/test_rl_env.py`

------
https://chatgpt.com/codex/tasks/task_e_687ceeb49cc4832ea38f56eee0038f2e