### PR TITLE
Improve yara builder feature extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ from rulegen import make_env
 env = make_env(hint_features=["import", "pe", "strings", "$a"])
 obs, _ = env.reset()  # `reset()` 호출 시 다른 힌트를 전달할 수도 있습니다.
 ```
+# The YARA builder keeps at least one real feature even when token
+# extraction fails. Short hint tokens such as `pe` are accepted
+# without padding.
 # XAI selector 학습
 # 분류기가 HeteroData 그래프를 입력으로 받아도 동일하게 사용할 수 있습니다.
 

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -92,15 +92,21 @@ def _detokenize(tokens: Sequence[str]) -> str:
 
 
 def _token_is_feature(tok: str) -> bool:
+    """Return True if ``tok`` resembles a feature string.
+
+    The original logic rejected tokens shorter than three characters and
+    filtered out anything containing whitespace.  This caused perfectly
+    valid short hints such as ``pe`` to be dropped.  Tokens are now trimmed
+    and allowed when at least two characters long, ignoring spaces but still
+    excluding control characters.
     """
-    문자열 정의 대상이 될 만한 토큰인지.
-    (길이 ≥3 and 알파벳/숫자 포함 and 제어문자·공백 없음)
-    """
-    if len(tok) < 3:
+
+    tok = tok.strip()
+    if len(tok) < 2:
         return False
     if not any(c.isalnum() for c in tok):
         return False
-    if any(c in string.whitespace for c in tok):
+    if any(ord(c) < 32 for c in tok):
         return False
     return True
 
@@ -138,6 +144,11 @@ class YaraBuilder:
 
         # 2) feature 선정
         unique_feats = self._extract_features(tokens)
+        if not unique_feats:
+            for tok in tokens:
+                if _token_is_feature(tok):
+                    unique_feats = [tok]
+                    break
         if not unique_feats:
             unique_feats = ["dummy_token_unlikely_to_match"]
 

--- a/tests/test_yara_builder_feature_fallback.py
+++ b/tests/test_yara_builder_feature_fallback.py
@@ -1,0 +1,10 @@
+import pytest
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_build_uses_short_token_when_no_features():
+    builder = YaraBuilder()
+    # previously rejected because len < 3
+    rule = builder.build(["pe"])
+    assert "pe" in rule
+


### PR DESCRIPTION
## Summary
- loosen `_token_is_feature` rules to allow short tokens and ignore whitespace
- choose a real token if no feature candidates exist when building rules
- document new fallback in README
- test builder fallback behavior

## Testing
- `pytest -q tests/test_yara_builder_feature_fallback.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687cf1f01870832e8a40860ec470abd8