### PR TITLE
Add metadata attributes when building PPO dataset

### DIFF
--- a/src/cli/build_ppo_dataset.py
+++ b/src/cli/build_ppo_dataset.py
@@ -67,8 +67,18 @@ def _load_graph(graph_dir: Path, sha: str):
         import pickle
 
         with path.open("rb") as f:
-            return pickle.load(f)
-    return torch.load(path, map_location="cpu", weights_only=False)
+            g = pickle.load(f)
+    else:
+        g = torch.load(path, map_location="cpu", weights_only=False)
+
+    # attach metadata used by RuleEvaluator and other components
+    try:
+        g.file_path = str(path)
+        g.sha256 = sha
+    except Exception:
+        # non-data objects may not allow attribute assignment
+        pass
+    return g
 
 
 def main(argv: List[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- enrich `_load_graph` in `build_ppo_dataset.py` to store `file_path` and `sha256`
- keep this metadata when saving clean/dummy graph lists

## Testing
- `pytest -k build_ppo_dataset -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_687d16b9a3f8832e9b75cad6fef4cb28