### PR TITLE
Add condition-type option for PPO training

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -466,7 +466,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         *,
         hint_features: list[str] | None = None,
     ) -> dict:
-        builder = YaraBuilder() if getattr(env, "rule_type", "yara") == "yara" else CapaBuilder()
+        builder = (
+            YaraBuilder(condition_type=args.condition_type)
+            if getattr(env, "rule_type", "yara") == "yara"
+            else CapaBuilder()
+        )
         f1_c = f1_d = r_sum = 0.0
         orig_hints = getattr(env, "hint_features", None)
         if hint_features is not None and hasattr(env, "hint_features"):
@@ -562,7 +566,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         # NOTE: 학습에 사용된 설정 파일과 생성된 예시 룰을
         #       동일한 디렉터리 아래에 보관하면 관리가 용이하다.
 
-        builder = YaraBuilder()
+        builder = YaraBuilder(condition_type=args.condition_type)
         sample_tokens = agent.sample_rules(n=1)[0]
         sample_rule = builder.build(sample_tokens)
         out_dir = Path("results")
@@ -807,6 +811,12 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument(
         "--policy",
         help="Policy network architecture: 'gru', 'attn' or GPT model name",
+    )
+    pt.add_argument(
+        "--condition-type",
+        choices=["any", "all", "percentage"],
+        default="any",
+        help="Condition aggregation strategy ('any', 'all', 'percentage'), defaults to 'any'",
     )
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")
     pt.add_argument(


### PR DESCRIPTION
## Summary
- allow selecting Yara condition aggregation with `--condition-type`
- propagate option to rule sampling and example rule generation

## Testing
- `pytest tests/test_ppo_train_cli.py::test_hint_file_passed -q` *(fails: ModuleNotFoundError: No module named 'common')*

------
https://chatgpt.com/codex/tasks/task_e_687d47dedf58832eb35c2215116d6a32