### PR TITLE
Implement Lagrange constraint for PPO agent

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -529,6 +529,8 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             schedule_type=sched_name,
             total_updates=total_steps,
             seed=args.seed,
+            constraint_thresh=args.constraint_thresh,
+            lagrange_lr=args.lagrange_lr,
         )
     except TypeError:
         # backward compatibility with older API in tests
@@ -919,6 +921,18 @@ def _build_parser() -> argparse.ArgumentParser:
         "--reward-weights",
         type=_parse_reward_weights,
         help="JSON mapping or path with reward weights",
+    )
+    pt.add_argument(
+        "--constraint-thresh",
+        type=float,
+        default=0.5,
+        help="Constraint threshold for f1_clean",
+    )
+    pt.add_argument(
+        "--lagrange-lr",
+        type=float,
+        default=0.01,
+        help="Lagrange multiplier learning rate",
     )
     pt.add_argument(
         "--cpu", action="store_true", help="Force CPU even if CUDA available"

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -201,6 +201,8 @@ def load_agent(
     schedule_type: str | None = None,
     total_updates: int | None = None,
     seed: int | None = None,
+    constraint_thresh: float = 0.5,
+    lagrange_lr: float = 0.01,
     **env_kwargs: Any,
 ) -> PPORuleAgent:
     """
@@ -227,6 +229,8 @@ def load_agent(
         schedule_type=schedule_type,
         total_updates=total_updates,
         seed=seed if seed is not None else 2024,
+        constraint_thresh=constraint_thresh,
+        lagrange_lr=lagrange_lr,
     )
     if ckpt_path:
         agent.load(ckpt_path)

--- a/src/rulegen/__init__.pyi
+++ b/src/rulegen/__init__.pyi
@@ -25,6 +25,8 @@ def load_agent(
     schedule_type: str | None = ...,
     total_updates: int | None = ...,
     seed: int | None = None,
+    constraint_thresh: float = ...,
+    lagrange_lr: float = ...,
     **env_kwargs: Dict[str, Any],
 ) -> PPORuleAgent: ...
 

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -235,6 +235,9 @@ class PPORuleAgent:
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         use_hint: bool = False,
         seed: int = 2024,
+        constraint_thresh: float = 0.5,
+        lagrange_lr: float = 0.01,
+        init_lagrange_multiplier: float = 1.0,
     ):
         set_random_seed(seed)
         self.env = env
@@ -253,6 +256,10 @@ class PPORuleAgent:
 
         self.device = torch.device(device)
         self.use_hint = use_hint
+
+        self.constraint_thresh = constraint_thresh
+        self.lagrange_lr = lagrange_lr
+        self.lagrange_multiplier = init_lagrange_multiplier
 
         self.policy_net = policy_net
 
@@ -342,6 +349,7 @@ class PPORuleAgent:
         self.val_buf: List[float] = []
         if self.use_hint:
             self.hint_buf: List[np.ndarray] = []
+        self.f1_buf: List[float] = []
 
     @torch.no_grad()
     def select_action(
@@ -411,6 +419,8 @@ class PPORuleAgent:
             self.val_buf.append(value)
             self.rew_buf.append(reward)
             self.done_buf.append(done or trunc)
+            metrics = info.get("metrics", {}) if isinstance(info, dict) else {}
+            self.f1_buf.append(float(metrics.get("f1_clean", 0.0)))
             if self.use_hint:
                 if hint is not None:
                     self.hint_buf.append(hint)
@@ -519,6 +529,15 @@ class PPORuleAgent:
         returns = advs + vals
         advs = (advs - advs.mean()) / (advs.std(unbiased=False) + 1e-8)
 
+        # --- constraint violation using f1_clean statistics
+        finished_idxs = [i for i, d in enumerate(self.done_buf) if d]
+        if finished_idxs:
+            avg_f1 = float(np.mean([self.f1_buf[i] for i in finished_idxs]))
+            violation = self.constraint_thresh - avg_f1
+        else:
+            avg_f1 = 0.0
+            violation = 0.0
+
         # 3) Epoch loop
         n_samples = obs.shape[0]
         idxs = np.arange(n_samples)
@@ -555,14 +574,26 @@ class PPORuleAgent:
                 v_loss2 = (value_clip - mb_returns).pow(2)
                 value_loss = 0.5 * torch.max(v_loss1, v_loss2).mean()
 
-                loss = pg_loss + self.vf_coef * value_loss - self.entropy_coef * entropy
+                constraint_penalty = self.lagrange_multiplier * violation
+                loss = (
+                    pg_loss
+                    + self.vf_coef * value_loss
+                    - self.entropy_coef * entropy
+                    + constraint_penalty
+                )
 
                 self.optimizer.zero_grad()
                 loss.backward()
                 nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
                 self.optimizer.step()
+
                 if self.scheduler is not None:
                     self.scheduler.step()
+
+        # update lagrange multiplier using constraint violation
+        self.lagrange_multiplier = max(
+            0.0, self.lagrange_multiplier + self.lagrange_lr * violation
+        )
 
         self.reset_rollout_buffers()
 


### PR DESCRIPTION
## Summary
- add constraint threshold and Lagrange multiplier options to `PPORuleAgent`
- store `f1_clean` during rollout and apply Lagrangian update in `_update`
- expose new options in the rulegen CLI
- pass parameters through `rulegen.load_agent`

## Testing
- `pytest -q` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d4ece9f58832eb5e3bcefe71a0e3a