### PR TITLE
Implement FP penalty scheduling for RuleGenEnv

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+import importlib, sys
+
+gnn = importlib.import_module('src.models.gnn')
+sys.modules[__name__ + '.gnn'] = gnn
+__all__ = ['gnn']

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -99,6 +99,9 @@ class RuleGenEnv(gym.Env):
         use_shaping: bool = False,
         use_adv_perturb: bool = False,
         reward_weights: dict | None = None,
+        fp_penalty_start: float = 1.0,
+        fp_penalty_end: float = 0.0,
+        curriculum_steps: int = 100000,
     ):
         """
         Parameters
@@ -119,6 +122,9 @@ class RuleGenEnv(gym.Env):
         core_tokens      : shaping potential 계산에 사용할 핵심 토큰 시퀀스
         use_shaping      : ``True``면 potential based reward shaping 활성화
         reward_weights   : F1/길이/인증 보상 가중치 딕셔너리
+        fp_penalty_start : 초기 False Positive 패널티 배율
+        fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
+        curriculum_steps : 패널티 스케줄 총 스텝 수
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -209,6 +215,11 @@ class RuleGenEnv(gym.Env):
         self.gamma = 0.99
         self.use_adv_perturb = bool(use_adv_perturb)
 
+        self.fp_penalty_start = float(fp_penalty_start)
+        self.fp_penalty_end = float(fp_penalty_end)
+        self.curriculum_steps = max(1, int(curriculum_steps))
+        self.total_steps = 0
+
         # Hint features / tokens
         self.hint_features = hint_features or []
         self._default_hint_tokens: List[int] = []
@@ -287,6 +298,7 @@ class RuleGenEnv(gym.Env):
         reward = 0.0
         info: dict = {}
         self._episode_steps += 1
+        self.total_steps += 1
 
         # 1) 토큰 append
         self._tokens.append(action)
@@ -531,6 +543,20 @@ class RuleGenEnv(gym.Env):
 
         rule_len = len(self._rule_tokenize(rule_text))
 
+        # dynamic FP penalty schedule
+        progress = min(self.total_steps, self.curriculum_steps) / self.curriculum_steps
+        curr_penalty = self.fp_penalty_start + (self.fp_penalty_end - self.fp_penalty_start) * progress
+
+        m = len(dummy_set)
+        n = len(clean_set)
+        denom = (2 - f1_dummy) - f1_clean
+        if denom == 0:
+            fp_count = 0.0
+        else:
+            fp_count = ((2 - f1_dummy) * n - f1_clean * (m * (1 - f1_dummy) + n * (2 - f1_dummy))) / denom
+            fp_count = max(fp_count, 0.0)
+        fp_rate = 0.0 if n == 0 else fp_count / n
+
         w = self.reward_weights
         weighted_f1 = w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy
         reward = weighted_f1 + w["rule_len"] * rule_len
@@ -539,6 +565,8 @@ class RuleGenEnv(gym.Env):
 
         if invalid_rule:
             reward -= 1.0
+
+        reward -= curr_penalty * fp_rate
 
         used_tokens = self._rule_tokenize(rule_text)
         if used_tokens:
@@ -554,6 +582,9 @@ class RuleGenEnv(gym.Env):
             rule_len=rule_len,
             certified_r=certified_r,
             invalid_rule=invalid_rule,
+            fp_rate=fp_rate,
+            fp_penalty=curr_penalty * fp_rate,
+            fp_penalty_factor=curr_penalty,
             saliency_bonus=bonus,
             reward=reward,
         )

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -294,3 +294,32 @@ def test_reward_weights_override(tmp_path, monkeypatch):
     monkeypatch.setattr(env.evaluator, "evaluate_rule", lambda *a, **k: (0.5, 0.2, 3.0))
     r, m, _ = env._compute_reward("", update_stats=False)
     assert pytest.approx(r) == 0.5
+
+
+def test_fp_penalty_curriculum(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        fp_penalty_start=1.0,
+        fp_penalty_end=0.0,
+        curriculum_steps=10,
+    )
+    monkeypatch.setattr(env.evaluator, "evaluate_rule", lambda *a, **k: (0.5, 0.5, 0.0))
+    env.total_steps = 0
+    r1, m1, _ = env._compute_reward("", update_stats=False)
+    env.total_steps = 10
+    r2, m2, _ = env._compute_reward("", update_stats=False)
+    assert r2 > r1
+    assert m1["fp_penalty"] > m2["fp_penalty"]


### PR DESCRIPTION
## Summary
- expand `RuleGenEnv` constructor with FP penalty scheduling parameters
- track `total_steps` in the environment
- apply step‐aware FP penalty in reward computation
- expose `src.models` and `src.common` modules via top-level packages
- test penalty scheduling logic

## Testing
- `pytest tests/test_rl_env.py::test_reward_weights_override -q` *(fails: ModuleNotFoundError: No module named 'common.running_stats')*
- `pytest tests/test_rl_env.py::test_fp_penalty_curriculum -q` *(fails: ModuleNotFoundError: No module named 'common.running_stats')*

------
https://chatgpt.com/codex/tasks/task_e_687d50bf754c832e9e20955f74745cb7