### PR TITLE
Implement warm-start pretraining for rule agent

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -41,3 +41,15 @@ python -m cli.rulegen_cli ppo-train \
     --reward-weights '{"f1_clean":0.7,"f1_dummy":0.2,"rule_len":-0.05}'
 ```
 
+## Warm-start
+
+`PPORuleAgent`는 GNN 분류기가 예측한 규칙 시퀀스와 라벨을 이용해 사전 학습할 수 있습니다.
+준비한 데이터셋을 `train()` 호출 시 인자로 전달하면 PPO 업데이트 전에 한 번 학습합니다.
+
+```python
+dataset = [([1, 2, 3], 1), ([4, 5], 0)]  # (token id list, label)
+agent.train(total_timesteps=50000,
+            pretrain_dataset=dataset,
+            pretrain_epochs=3)
+```
+

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -48,7 +48,7 @@ import argparse
 import logging
 import math
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Sequence
 
 import gymnasium as gym
 import numpy as np
@@ -111,6 +111,7 @@ class GRUPolicy(nn.Module):
         )
         self.pi_head = nn.Linear(hidden_size, vocab_size)
         self.v_head = nn.Linear(hidden_size, 1)
+        self.aux_head = nn.Linear(hidden_size, 2)
 
         # Orthogonal init (Amodei et al. 2016 style)
         for m in self.modules():
@@ -118,6 +119,47 @@ class GRUPolicy(nn.Module):
                 nn.init.orthogonal_(m.weight, gain=math.sqrt(2))
                 nn.init.zeros_(m.bias)
         nn.init.orthogonal_(self.pi_head.weight, gain=0.01)
+
+    def encode(
+        self,
+        obs: torch.Tensor,
+        hint: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return final hidden state for a batch of token sequences."""
+        self.gru.flatten_parameters()
+        mask = obs != self.pad_id
+        if mask.ndim == 1:
+            mask = mask.unsqueeze(0)
+            obs = obs.unsqueeze(0)
+            if hint is not None and hint.ndim == 1:
+                hint = hint.unsqueeze(0)
+        x = self.embed(obs)
+        x = self.ln(x)
+        lengths = mask.sum(dim=1).clamp(min=1)
+
+        if self.use_hint:
+            if self.hint_size is None:
+                if hint is None:
+                    hint_vec = torch.zeros(x.size(0), x.size(2), device=x.device, dtype=x.dtype)
+                else:
+                    hint_vec = self.embed(hint.long()).mean(dim=1)
+            else:
+                if hint is None:
+                    hint_input = torch.zeros((x.size(0), self.hint_size), device=x.device, dtype=x.dtype)
+                else:
+                    hint_input = hint.unsqueeze(0) if hint.ndim == 1 else hint
+                    hint_input = hint_input.to(x.dtype)
+                hint_vec = self.hint_proj(hint_input)
+
+            hint_seq = hint_vec.unsqueeze(1).expand(-1, x.size(1), -1)
+            x = torch.cat([x, hint_seq], dim=2).contiguous()
+
+        x_packed = nn.utils.rnn.pack_padded_sequence(
+            x, lengths.cpu(), batch_first=True, enforce_sorted=False
+        )
+        _, h_n = self.gru(x_packed)
+        h = h_n[-1]
+        return h
 
     def forward(
         self,
@@ -134,46 +176,7 @@ class GRUPolicy(nn.Module):
         logits : (B, vocab_size)
         value  : (B, 1)
         """
-        self.gru.flatten_parameters()
-        mask = obs != self.pad_id
-        if mask.ndim == 1:
-            mask = mask.unsqueeze(0)
-            obs = obs.unsqueeze(0)
-            if hint is not None and hint.ndim == 1:
-                hint = hint.unsqueeze(0)
-        x = self.embed(obs)  # (B,L,E)
-        x = self.ln(x)
-        lengths = mask.sum(dim=1).clamp(min=1)
-
-        if self.use_hint:
-            if self.hint_size is None:
-                if hint is None:
-                    hint_vec = torch.zeros(x.size(0), x.size(2), device=x.device, dtype=x.dtype)
-                else:
-                    hint_vec = self.embed(hint.long()).mean(dim=1)
-            else:
-                if hint is None:
-                    hint_input = torch.zeros(
-                        (x.size(0), self.hint_size),
-                        device=x.device,
-                        dtype=x.dtype,
-                    )
-                else:
-                    if hint.ndim == 1:
-                        hint_input = hint.unsqueeze(0)
-                    else:
-                        hint_input = hint
-                    hint_input = hint_input.to(x.dtype)
-                hint_vec = self.hint_proj(hint_input)
-
-            hint_seq = hint_vec.unsqueeze(1).expand(-1, x.size(1), -1)
-            x = torch.cat([x, hint_seq], dim=2).contiguous()
-
-        x_packed = nn.utils.rnn.pack_padded_sequence(
-            x, lengths.cpu(), batch_first=True, enforce_sorted=False
-        )
-        _, h_n = self.gru(x_packed)
-        h = h_n[-1]  # (B,H)
+        h = self.encode(obs, hint)
         logits = self.pi_head(h)
         value = self.v_head(h).squeeze(-1)
         return logits, value
@@ -351,6 +354,45 @@ class PPORuleAgent:
             self.hint_buf: List[np.ndarray] = []
         self.f1_buf: List[float] = []
 
+    def pretrain(
+        self,
+        dataset: Sequence[Tuple[Sequence[int], int]],
+        *,
+        epochs: int = 1,
+        batch_size: int = 64,
+        lr: float | None = None,
+    ) -> None:
+        """Warm-start the policy on a labeled rule dataset."""
+        pad_id = self.env.token2id.get(self.env.PAD, 0)
+
+        def collate(batch: Sequence[Tuple[Sequence[int], int]]):
+            seqs, labels = zip(*batch)
+            seq_t = [torch.tensor(s, dtype=torch.long) for s in seqs]
+            obs = nn.utils.rnn.pad_sequence(seq_t, batch_first=True, padding_value=pad_id)
+            lbl = torch.tensor(labels, dtype=torch.long)
+            return obs, lbl
+
+        loader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=True,
+            collate_fn=collate,
+        )
+
+        opt = torch.optim.Adam(self.policy.parameters(), lr=lr or self.optimizer.param_groups[0]["lr"])
+        loss_fn = nn.CrossEntropyLoss()
+        self.policy.train()
+        for _ in range(epochs):
+            for obs, lbl in loader:
+                obs = obs.to(self.device)
+                lbl = lbl.to(self.device)
+                h = self.policy.encode(obs)
+                logits = self.policy.aux_head(h)
+                loss = loss_fn(logits, lbl)
+                opt.zero_grad()
+                loss.backward()
+                opt.step()
+
     @torch.no_grad()
     def select_action(
         self,
@@ -393,6 +435,9 @@ class PPORuleAgent:
         total_timesteps: int,
         log_interval: int = 10_000,
         save_path: str | Path | None = None,
+        *,
+        pretrain_dataset: Sequence[Tuple[Sequence[int], int]] | None = None,
+        pretrain_epochs: int = 1,
     ) -> List[Tuple[int, float]]:
         """Run the main PPO loop.
 
@@ -408,6 +453,14 @@ class PPORuleAgent:
         interval_returns: List[float] = []
         avg_history: List[Tuple[int, float]] = []
         ep_return = 0.0
+
+        if pretrain_dataset is not None and pretrain_epochs > 0:
+            _LOG.info(
+                "Warm-starting policy on %d samples for %d epochs",
+                len(pretrain_dataset),
+                pretrain_epochs,
+            )
+            self.pretrain(pretrain_dataset, epochs=pretrain_epochs)
 
         for _ in pbar:
             action, logp, value = self.select_action(obs, hint)


### PR DESCRIPTION
## Summary
- add auxiliary classification head to `GRUPolicy`
- implement `PPORuleAgent.pretrain` and optional warm-start in `train`
- document warm-start workflow

## Testing
- `pytest tests/test_gru_policy_hint.py -q`
- `pytest -q` *(fails: missing `torch_geometric`)*

------
https://chatgpt.com/codex/tasks/task_e_687d5764a394832eb7165bb528644903