### PR TITLE
Add lookahead reward in RuleGenEnv

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -98,8 +98,9 @@ class RuleGenEnv(gym.Env):
         core_tokens: Sequence[str] | None = None,
         use_shaping: bool = False,
         use_adv_perturb: bool = False,
+        use_lookahead: bool = False,
         reward_weights: dict | None = None,
-        fp_penalty_start: float = 1.0,
+        fp_penalty_start: float = 0.0,
         fp_penalty_end: float = 0.0,
         curriculum_steps: int = 100000,
     ):
@@ -121,6 +122,7 @@ class RuleGenEnv(gym.Env):
         normalize_reward : ``True``면 보상을 평균 0, 표준편차 1로 표준화해 반환
         core_tokens      : shaping potential 계산에 사용할 핵심 토큰 시퀀스
         use_shaping      : ``True``면 potential based reward shaping 활성화
+        use_lookahead   : ``True``면 룰 미완성 시 분류기 확률을 임시 보상으로 사용
         reward_weights   : F1/길이/인증 보상 가중치 딕셔너리
         fp_penalty_start : 초기 False Positive 패널티 배율
         fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
@@ -210,6 +212,7 @@ class RuleGenEnv(gym.Env):
 
         self.core_tokens = set(core_tokens or [])
         self.use_shaping = use_shaping
+        self.use_lookahead = bool(use_lookahead)
         self._phi_last = 0.0
         self._episode_steps = 0
         self.gamma = 0.99
@@ -333,6 +336,10 @@ class RuleGenEnv(gym.Env):
                     final_r = (final_r - self.running_stats.mean) / std
                 reward += final_r
                 info["metrics"] = metrics
+        elif self.use_lookahead:
+            look_p = self._lookahead_prob(self._tokens)
+            reward += look_p
+            info["lookahead_prob"] = look_p
 
         if self.use_shaping:
             reward += shaping
@@ -521,6 +528,20 @@ class RuleGenEnv(gym.Env):
             from .capa_builder import tokens_to_capa  # type: ignore
 
             return tokens_to_capa(raw_tokens)
+
+    @torch.inference_mode()
+    def _lookahead_prob(self, tokens: Sequence[int]) -> float:
+        """Return classifier probability for the current token sequence."""
+        if not tokens:
+            return 0.0
+        x = torch.tensor(tokens, dtype=torch.long, device=self.device).unsqueeze(0)
+        out = self.classifier(x)
+        if isinstance(out, (tuple, list)):
+            out = out[0]
+        if out.ndim > 1:
+            out = out.squeeze(0)
+        prob = torch.sigmoid(out).squeeze().item()
+        return float(prob)
 
     # reward
     @torch.inference_mode()

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -23,7 +23,12 @@ import models.gnn.res_wrapper as res_wrapper_pkg
 
 
 class DummyClf(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
     def forward(self, data):
+        self.calls += 1
         return torch.zeros(len(data), dtype=torch.float)
 
 
@@ -323,3 +328,30 @@ def test_fp_penalty_curriculum(tmp_path, monkeypatch):
     r2, m2, _ = env._compute_reward("", update_stats=False)
     assert r2 > r1
     assert m1["fp_penalty"] > m2["fp_penalty"]
+
+
+def test_lookahead_reward(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        use_lookahead=True,
+    )
+
+    env.reset()
+    dummy_clf.calls = 0
+    _, r, done, tr, info = env.step(env.token2id["A"])
+    assert dummy_clf.calls == 1
+    assert not done
+    assert "lookahead_prob" in info


### PR DESCRIPTION
## Summary
- allow RuleGenEnv to give temporary reward based on classifier probability when the rule is incomplete
- control the behavior with a new `use_lookahead` flag
- set false-positive penalty off by default
- test lookahead reward path

## Testing
- `pytest tests/test_rl_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d597c20cc832e9c7baba53d5d815f