### PR TITLE
Add hint_size option to GPTPolicy

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -185,7 +185,13 @@ class GRUPolicy(nn.Module):
 class GPTPolicy(nn.Module):
     """GPT 기반 정책 네트워크 (실험용)."""
 
-    def __init__(self, model_name: str, vocab_size: int, use_hint: bool = False):
+    def __init__(
+        self,
+        model_name: str,
+        vocab_size: int,
+        use_hint: bool = False,
+        hint_size: int | None = None,
+    ):
         super().__init__()
         try:
             from transformers import AutoModelForCausalLM
@@ -195,6 +201,7 @@ class GPTPolicy(nn.Module):
             ) from exc
 
         self.use_hint = use_hint
+        self.hint_size = hint_size
         self.gpt = AutoModelForCausalLM.from_pretrained(model_name)
         hidden = getattr(self.gpt.config, "hidden_size", 768)
         self.pi_head = nn.Linear(hidden, vocab_size)
@@ -312,7 +319,12 @@ class PPORuleAgent:
             ).to(self.device)
         else:
             _LOG.info("Using GPT policy: %s", policy_net)
-            self.policy = GPTPolicy(policy_net, env.action_space.n, use_hint).to(self.device)
+            self.policy = GPTPolicy(
+                policy_net,
+                env.action_space.n,
+                use_hint,
+                hint_size=None,
+            ).to(self.device)
 
         self.optimizer = torch.optim.Adam(self.policy.parameters(), lr=lr)
 

--- a/tests/test_gpt_policy_hint.py
+++ b/tests/test_gpt_policy_hint.py
@@ -1,0 +1,59 @@
+import sys
+import types
+from pathlib import Path
+import pytest
+
+torch = pytest.importorskip("torch")
+
+# Provide a lightweight transformers stub
+trans_stub = types.ModuleType("transformers")
+
+gym_stub = types.ModuleType("gymnasium")
+gym_stub.Env = object
+
+
+class _Box:
+    def __init__(self, *a, **k):
+        pass
+
+
+class _Discrete:
+    def __init__(self, *a, **k):
+        pass
+
+
+gym_stub.spaces = types.SimpleNamespace(Box=_Box, Discrete=_Discrete)
+gym_stub.registry = {}
+gym_stub.register = lambda *a, **k: None
+sys.modules.setdefault("gymnasium", gym_stub)
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = types.SimpleNamespace(hidden_size=4)
+
+    def forward(self, input_ids=None, **kwargs):
+        bsz, seq_len = input_ids.shape
+        hidden = torch.zeros(bsz, seq_len, self.config.hidden_size)
+        return types.SimpleNamespace(last_hidden_state=hidden)
+
+
+trans_stub.AutoModelForCausalLM = types.SimpleNamespace(
+    from_pretrained=lambda *a, **k: DummyModel()
+)
+
+sys.modules.setdefault("transformers", trans_stub)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from src.rulegen.rl_agent import GPTPolicy
+
+
+def test_gpt_policy_hint_forward():
+    policy = GPTPolicy("dummy", vocab_size=8, use_hint=True, hint_size=None)
+    assert hasattr(policy, "hint_size")
+    obs = torch.tensor([[1, 2]], dtype=torch.long)
+    hint = torch.tensor([[3, 4]], dtype=torch.long)
+    # Ensure forward accepts hint_ids kwarg
+    policy(obs, hint_ids=hint)


### PR DESCRIPTION
## Summary
- extend `GPTPolicy` to store optional `hint_size`
- forward `hint_size=None` when GPTPolicy is used by `PPORuleAgent`
- add unit test verifying `GPTPolicy` accepts `hint_ids`

## Testing
- `pytest tests/test_gpt_policy_hint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5fccceb0832ea9844a43b71c9806