### PR TITLE
Enable GPT2 tokenizer support in PPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ python -m cli.rulegen_cli ppo-train \
        --epochs 50000 \
        --checkpoint models/rulegen/ppo_agent.pt \
        --plot-path runs/rulegen/ppo_train.png
+# GPT-2 정책 사용 예시
+python -m cli.rulegen_cli ppo-train \
+       --train-features features.json \
+       --policy gpt2 \
+       --checkpoint models/rulegen/gpt2_agent.pt
 # 간단한 환경 생성 예시
 ```python
 from rulegen import make_env

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -41,6 +41,14 @@ python -m cli.rulegen_cli ppo-train \
     --reward-weights '{"f1_clean":0.7,"f1_dummy":0.2,"rule_len":-0.05}'
 ```
 
+```bash
+python -m cli.rulegen_cli ppo-train \
+    --train-features feats.json \
+    --dataset-dir data/splits \
+    --policy gpt2 \
+    --checkpoint models/rulegen/gpt2_agent.pt
+```
+
 ## Warm-start
 
 `PPORuleAgent`는 GNN 분류기가 예측한 규칙 시퀀스와 라벨을 이용해 사전 학습할 수 있습니다.

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -438,6 +438,14 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     policy_net = cfg.get("model", {}).get("policy_net", "gru")
     if getattr(args, "policy", None):
         policy_net = args.policy
+    tok = None
+    if str(policy_net).startswith("gpt2"):
+        try:
+            from transformers import AutoTokenizer
+        except Exception as exc:  # pragma: no cover - optional dep
+            logger.error("transformers 라이브러리가 필요합니다: %s", exc)
+            raise
+        tok = AutoTokenizer.from_pretrained(policy_net)
 
     logger.info("Training on %s", device)
 
@@ -518,6 +526,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         classifier_ckpt=args.classifier_checkpoint,
         seed=args.seed,
         reward_weights=args.reward_weights,
+        tokenizer=tok,
     )
     sched_cfg = cfg.get("scheduler", {})
     sched_name = sched_cfg.get("name")

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -30,6 +30,11 @@ from __future__ import annotations
 import logging
 from importlib import metadata
 from typing import Any, Dict, Optional
+
+try:
+    from transformers import PreTrainedTokenizer  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    PreTrainedTokenizer = Any  # type: ignore
 from pathlib import Path
 import importlib
 import sys
@@ -150,6 +155,7 @@ def make_env(
     *,
     classifier_checkpoint: str | Path = "models/gnn/res_gcl.pt",
     seed: int | None = None,
+    tokenizer: Optional[PreTrainedTokenizer] = None,
     use_domain_rand: bool = False,
     edge_drop_range: tuple[float, float] = (0.0, 0.1),
     use_adv_perturb: bool = False,
@@ -161,6 +167,12 @@ def make_env(
     Example
     -------
     >>> env = rulegen.make_env(rule_type="capa", max_len=128)
+
+    Parameters
+    ----------
+    tokenizer : Optional transformers tokenizer
+        If provided, custom rule tokens are added to this tokenizer and used
+        by the environment.
     """
     # Legacy argument mapping
     if "classifier_ckpt" in kwargs:
@@ -170,6 +182,7 @@ def make_env(
         rule_type=rule_type,
         classifier_checkpoint=classifier_checkpoint,
         seed=seed if seed is not None else 2024,
+        tokenizer=tokenizer,
         **kwargs,
     )
 

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -48,7 +48,7 @@ import argparse
 import logging
 import math
 from pathlib import Path
-from typing import Dict, List, Tuple, Sequence
+from typing import Dict, List, Tuple, Sequence, Optional
 
 import gymnasium as gym
 import numpy as np
@@ -189,6 +189,7 @@ class GPTPolicy(nn.Module):
         self,
         model_name: str,
         vocab_size: int,
+        tokenizer: Optional["PreTrainedTokenizer"] = None,
         use_hint: bool = False,
         hint_size: int | None = None,
     ):
@@ -203,6 +204,8 @@ class GPTPolicy(nn.Module):
         self.use_hint = use_hint
         self.hint_size = hint_size
         self.gpt = AutoModelForCausalLM.from_pretrained(model_name)
+        if tokenizer is not None:
+            self.gpt.resize_token_embeddings(len(tokenizer))
         hidden = getattr(self.gpt.config, "hidden_size", 768)
         self.pi_head = nn.Linear(hidden, vocab_size)
         self.v_head = nn.Linear(hidden, 1)
@@ -322,7 +325,8 @@ class PPORuleAgent:
             self.policy = GPTPolicy(
                 policy_net,
                 env.action_space.n,
-                use_hint,
+                tokenizer=getattr(env, "tokenizer", None),
+                use_hint=use_hint,
                 hint_size=None,
             ).to(self.device)
 

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -39,6 +39,11 @@ import logging
 import random
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+try:
+    from transformers import PreTrainedTokenizer  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    PreTrainedTokenizer = None  # type: ignore
 import re
 
 import gymnasium as gym
@@ -90,6 +95,7 @@ class RuleGenEnv(gym.Env):
         classifier_checkpoint: str | Path = "models/gnn/res_gcl.pt",
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         seed: int = 2024,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
         hint_features: List[str] | None = None,
         token_saliency: Dict[str, float] | None = None,
         step_penalty: float = -0.01,
@@ -115,6 +121,7 @@ class RuleGenEnv(gym.Env):
         classifier_ckpt  : 보상 계산용 분류기 체크포인트 경로
         device           : 모델/데이터 평가 디바이스
         seed             : reproducibility
+        tokenizer        : HuggingFace tokenizer to extend with rule tokens
         hint_features    : 초기 관측에 포함할 토큰 문자열 시퀀스
         token_saliency   : 토큰별 중요도 가중치 딕셔너리
         step_penalty     : 매 스텝 적용할 패널티 (e.g. ``-0.01``)
@@ -162,8 +169,19 @@ class RuleGenEnv(gym.Env):
         # 특수 토큰 추가
         self.token2id.setdefault(self.PAD, len(self.token2id))
         self.token2id.setdefault(self.END, len(self.token2id))
-        self.id2token = {i: t for t, i in self.token2id.items()}
 
+        if tokenizer is not None:
+            self.tokenizer = tokenizer
+            tokenizer.add_special_tokens({"pad_token": self.PAD, "eos_token": self.END})
+            existing = set(tokenizer.get_vocab().keys())
+            new_tokens = [t for t in self.token2id if t not in existing]
+            if new_tokens:
+                tokenizer.add_tokens(new_tokens)
+            self.token2id = tokenizer.get_vocab()
+        else:
+            self.tokenizer = None
+
+        self.id2token = {i: t for t, i in self.token2id.items()}
         self.vocab_size = len(self.token2id)
         self.max_len = max_len
 


### PR DESCRIPTION
## Summary
- allow GPT2-based policies in the PPO training CLI
- pass a HuggingFace tokenizer through `make_env`
- register rule tokens with the tokenizer in `RuleGenEnv`
- resize GPT policy embeddings to match tokenizer vocab
- document GPT2 policy usage in README and quick start guide

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687d66cede90832ea40c6eb4c3c3f89a