### PR TITLE
Fix GPT policy hidden states usage

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -200,7 +200,7 @@ class GPTPolicy(nn.Module):
 
     def forward(self, obs: torch.Tensor, hint: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         # hint is not used by the GPT policy, but is kept for API compatibility
-        outputs = self.gpt(input_ids=obs)
+        outputs = self.gpt(input_ids=obs, output_hidden_states=True)
         logits = outputs.logits
         value = self.value_head(outputs.hidden_states[-1])
         return logits[:, -1, :], value[:, -1]


### PR DESCRIPTION
## Summary
- ensure `GPTPolicy.forward` requests hidden states from the GPT model

## Testing
- `pytest -q tests/test_gpt_policy_hint.py::test_gpt_policy_hint_forward` *(fails: cannot import name 'GPT2LMHeadModel')*

------
https://chatgpt.com/codex/tasks/task_e_687d71812f00832eb64ab4dd91b64a89