### PR TITLE
Add AMP, gradient checkpointing, and LoRA support

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -531,6 +531,16 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     sched_cfg = cfg.get("scheduler", {})
     sched_name = sched_cfg.get("name")
     total_steps = int(sched_cfg.get("total_updates", args.epochs))
+    agent_kwargs = {
+        "use_amp": getattr(args, "amp", False),
+        "checkpoint_layers": getattr(args, "grad_checkpoint", False),
+    }
+    if any(getattr(args, n) is not None for n in ["lora_r", "lora_alpha", "lora_dropout"]):
+        agent_kwargs["lora_cfg"] = {
+            "r": args.lora_r,
+            "alpha": args.lora_alpha,
+            "dropout": args.lora_dropout,
+        }
     try:
         agent = rulegen.load_agent(
             env=env,
@@ -540,6 +550,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             seed=args.seed,
             constraint_thresh=args.constraint_thresh,
             lagrange_lr=args.lagrange_lr,
+            agent_kwargs=agent_kwargs,
         )
     except TypeError:
         # backward compatibility with older API in tests
@@ -943,6 +954,15 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0.01,
         help="Lagrange multiplier learning rate",
     )
+    pt.add_argument("--amp", action="store_true", help="Enable mixed precision training")
+    pt.add_argument(
+        "--grad-checkpoint",
+        action="store_true",
+        help="Enable gradient checkpointing for GPT policies",
+    )
+    pt.add_argument("--lora-r", type=int, help="LoRA rank for GPT policies")
+    pt.add_argument("--lora-alpha", type=float, help="LoRA alpha value")
+    pt.add_argument("--lora-dropout", type=float, help="LoRA dropout")
     pt.add_argument(
         "--cpu", action="store_true", help="Force CPU even if CUDA available"
     )

--- a/src/models/lora_utils.py
+++ b/src/models/lora_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:
+    from peft import LoraConfig, get_peft_model
+except Exception:  # pragma: no cover - peft optional
+    LoraConfig = None
+    def get_peft_model(model, config):  # type: ignore
+        raise ImportError("peft is required for LoRA")
+
+
+def apply_lora_gpt2(model, cfg: Dict[str, Any]):
+    """Apply LoRA adapters to a GPT2 model using PEFT.
+
+    Parameters
+    ----------
+    model : transformers.PreTrainedModel
+        GPT2 model instance.
+    cfg : dict
+        Configuration dictionary with keys `r`, `alpha`, `dropout` and
+        optional `target_modules`.
+    """
+    if LoraConfig is None:
+        raise ImportError("peft is required for LoRA")
+    lora_cfg = LoraConfig(
+        r=cfg.get("r", 8),
+        lora_alpha=cfg.get("alpha", 16),
+        lora_dropout=cfg.get("dropout", 0.1),
+        target_modules=cfg.get("target_modules", ["c_attn"]),
+    )
+    return get_peft_model(model, lora_cfg)
+

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -55,6 +55,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.cuda.amp import GradScaler, autocast
 
 from common.utils import set_random_seed, tqdm_wrap
 
@@ -74,6 +75,7 @@ except ModuleNotFoundError:
 
 
 from .rl_env import RuleGenEnv
+from models.lora_utils import apply_lora_gpt2
 from lr_scheduler import build_warm_cosine
 
 _LOG = get_logger(__name__)
@@ -190,10 +192,14 @@ class GRUPolicy(nn.Module):
 class GPTPolicy(nn.Module):
     """GPT‑based policy network."""
 
-    def __init__(self, env: RuleGenEnv, policy_net: str = "gpt2"):
+    def __init__(
+        self, env: RuleGenEnv, policy_net: str = "gpt2", *, checkpoint_layers: bool = False
+    ):
         super().__init__()
         self.env = env
         self.gpt = GPT2LMHeadModel.from_pretrained(policy_net)
+        if checkpoint_layers and hasattr(self.gpt, "gradient_checkpointing_enable"):
+            self.gpt.gradient_checkpointing_enable()
         self.gpt.resize_token_embeddings(len(self.env.tokenizer))
         self.value_head = nn.Linear(self.gpt.config.hidden_size, 1)
         self.hint_size = None
@@ -249,6 +255,9 @@ class PPORuleAgent:
         minibatch_size: int = 64,
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         use_hint: bool = False,
+        use_amp: bool = False,
+        checkpoint_layers: bool = False,
+        lora_cfg: dict | None = None,
         seed: int = 2024,
         constraint_thresh: float = 0.5,
         lagrange_lr: float = 0.01,
@@ -271,6 +280,10 @@ class PPORuleAgent:
 
         self.device = torch.device(device)
         self.use_hint = use_hint
+        self.use_amp = use_amp
+        self.scaler = torch.cuda.amp.GradScaler(enabled=self.use_amp)
+        self.checkpoint_layers = checkpoint_layers
+        self.lora_cfg = lora_cfg
 
         self.constraint_thresh = constraint_thresh
         self.lagrange_lr = lagrange_lr
@@ -324,7 +337,14 @@ class PPORuleAgent:
             ).to(self.device)
         else:
             _LOG.info("Using GPT policy: %s", policy_net)
-            self.policy = GPTPolicy(env, policy_net=policy_net).to(self.device)
+            self.policy = GPTPolicy(
+                env, policy_net=policy_net, checkpoint_layers=self.checkpoint_layers
+            ).to(self.device)
+            if self.lora_cfg is not None:
+                try:
+                    self.policy.gpt = apply_lora_gpt2(self.policy.gpt, self.lora_cfg)
+                except Exception as exc:  # pragma: no cover - optional dep
+                    _LOG.error("Failed to apply LoRA: %s", exc)
             self.critic = GPTCritic(self.policy).to(self.device)
 
         self.optimizer = torch.optim.Adam(self.policy.parameters(), lr=lr)
@@ -618,40 +638,48 @@ class PPORuleAgent:
                 mb_advs = advs[mb_idx]
                 mb_hint = hints[mb_idx] if hints is not None else None
 
-                logits, values = self.policy(mb_obs, mb_hint)
-                masks = []
-                pad_id = self.env.token2id[self.env.PAD]
-                for row in mb_obs.cpu().numpy():
-                    toks = [int(t) for t in row if int(t) != pad_id]
-                    masks.append(self.env.get_action_mask(tokens=toks))
-                mask_t = torch.from_numpy(np.stack(masks)).to(self.device)
-                logits = logits + torch.where(mask_t > 0, 0.0, -1e9)
-                dist = torch.distributions.Categorical(logits=logits)
-                new_logp = dist.log_prob(mb_act)
-                entropy = dist.entropy().mean()
+                with autocast(enabled=self.use_amp):
+                    logits, values = self.policy(mb_obs, mb_hint)
+                    masks = []
+                    pad_id = self.env.token2id[self.env.PAD]
+                    for row in mb_obs.cpu().numpy():
+                        toks = [int(t) for t in row if int(t) != pad_id]
+                        masks.append(self.env.get_action_mask(tokens=toks))
+                    mask_t = torch.from_numpy(np.stack(masks)).to(self.device)
+                    logits = logits + torch.where(mask_t > 0, 0.0, -1e9)
+                    dist = torch.distributions.Categorical(logits=logits)
+                    new_logp = dist.log_prob(mb_act)
+                    entropy = dist.entropy().mean()
 
-                ratio = (new_logp - mb_old_logp).exp()
-                pg_loss1 = ratio * mb_advs
-                pg_loss2 = torch.clamp(ratio, 1 - self.clip_eps, 1 + self.clip_eps) * mb_advs
-                pg_loss = -torch.min(pg_loss1, pg_loss2).mean()
+                    ratio = (new_logp - mb_old_logp).exp()
+                    pg_loss1 = ratio * mb_advs
+                    pg_loss2 = torch.clamp(ratio, 1 - self.clip_eps, 1 + self.clip_eps) * mb_advs
+                    pg_loss = -torch.min(pg_loss1, pg_loss2).mean()
 
-                value_clip = vals[mb_idx] + (values - vals[mb_idx]).clamp(-self.clip_eps, self.clip_eps)
-                v_loss1 = (values - mb_returns).pow(2)
-                v_loss2 = (value_clip - mb_returns).pow(2)
-                value_loss = 0.5 * torch.max(v_loss1, v_loss2).mean()
+                    value_clip = vals[mb_idx] + (values - vals[mb_idx]).clamp(-self.clip_eps, self.clip_eps)
+                    v_loss1 = (values - mb_returns).pow(2)
+                    v_loss2 = (value_clip - mb_returns).pow(2)
+                    value_loss = 0.5 * torch.max(v_loss1, v_loss2).mean()
 
-                constraint_penalty = self.lagrange_multiplier * violation
-                loss = (
-                    pg_loss
-                    + self.vf_coef * value_loss
-                    - self.entropy_coef * entropy
-                    + constraint_penalty
-                )
+                    constraint_penalty = self.lagrange_multiplier * violation
+                    loss = (
+                        pg_loss
+                        + self.vf_coef * value_loss
+                        - self.entropy_coef * entropy
+                        + constraint_penalty
+                    )
 
                 self.optimizer.zero_grad()
-                loss.backward()
-                nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
-                self.optimizer.step()
+                if self.use_amp:
+                    self.scaler.scale(loss).backward()
+                    self.scaler.unscale_(self.optimizer)
+                    nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+                else:
+                    loss.backward()
+                    nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+                    self.optimizer.step()
 
                 if self.scheduler is not None:
                     self.scheduler.step()

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -3,7 +3,22 @@ import logging
 import sys
 import types
 import importlib
+from pathlib import Path
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide lightweight psutil stub for common.utils
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+tg_stub = types.ModuleType("torch_geometric")
+tg_data = types.ModuleType("torch_geometric.data")
+tg_data.Data = object
+tg_data.HeteroData = object
+tg_stub.data = tg_data
+sys.modules.setdefault("torch_geometric", tg_stub)
+sys.modules.setdefault("torch_geometric.data", tg_data)
 
 
 def test_ppo_train_checks_dataset(tmp_path, caplog, monkeypatch):
@@ -91,10 +106,17 @@ def test_hint_file_passed(tmp_path, monkeypatch):
     ra_mod.PPORuleAgent = object
     monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
     y_mod = types.ModuleType("rulegen.yara_builder")
-    y_mod.YaraBuilder = object
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod.YaraBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
     c_mod = types.ModuleType("rulegen.capa_builder")
-    c_mod.CapaBuilder = object
+    c_mod.CapaBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
     gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
     gd_mod.GraphDataset = object
@@ -177,10 +199,17 @@ def test_use_explainer_hints(tmp_path, monkeypatch):
     ra_mod.PPORuleAgent = object
     monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
     y_mod = types.ModuleType("rulegen.yara_builder")
-    y_mod.YaraBuilder = object
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod.YaraBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
     c_mod = types.ModuleType("rulegen.capa_builder")
-    c_mod.CapaBuilder = object
+    c_mod.CapaBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
     gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
     gd_mod.GraphDataset = object
@@ -257,10 +286,17 @@ def test_use_explainer_hints_env_instance(tmp_path, monkeypatch):
     ra_mod.PPORuleAgent = object
     monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
     y_mod = types.ModuleType("rulegen.yara_builder")
-    y_mod.YaraBuilder = object
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod.YaraBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
     c_mod = types.ModuleType("rulegen.capa_builder")
-    c_mod.CapaBuilder = object
+    c_mod.CapaBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
     gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
     gd_mod.GraphDataset = object
@@ -337,10 +373,17 @@ def test_reward_weights_cli(tmp_path, monkeypatch):
     ra_mod.PPORuleAgent = object
     monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
     y_mod = types.ModuleType("rulegen.yara_builder")
-    y_mod.YaraBuilder = object
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod.YaraBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
     c_mod = types.ModuleType("rulegen.capa_builder")
-    c_mod.CapaBuilder = object
+    c_mod.CapaBuilder = _DummyBuilder
     monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
     gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
     gd_mod.GraphDataset = object
@@ -375,3 +418,103 @@ def test_reward_weights_cli(tmp_path, monkeypatch):
 
     args.func(args)
     assert captured["reward_weights"]["f1_clean"] == 1.0
+
+def test_amp_lora_cli(tmp_path, monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["agent_env"] = env
+
+        def train(self, **kw):
+            return []
+
+    def fake_load_agent(**kw):
+        captured["agent_kwargs"] = kw.get("agent_kwargs")
+        return DummyAgent(kw.get("env"))
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = fake_load_agent
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner")
+    fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent")
+    ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+    y_mod = types.ModuleType("rulegen.yara_builder")
+    y_mod.YaraBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder")
+    c_mod.CapaBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            str(train_fp),
+            "--dataset-dir",
+            str(ds),
+            "--amp",
+            "--grad-checkpoint",
+            "--lora-r",
+            "4",
+            "--lora-alpha",
+            "8",
+            "--lora-dropout",
+            "0.2",
+            "--epochs",
+            "1",
+            "--cpu",
+        ]
+    )
+
+    args.func(args)
+    assert captured["agent_kwargs"]["use_amp"] is True
+    assert captured["agent_kwargs"]["checkpoint_layers"] is True
+    assert captured["agent_kwargs"]["lora_cfg"]["r"] == 4
+    assert captured["agent_kwargs"]["lora_cfg"]["alpha"] == 8.0
+    assert captured["agent_kwargs"]["lora_cfg"]["dropout"] == 0.2


### PR DESCRIPTION
## Summary
- enable optional AMP in PPORuleAgent via `use_amp` and GradScaler
- allow GPTPolicy to enable gradient checkpointing
- add LoRA adapter utility and integrate with PPORuleAgent
- expose new CLI flags for AMP, gradient checkpointing and LoRA
- test CLI parsing of AMP and LoRA options

## Testing
- `pytest tests/test_ppo_train_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7551f4fc832ea98861973225f2c1