### PR TITLE
Expose PPO hyperparameters via rulegen_cli

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -41,6 +41,17 @@ python -m cli.rulegen_cli ppo-train \
     --reward-weights '{"f1_clean":0.7,"f1_dummy":0.2,"rule_len":-0.05}'
 ```
 
+PPO 하이퍼파라미터는 다음 옵션으로 조정할 수 있습니다.
+
+```bash
+python -m cli.rulegen_cli ppo-train \
+    --train-features feats.json \
+    --dataset-dir data/splits \
+    --num-steps 2048 \
+    --minibatch-size 128 \
+    --ppo-epochs 8
+```
+
 ```bash
 python -m cli.rulegen_cli ppo-train \
     --train-features feats.json \

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -534,6 +534,9 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     agent_kwargs = {
         "use_amp": getattr(args, "amp", False),
         "checkpoint_layers": getattr(args, "grad_checkpoint", False),
+        "n_steps": args.num_steps,
+        "minibatch_size": args.minibatch_size,
+        "n_epochs": args.ppo_epochs,
     }
     if any(getattr(args, n) is not None for n in ["lora_r", "lora_alpha", "lora_dropout"]):
         agent_kwargs["lora_cfg"] = {
@@ -954,6 +957,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0.01,
         help="Lagrange multiplier learning rate",
     )
+    pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")
+    pt.add_argument("--minibatch-size", type=int, default=64)
+    pt.add_argument("--ppo-epochs", type=int, default=4)
     pt.add_argument("--amp", action="store_true", help="Enable mixed precision training")
     pt.add_argument(
         "--grad-checkpoint",

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -518,3 +518,101 @@ def test_amp_lora_cli(tmp_path, monkeypatch):
     assert captured["agent_kwargs"]["lora_cfg"]["r"] == 4
     assert captured["agent_kwargs"]["lora_cfg"]["alpha"] == 8.0
     assert captured["agent_kwargs"]["lora_cfg"]["dropout"] == 0.2
+
+
+def test_agent_hyperparam_cli(tmp_path, monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["agent_env"] = env
+
+        def train(self, **kw):
+            return []
+
+    def fake_load_agent(**kw):
+        captured["agent_kwargs"] = kw.get("agent_kwargs")
+        return DummyAgent(kw.get("env"))
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = fake_load_agent
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner")
+    fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent")
+    ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod = types.ModuleType("rulegen.yara_builder")
+    y_mod.YaraBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder")
+    c_mod.CapaBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            str(train_fp),
+            "--dataset-dir",
+            str(ds),
+            "--num-steps",
+            "2048",
+            "--minibatch-size",
+            "32",
+            "--ppo-epochs",
+            "8",
+            "--epochs",
+            "1",
+            "--cpu",
+        ]
+    )
+
+    args.func(args)
+    assert captured["agent_kwargs"]["n_steps"] == 2048
+    assert captured["agent_kwargs"]["minibatch_size"] == 32
+    assert captured["agent_kwargs"]["n_epochs"] == 8


### PR DESCRIPTION
## Summary
- add `--num-steps`, `--minibatch-size`, `--ppo-epochs` options to `ppo-train`
- forward these parameters through `load_agent`
- document new CLI usage in quick start guide
- test passing of new arguments

## Testing
- `pytest tests/test_ppo_train_cli.py::test_agent_hyperparam_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7c79968c832ea1c260a1569020cd