### PR TITLE
Add BitsAndBytes quantization options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ angr
 gensim
 sentencepiece
 pyarrow
+bitsandbytes

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -534,6 +534,8 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     agent_kwargs = {
         "use_amp": getattr(args, "amp", False),
         "checkpoint_layers": getattr(args, "grad_checkpoint", False),
+        "load_4bit": getattr(args, "load_4bit", False),
+        "load_8bit": getattr(args, "load_8bit", False),
         "n_steps": args.num_steps,
         "minibatch_size": args.minibatch_size,
         "n_epochs": args.ppo_epochs,
@@ -969,6 +971,8 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--lora-r", type=int, help="LoRA rank for GPT policies")
     pt.add_argument("--lora-alpha", type=float, help="LoRA alpha value")
     pt.add_argument("--lora-dropout", type=float, help="LoRA dropout")
+    pt.add_argument("--load-4bit", action="store_true", help="Load GPT policy in 4-bit mode")
+    pt.add_argument("--load-8bit", action="store_true", help="Load GPT policy in 8-bit mode")
     pt.add_argument(
         "--cpu", action="store_true", help="Force CPU even if CUDA available"
     )

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -69,9 +69,10 @@ except ModuleNotFoundError:
         return logging.getLogger(name)
 
 try:
-    from transformers import GPT2LMHeadModel
+    from transformers import GPT2LMHeadModel, BitsAndBytesConfig
 except ModuleNotFoundError:
     GPT2LMHeadModel = None
+    BitsAndBytesConfig = None  # type: ignore
 
 
 from .rl_env import RuleGenEnv
@@ -193,11 +194,24 @@ class GPTPolicy(nn.Module):
     """GPT‑based policy network."""
 
     def __init__(
-        self, env: RuleGenEnv, policy_net: str = "gpt2", *, checkpoint_layers: bool = False
+        self,
+        env: RuleGenEnv,
+        policy_net: str = "gpt2",
+        *,
+        checkpoint_layers: bool = False,
+        load_4bit: bool = False,
+        load_8bit: bool = False,
     ):
         super().__init__()
         self.env = env
-        self.gpt = GPT2LMHeadModel.from_pretrained(policy_net)
+
+        qconfig = None
+        if load_4bit or load_8bit:
+            if BitsAndBytesConfig is None:
+                raise RuntimeError("bitsandbytes is required for quantized loading")
+            qconfig = BitsAndBytesConfig(load_in_4bit=load_4bit, load_in_8bit=load_8bit)
+
+        self.gpt = GPT2LMHeadModel.from_pretrained(policy_net, quantization_config=qconfig)
         if checkpoint_layers and hasattr(self.gpt, "gradient_checkpointing_enable"):
             self.gpt.gradient_checkpointing_enable()
         self.gpt.resize_token_embeddings(len(self.env.tokenizer))
@@ -257,6 +271,8 @@ class PPORuleAgent:
         use_hint: bool = False,
         use_amp: bool = False,
         checkpoint_layers: bool = False,
+        load_4bit: bool = False,
+        load_8bit: bool = False,
         lora_cfg: dict | None = None,
         seed: int = 2024,
         constraint_thresh: float = 0.5,
@@ -283,6 +299,8 @@ class PPORuleAgent:
         self.use_amp = use_amp
         self.scaler = torch.cuda.amp.GradScaler(enabled=self.use_amp)
         self.checkpoint_layers = checkpoint_layers
+        self.load_4bit = load_4bit
+        self.load_8bit = load_8bit
         self.lora_cfg = lora_cfg
 
         self.constraint_thresh = constraint_thresh
@@ -338,7 +356,11 @@ class PPORuleAgent:
         else:
             _LOG.info("Using GPT policy: %s", policy_net)
             self.policy = GPTPolicy(
-                env, policy_net=policy_net, checkpoint_layers=self.checkpoint_layers
+                env,
+                policy_net=policy_net,
+                checkpoint_layers=self.checkpoint_layers,
+                load_4bit=self.load_4bit,
+                load_8bit=self.load_8bit,
             ).to(self.device)
             if self.lora_cfg is not None:
                 try:


### PR DESCRIPTION
## Summary
- allow loading GPT policy with 4-bit/8-bit quantization via bitsandbytes
- pass 4bit/8bit flags in CLI to PPO agent
- list bitsandbytes in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for many optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_687d84320844832e918867c13a259b1d