### PR TITLE
Add classifier device option to RuleGenEnv

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -524,6 +524,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         device=device,
         hint_features=hint_tokens,
         classifier_ckpt=args.classifier_checkpoint,
+        classifier_device=args.classifier_device,
         seed=args.seed,
         reward_weights=args.reward_weights,
         tokenizer=policy_net,
@@ -911,6 +912,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--classifier-ckpt",
         help=argparse.SUPPRESS,
         dest="classifier_checkpoint",
+    )
+    pt.add_argument(
+        "--classifier-device",
+        default="cpu",
+        help="Device for loading the reward classifier",
     )
     pt.add_argument(
         "--policy",

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -94,6 +94,7 @@ class RuleGenEnv(gym.Env):
         batch_size_eval: int = 128,
         classifier_checkpoint: str | Path = "models/gnn/res_gcl.pt",
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
+        classifier_device: str | torch.device = "cpu",
         seed: int = 2024,
         tokenizer: Optional[PreTrainedTokenizer] = None,
         hint_features: List[str] | None = None,
@@ -118,8 +119,9 @@ class RuleGenEnv(gym.Env):
         dataset_dir      : time‑split train/val/test parquet 경로
         max_len          : 룰 최대 토큰 길이 (spec ≤ 512 제한 대비 여유)
         batch_size_eval  : 보상 산출 시 배치 추론 크기
-        classifier_ckpt  : 보상 계산용 분류기 체크포인트 경로
+        classifier_checkpoint  : 보상 계산용 분류기 체크포인트 경로
         device           : 모델/데이터 평가 디바이스
+        classifier_device : 분류기 로드 및 추론에 사용할 디바이스
         seed             : reproducibility
         tokenizer        : HuggingFace tokenizer to extend with rule tokens
         hint_features    : 초기 관측에 포함할 토큰 문자열 시퀀스
@@ -263,8 +265,9 @@ class RuleGenEnv(gym.Env):
         # ── 데이터셋 & 모델 로드 ───────────────────────────────
         self._load_datasets(dataset_dir)
         self.device = torch.device(device)
+        self.classifier_device = torch.device(classifier_device)
         self.classifier: RESGCLClassifier = RESGCLClassifier.load_pretrained(
-            Path(classifier_checkpoint), map_location=self.device
+            Path(classifier_checkpoint), map_location=self.classifier_device
         )
         self.batch_size_eval = batch_size_eval
 
@@ -423,7 +426,7 @@ class RuleGenEnv(gym.Env):
         )
 
     def _fgsm_graph(self, g: HeteroData, label: int, epsilon: float) -> HeteroData:
-        g_adv = g.clone().to(self.device)
+        g_adv = g.clone().to(self.classifier_device)
         for nt in g_adv.node_types:
             x = g_adv[nt].get("x")
             if x is not None and torch.is_floating_point(x):
@@ -431,7 +434,7 @@ class RuleGenEnv(gym.Env):
 
         self.classifier.eval()
         logit = self.classifier(g_adv, return_logits=True)
-        target = torch.tensor([float(label)], device=self.device)
+        target = torch.tensor([float(label)], device=self.classifier_device)
         loss = F.binary_cross_entropy_with_logits(logit.squeeze(), target)
         self.classifier.zero_grad()
         loss.backward()
@@ -552,7 +555,7 @@ class RuleGenEnv(gym.Env):
         """Return classifier probability for the current token sequence."""
         if not tokens:
             return 0.0
-        x = torch.tensor(tokens, dtype=torch.long, device=self.device).unsqueeze(0)
+        x = torch.tensor(tokens, dtype=torch.long, device=self.classifier_device).unsqueeze(0)
         out = self.classifier(x)
         if isinstance(out, (tuple, list)):
             out = out[0]


### PR DESCRIPTION
## Summary
- allow specifying classifier device for rule generation env
- update CLI to accept `--classifier-device` and pass to env

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d864a4428832eae9bdacf6501dd98