### PR TITLE
Switch to device-aware AMP API

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1910,7 +1910,7 @@ def train_global(args: argparse.Namespace) -> None:
     if args.plot_path:
         args.plot_path.parent.mkdir(parents=True, exist_ok=True)
 
-    scaler = torch.cuda.amp.GradScaler(enabled=(args.amp and device.type == "cuda"))
+    scaler = torch.amp.GradScaler("cuda", enabled=(args.amp and device.type == "cuda"))
 
     beta_cap = args.beta if args.beta_max is None else args.beta_max
     current_beta = args.beta_start if args.beta_schedule else args.beta
@@ -1956,8 +1956,8 @@ def train_global(args: argparse.Namespace) -> None:
                 _cast_graph_dtype(g, param_dtype)
                 g = g.to(device)
 
-                with torch.cuda.amp.autocast(
-                    enabled=(args.amp and device.type == "cuda")
+                with torch.amp.autocast(
+                    "cuda", enabled=(args.amp and device.type == "cuda")
                 ):
                     embeds = _compute_node_embeddings(g, model.encoder)
                     with torch.no_grad():

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -55,7 +55,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.cuda.amp import GradScaler, autocast
+
 
 from common.utils import set_random_seed, tqdm_wrap
 
@@ -297,7 +297,7 @@ class PPORuleAgent:
         self.device = torch.device(device)
         self.use_hint = use_hint
         self.use_amp = use_amp
-        self.scaler = torch.cuda.amp.GradScaler(enabled=self.use_amp)
+        self.scaler = torch.amp.GradScaler("cuda", enabled=self.use_amp)
         self.checkpoint_layers = checkpoint_layers
         self.load_4bit = load_4bit
         self.load_8bit = load_8bit
@@ -671,7 +671,7 @@ class PPORuleAgent:
                     else None
                 )
 
-                with autocast(enabled=self.use_amp):
+                with torch.amp.autocast("cuda", enabled=self.use_amp):
                     logits, values = self.policy(mb_obs, mb_hint)
                     masks = []
                     pad_id = self.env.token2id[self.env.PAD]

--- a/tests/test_soft_mask_mode.py
+++ b/tests/test_soft_mask_mode.py
@@ -133,7 +133,7 @@ def test_soft_mask_switch(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "_load_model", dummy_load_model)
     monkeypatch.setattr(mod, "_compute_node_embeddings", dummy_embeddings)
     monkeypatch.setattr(mod, "PGExplainer", DummyExplainer)
-    monkeypatch.setattr(mod.torch.cuda.amp, "GradScaler", DummyScaler)
+    monkeypatch.setattr(mod.torch.amp, "GradScaler", DummyScaler)
 
     calls = []
     monkeypatch.setattr(mod, "_soft_masked_score", lambda *a, **k: calls.append("soft") or torch.tensor(0.0))


### PR DESCRIPTION
## Summary
- use `torch.amp.GradScaler` instead of the legacy `torch.cuda.amp` variant
- update autocast contexts to specify the CUDA device
- adjust tests to patch the new GradScaler

## Testing
- `pytest tests/test_soft_mask_mode.py -k test_soft_mask_switch -q` *(fails: no tests collected / skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687d88871cf8832eb6466713f0a9b7e9