### PR TITLE
Add gradient accumulation to PPO training

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -540,6 +540,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         "n_steps": args.num_steps,
         "minibatch_size": args.minibatch_size,
         "n_epochs": args.ppo_epochs,
+        "accum_steps": args.accum_steps,
     }
     if any(getattr(args, n) is not None for n in ["lora_r", "lora_alpha", "lora_dropout"]):
         agent_kwargs["lora_cfg"] = {
@@ -968,6 +969,12 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")
     pt.add_argument("--minibatch-size", type=int, default=64)
     pt.add_argument("--ppo-epochs", type=int, default=4)
+    pt.add_argument(
+        "--accum-steps",
+        type=int,
+        default=1,
+        help="Number of minibatches to accumulate gradients before optimizer step",
+    )
     pt.add_argument("--amp", action="store_true", help="Enable mixed precision training")
     pt.add_argument(
         "--grad-checkpoint",

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -267,6 +267,7 @@ class PPORuleAgent:
         n_epochs: int = 4,
         batch_size: int = 256,
         minibatch_size: int = 64,
+        accum_steps: int = 1,
         device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu",
         use_hint: bool = False,
         use_amp: bool = False,
@@ -293,6 +294,7 @@ class PPORuleAgent:
         self.n_epochs = n_epochs
         self.batch_size = batch_size
         self.minibatch_size = minibatch_size
+        self.accum_steps = max(1, accum_steps)
 
         self.device = torch.device(device)
         self.use_hint = use_hint
@@ -656,7 +658,9 @@ class PPORuleAgent:
         # 3) Epoch loop
         n_samples = obs_cpu.shape[0]
         idxs = np.arange(n_samples)
-        for _ in range(self.n_epochs):
+        self.optimizer.zero_grad()
+        mb_count = 0
+        for epoch in range(self.n_epochs):
             np.random.shuffle(idxs)
             for start in range(0, n_samples, self.minibatch_size):
                 mb_idx = idxs[start : start + self.minibatch_size]
@@ -703,20 +707,28 @@ class PPORuleAgent:
                         + constraint_penalty
                     )
 
-                self.optimizer.zero_grad()
                 if self.use_amp:
-                    self.scaler.scale(loss).backward()
-                    self.scaler.unscale_(self.optimizer)
-                    nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
+                    self.scaler.scale(loss / self.accum_steps).backward()
                 else:
-                    loss.backward()
-                    nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
-                    self.optimizer.step()
+                    (loss / self.accum_steps).backward()
+                mb_count += 1
+                is_last_mb = (
+                    epoch == self.n_epochs - 1
+                    and start + self.minibatch_size >= n_samples
+                )
+                if mb_count % self.accum_steps == 0 or is_last_mb:
+                    if self.use_amp:
+                        self.scaler.unscale_(self.optimizer)
+                        nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+                        self.scaler.step(self.optimizer)
+                        self.scaler.update()
+                    else:
+                        nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+                        self.optimizer.step()
 
-                if self.scheduler is not None:
-                    self.scheduler.step()
+                    if self.scheduler is not None:
+                        self.scheduler.step()
+                    self.optimizer.zero_grad()
 
         # update lagrange multiplier using constraint violation
         self.lagrange_multiplier = max(
@@ -817,6 +829,7 @@ def _cli():
     parser.add_argument("--timesteps", type=int, default=3_000)
     parser.add_argument("--save", type=str, default=None)
     parser.add_argument("--smoke_test", action="store_true")
+    parser.add_argument("--accum-steps", type=int, default=1)
     args = parser.parse_args()
 
     env = RuleGenEnv(
@@ -825,7 +838,13 @@ def _cli():
         max_len=64,
     )
 
-    agent = PPORuleAgent(env, n_steps=512, minibatch_size=128, seed=2024)
+    agent = PPORuleAgent(
+        env,
+        n_steps=512,
+        minibatch_size=128,
+        accum_steps=args.accum_steps,
+        seed=2024,
+    )
 
     if args.smoke_test:
         _LOG.info("Running smoke‑test (%d timesteps) …", args.timesteps)


### PR DESCRIPTION
## Summary
- add `--accum-steps` option in CLI for PPO training
- support gradient accumulation in `PPORuleAgent`
- expose argument in simple RL agent CLI

## Testing
- `pytest tests/test_ppo_train_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8b0d1914832ea97b3924788febb5