### PR TITLE
Add CUDA cache clear after PPO update

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -736,6 +736,8 @@ class PPORuleAgent:
         )
 
         self.reset_rollout_buffers()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     # ──────────────────────────────── save / load ───────────────
     def save(self, path: str | Path):


### PR DESCRIPTION
## Summary
- clear CUDA cache after each PPO update in rl_agent

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_687d8c8d2760832eaef99a4fdfa8391d