### PR TITLE
Fix LoRA utilities import path

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -76,7 +76,12 @@ except ModuleNotFoundError:
 
 
 from .rl_env import RuleGenEnv
-from models.lora_utils import apply_lora_gpt2
+# NOTE: lora utilities live under the project `src` package. When
+# running the CLI with `PYTHONPATH=src` or after installing the
+# package, they are available as ``src.models``. Importing from the
+# top-level ``models`` package would fail because that directory is
+# reserved for checkpoints and does not contain code.
+from src.models.lora_utils import apply_lora_gpt2
 from lr_scheduler import build_warm_cosine
 
 _LOG = get_logger(__name__)


### PR DESCRIPTION
## Summary
- fix rulegen import for LoRA utilities

## Testing
- `pytest tests/test_rulegen_submodule_import.py::test_feature_miner_submodule_importable -q`
- `pytest -k rl_agent -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_687d8dee48b8832ea3c70f5166934da2