### PR TITLE
Prevent reserved words as YARA features

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -67,6 +67,28 @@ _PUNCT = {":", ",", ".", ";", ")", "]", "}", "?", "!"}
 _OPEN_PUNCT = {"(", "[", "{"}
 _WHITESPACE_RX = re.compile(r"\s+")
 
+# YARA reserved words that should not be treated as features
+_RESERVED = {
+    "rule",
+    "strings",
+    "condition",
+    "any",
+    "all",
+    "private",
+    "global",
+    "meta",
+    "import",
+    "include",
+    "for",
+    "in",
+    "of",
+    "and",
+    "or",
+    "not",
+    "true",
+    "false",
+}
+
 
 def _token_is_feature(tok: str) -> bool:
     """Return True if ``tok`` resembles a feature string.
@@ -264,13 +286,18 @@ class YaraBuilder:
         while i < N:
             tok = tokens[i]
             # case 1: "<X>" ":" "<Y>"  ⇒  "X:Y"
-            if i + 2 < N and tokens[i + 1] == ":" and _token_is_feature(tok):
+            if (
+                i + 2 < N
+                and tokens[i + 1] == ":"
+                and _token_is_feature(tok)
+                and tok not in _RESERVED
+            ):
                 combined = f"{tok}:{tokens[i + 2]}"
                 feats.append(combined)
                 i += 3
                 continue
             # default
-            if _token_is_feature(tok):
+            if _token_is_feature(tok) and tok not in _RESERVED:
                 feats.append(tok)
             i += 1
         # 중복 제거, 순서 유지

--- a/tests/test_yara_builder_reserved.py
+++ b/tests/test_yara_builder_reserved.py
@@ -1,0 +1,12 @@
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_reserved_words_filtered():
+    builder = YaraBuilder()
+    tokens = ["rule", "call", ":", "CreateFileW", "strings", "condition", "any"]
+    feats = builder._extract_features(tokens)
+    assert "call:CreateFileW" in feats
+    assert "rule" not in feats
+    assert "strings" not in feats
+    assert "condition" not in feats
+    assert "any" not in feats


### PR DESCRIPTION
## Summary
- exclude YARA keywords when extracting features
- provide reserved keyword set in `yara_builder`
- test that reserved words are filtered out

## Testing
- `pytest tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_quotes.py tests/test_yara_builder_reserved.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687dd90db790832eb9b1d80939156723