### PR TITLE
Fix rulegen_cli matplotlib backend

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -64,6 +64,8 @@ from common.utils import set_random_seed
 import pandas as pd
 import torch
 import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 from src.cli.preprocessing import ensure_dir


### PR DESCRIPTION
## Summary
- ensure rulegen CLI uses matplotlib's non-GUI backend

## Testing
- `python - <<'EOF'
<stubbed env script>
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687ddaf0d1c0832e88e151bf33504ca6