### PR TITLE
Add metadata vocab generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ python -m cli.pretrain_selfgcl data/hetero \
 python scripts/sanitise_graphs.py data/hetero data/hetero_clean
 ```
 
+그래프 메타데이터의 토큰 사전 크기를 확인하려면 다음 스크립트를 실행합니다.
+
+```bash
+python scripts/generate_metadata_vocab.py data/splits --output meta_vocab.json
+```
+
 # GNN 학습
 
 # GNN 학습

--- a/scripts/generate_metadata_vocab.py
+++ b/scripts/generate_metadata_vocab.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Generate metadata vocabulary sizes from graph dataset.
+
+This script scans graph files under a dataset directory using
+``GraphDataset`` and computes the maximum observed id value for each
+``<name>_id`` tensor grouped by node type.  The resulting dictionary is
+stored as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict
+
+import torch
+
+# Add repository root so ``src`` can be imported when run directly
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.graphs.dataset import GraphDataset  # type: ignore
+from torch_geometric.data import Data, HeteroData
+
+
+def collect_vocab(ds: GraphDataset) -> Dict[str, Dict[str, int]]:
+    """Collect maximum id values for ``<name>_id`` tensors within ``ds``."""
+    vocab: Dict[str, Dict[str, int]] = {}
+    for i in range(len(ds)):
+        item = ds[i]
+        g = item[0] if isinstance(item, tuple) else item
+        if isinstance(g, HeteroData):
+            for nt in g.node_types:
+                store = g[nt]
+                for key, val in store.items():
+                    if key.endswith("_id") and isinstance(val, torch.Tensor):
+                        if val.numel() == 0:
+                            continue
+                        attr = key[:-3]
+                        nt_map = vocab.setdefault(nt, {})
+                        nt_map[attr] = max(nt_map.get(attr, -1), int(val.max()))
+        elif isinstance(g, Data):
+            for key, val in g.items():
+                if key.endswith("_id") and isinstance(val, torch.Tensor):
+                    if val.numel() == 0:
+                        continue
+                    attr = key[:-3]
+                    nt_map = vocab.setdefault("", {})
+                    nt_map[attr] = max(nt_map.get(attr, -1), int(val.max()))
+    return vocab
+
+
+def merge_vocab(dest: Dict[str, Dict[str, int]], src: Dict[str, Dict[str, int]]) -> None:
+    for nt, attrs in src.items():
+        dest_nt = dest.setdefault(nt, {})
+        for name, val in attrs.items():
+            dest_nt[name] = max(dest_nt.get(name, -1), val)
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description="Collect metadata vocab sizes")
+    p.add_argument("data_dir", type=Path, help="Dataset root directory")
+    p.add_argument("--output", type=Path, required=True, help="Output JSON file")
+    p.add_argument(
+        "--splits",
+        nargs="*",
+        default=("train", "val", "test"),
+        help="Dataset splits to process (default: train val test)",
+    )
+    args = p.parse_args(argv)
+
+    vocab: Dict[str, Dict[str, int]] = {}
+    for split in args.splits:
+        if not (args.data_dir / split).is_dir():
+            continue
+        ds = GraphDataset(
+            args.data_dir,
+            split=split,
+            label_file=None,
+            require_labels=False,
+            load_embeds=False,
+        )
+        split_vocab = collect_vocab(ds)
+        merge_vocab(vocab, split_vocab)
+
+    # Convert max id to vocab size
+    result = {
+        nt: {name: val + 1 for name, val in attrs.items()} for nt, attrs in vocab.items()
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as fp:
+        json.dump(result, fp, indent=2)
+    print(f"[OK] saved -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_metadata_vocab.py` utility script
- document new script usage in README

## Testing
- `pytest -k collect_dataset_metadata -q` *(fails: ModuleNotFoundError: No module named 'gensim')*

------
https://chatgpt.com/codex/tasks/task_e_687ddd2642d0832e8e8746211fa9dba5