### PR TITLE
Update PPO dataset build script with metadata support

### DIFF
--- a/src/cli/build_ppo_dataset.py
+++ b/src/cli/build_ppo_dataset.py
@@ -13,7 +13,7 @@ import torch
 
 from common.logger import get_logger
 from common.utils import ensure_dir
-from graphs.dataset.graph_dataset import _guess_graph_path
+from graphs.dataset.graph_dataset import GraphDataset, _guess_graph_path
 
 LOGGER = get_logger(__name__)
 
@@ -26,6 +26,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--hetero-dir", type=Path, required=True, help="Directory of graph files")
     p.add_argument("--labels", type=Path, required=True, help="CSV or JSONL (sha256,label)")
     p.add_argument("--out-dir", type=Path, required=True, help="Output directory")
+    p.add_argument("--metadata-vocab", type=Path, required=True, help="metadata_vocab.json path")
     p.add_argument("--clean-label", type=int, default=0)
     p.add_argument("--dummy-label", type=int, default=1)
     return p.parse_args()
@@ -85,6 +86,10 @@ def main(argv: List[str] | None = None) -> None:
     args = parse_args() if argv is None else parse_args()
     ensure_dir(args.out_dir)
 
+    with args.metadata_vocab.open("r", encoding="utf-8") as f:
+        vocab = json.load(f)
+    attr_names = {nt: sorted(attrs.keys()) for nt, attrs in vocab.items()}
+
     label_map = _load_labels(args.labels)
     clean_graphs: List[object] = []
     dummy_graphs: List[object] = []
@@ -92,6 +97,7 @@ def main(argv: List[str] | None = None) -> None:
     for sha, lab in label_map.items():
         try:
             g = _load_graph(args.hetero_dir, sha)
+            g = GraphDataset._ensure_meta_ids(g, attr_names)
         except FileNotFoundError:
             LOGGER.warning("Graph for %s not found", sha)
             continue

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -824,6 +824,8 @@ def cmd_build_dataset(args: argparse.Namespace) -> None:
         args.labels,
         "--out-dir",
         args.out_dir,
+        "--metadata-vocab",
+        args.metadata_vocab,
         "--clean-label",
         str(args.clean_label),
         "--dummy-label",
@@ -885,6 +887,7 @@ def _build_parser() -> argparse.ArgumentParser:
     bd.add_argument("--hetero-dir", required=True, help="Directory of graph files")
     bd.add_argument("--labels", required=True, help="CSV or JSONL (sha256,label)")
     bd.add_argument("--out-dir", required=True, help="Output directory")
+    bd.add_argument("--metadata-vocab", required=True, help="metadata_vocab.json path")
     bd.add_argument("--clean-label", type=int, default=0, help="Label for clean graphs")
     bd.add_argument("--dummy-label", type=int, default=1, help="Label for dummy graphs")
     bd.set_defaults(func=cmd_build_dataset)


### PR DESCRIPTION
## Summary
- add `--metadata-vocab` to PPO dataset builder and rulegen CLI
- load metadata vocab and ensure metadata ids are present when building datasets

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ddf2e4bc8832ebe30aeb8832fd2ca