### PR TITLE
Handle metadata vocab when constructing RuleGenEnv

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -65,6 +65,7 @@ except ModuleNotFoundError:
 
 from evaluation.rule_evaluator import RuleEvaluator  # type: ignore
 from models.gnn.res_wrapper import RESGCLClassifier  # type: ignore
+from models.gnn.encoder import RGCNEncoder  # type: ignore
 from .feature_miner import FeatureMiner  # 단어 사전
 
 _LOG = get_logger(__name__)
@@ -90,6 +91,7 @@ class RuleGenEnv(gym.Env):
         rule_type: str = "yara",  # or "capa"
         vocab_file: Optional[Union[str, Path]] = None,
         dataset_dir: Union[str, Path] = "data/splits",
+        attr_dim: int = 16,
         max_len: int = 180,
         batch_size_eval: int = 128,
         classifier_checkpoint: str | Path = "models/gnn/res_gcl.pt",
@@ -117,6 +119,7 @@ class RuleGenEnv(gym.Env):
         rule_type        : "yara" | "capa"
         vocab_file       : 사전 json (토큰 → id) 경로; 없으면 FeatureMiner로 동적 생성
         dataset_dir      : time‑split train/val/test parquet 경로
+        attr_dim         : metadata embedding dimension when reconfiguring encoder
         max_len          : 룰 최대 토큰 길이 (spec ≤ 512 제한 대비 여유)
         batch_size_eval  : 보상 산출 시 배치 추론 크기
         classifier_checkpoint  : 보상 계산용 분류기 체크포인트 경로
@@ -141,6 +144,7 @@ class RuleGenEnv(gym.Env):
         torch.manual_seed(seed)
         random.seed(seed)
         np.random.seed(seed)
+        self.attr_dim = int(attr_dim)
 
         self.rule_type = rule_type.lower()
         assert self.rule_type in {"yara", "capa"}
@@ -277,6 +281,13 @@ class RuleGenEnv(gym.Env):
             device=self.device,
             batch_size=self.batch_size_eval,
         )
+
+        meta_file = Path(dataset_dir) / "metadata_vocab.json"
+        if meta_file.is_file():
+            try:
+                self._reconfigure_encoder_for_metadata(meta_file)
+            except Exception as exc:  # pragma: no cover - optional
+                _LOG.warning("Failed to reconfigure encoder for metadata: %s", exc)
 
         # 내부 상태
         self.reset()
@@ -459,6 +470,59 @@ class RuleGenEnv(gym.Env):
                 out.append(g)
         return out
 
+    def _reconfigure_encoder_for_metadata(self, vocab_path: Path) -> None:
+        """Reinitialize classifier.encoder based on dataset metadata."""
+        from src.graphs.dataset import collect_dataset_metadata  # lazy import
+
+        with vocab_path.open("r", encoding="utf-8") as fp:
+            vocab = json.load(fp)
+        attr_names = {nt: sorted(attrs.keys()) for nt, attrs in vocab.items()}
+
+        class _ListDS:
+            def __init__(self, graphs):
+                self.graphs = graphs
+
+            def __len__(self):
+                return len(self.graphs)
+
+            def __getitem__(self, idx):
+                return self.graphs[idx]
+
+        ds = _ListDS(self.clean_set + self.dummy_set)
+        metadata, in_dims, _, _, max_ids = collect_dataset_metadata(
+            [ds], attr_dim=self.attr_dim
+        )
+        vocab_size = max(max_ids.values(), default=0) + 1
+
+        old_enc = self.classifier.encoder
+        hidden_dim = old_enc.out_proj.in_features
+        out_dim = old_enc.out_proj.out_features
+        num_layers = len(getattr(old_enc, "convs", []))
+        target_node = getattr(old_enc, "target_node", None)
+        dropout = getattr(old_enc.drop, "p", 0.0) if hasattr(old_enc, "drop") else 0.0
+
+        new_enc = RGCNEncoder(
+            metadata=metadata,
+            in_dims=in_dims,
+            attr_names=attr_names,
+            vocab_size=vocab_size,
+            attr_dim=self.attr_dim,
+            hidden_dim=hidden_dim,
+            num_layers=num_layers,
+            out_dim=out_dim,
+            dropout=dropout,
+            target_node=target_node,
+        )
+
+        new_state = new_enc.state_dict()
+        old_state = old_enc.state_dict()
+        for k, v in old_state.items():
+            if k in new_state and new_state[k].shape == v.shape:
+                new_state[k] = v
+        new_enc.load_state_dict(new_state, strict=False)
+        new_enc.to(self.classifier_device)
+        self.classifier.encoder = new_enc
+
     # 관측 pad
     def _pad_obs(self, toks: Sequence[int]) -> np.ndarray:
         obs_len = self.observation_space.shape[0]
@@ -555,7 +619,9 @@ class RuleGenEnv(gym.Env):
         """Return classifier probability for the current token sequence."""
         if not tokens:
             return 0.0
-        x = torch.tensor(tokens, dtype=torch.long, device=self.classifier_device).unsqueeze(0)
+        x = torch.tensor(
+            tokens, dtype=torch.long, device=self.classifier_device
+        ).unsqueeze(0)
         out = self.classifier(x)
         if isinstance(out, (tuple, list)):
             out = out[0]
@@ -587,7 +653,10 @@ class RuleGenEnv(gym.Env):
 
         # dynamic FP penalty schedule
         progress = min(self.total_steps, self.curriculum_steps) / self.curriculum_steps
-        curr_penalty = self.fp_penalty_start + (self.fp_penalty_end - self.fp_penalty_start) * progress
+        curr_penalty = (
+            self.fp_penalty_start
+            + (self.fp_penalty_end - self.fp_penalty_start) * progress
+        )
 
         m = len(dummy_set)
         n = len(clean_set)
@@ -595,7 +664,10 @@ class RuleGenEnv(gym.Env):
         if denom == 0:
             fp_count = 0.0
         else:
-            fp_count = ((2 - f1_dummy) * n - f1_clean * (m * (1 - f1_dummy) + n * (2 - f1_dummy))) / denom
+            fp_count = (
+                (2 - f1_dummy) * n
+                - f1_clean * (m * (1 - f1_dummy) + n * (2 - f1_dummy))
+            ) / denom
             fp_count = max(fp_count, 0.0)
         fp_rate = 0.0 if n == 0 else fp_count / n
 


### PR DESCRIPTION
## Summary
- add `attr_dim` argument to `RuleGenEnv` constructor
- automatically rebuild encoder when `metadata_vocab.json` is present

## Testing
- `pytest tests/test_rl_env.py -k test_env_instantiates -vv` *(fails: collected 0 items)*

------
https://chatgpt.com/codex/tasks/task_e_687de1b5e07c832ebbbc913bb406e922