### PR TITLE
Add label-file option for metadata vocab generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ python scripts/sanitise_graphs.py data/hetero data/hetero_clean
 그래프 메타데이터의 토큰 사전 크기를 확인하려면 다음 스크립트를 실행합니다.
 
 ```bash
-python scripts/generate_metadata_vocab.py data/splits --output meta_vocab.json
+python scripts/generate_metadata_vocab.py data/splits --output meta_vocab.json \
+       --label-file labels.csv
 ```
 
 # GNN 학습

--- a/scripts/generate_metadata_vocab.py
+++ b/scripts/generate_metadata_vocab.py
@@ -68,6 +68,12 @@ def main(argv: list[str] | None = None) -> None:
         default=("train", "val", "test"),
         help="Dataset splits to process (default: train val test)",
     )
+    p.add_argument(
+        "--label-file",
+        dest="label_file",
+        default="labels.csv",
+        help="Label filename inside each split (default: labels.csv)",
+    )
     args = p.parse_args(argv)
 
     vocab: Dict[str, Dict[str, int]] = {}
@@ -77,7 +83,7 @@ def main(argv: list[str] | None = None) -> None:
         ds = GraphDataset(
             args.data_dir,
             split=split,
-            label_file=None,
+            label_file=args.label_file,
             require_labels=False,
             load_embeds=False,
         )


### PR DESCRIPTION
## Summary
- support `--label-file` option for `generate_metadata_vocab.py`
- use the chosen label file when creating `GraphDataset`
- update README example with the new option

## Testing
- `pytest tests/test_graph_dataset_loader.py -k test_ensure_x_trim_pad -q`
- `pytest tests/test_graph_dataset_loader.py -k test_ensure_x_pad_missing -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4b424f7c832ebdf6968954baa4d3