### PR TITLE
Collect single-string fields in view vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ python scripts/generate_metadata_vocab.py graphs data/splits --output meta_vocab
 ```bash
 python scripts/generate_metadata_vocab.py views path/to/views --output view_vocab.json
 ```
+이 스크립트는 문자열 리스트뿐만 아니라 단일 문자열 필드(예: `"text"`)도
+사전에 포함합니다.
 
 # GNN 학습
 

--- a/scripts/generate_metadata_vocab.py
+++ b/scripts/generate_metadata_vocab.py
@@ -58,12 +58,20 @@ def merge_vocab(dest: Dict[str, Dict[str, int]], src: Dict[str, Dict[str, int]])
             dest_nt[name] = max(dest_nt.get(name, -1), val)
 
 
+# Gather vocabulary from view JSON by recursively scanning for lists of strings
+# or single string fields.
 def _collect_view(obj: Any, vocab: Dict[str, Set[str]]) -> None:
-    """Recursively collect lists of strings from ``obj`` into ``vocab``."""
+    """Recursively collect string fields from ``obj`` into ``vocab``.
+
+    This processes lists of strings as well as single string fields, so view
+    JSON files can store tokens either way.
+    """
     if isinstance(obj, dict):
         for k, v in obj.items():
             if isinstance(v, list) and all(isinstance(it, str) for it in v):
                 vocab.setdefault(k, set()).update(v)
+            elif isinstance(v, str):
+                vocab.setdefault(k, set()).add(v)
             else:
                 _collect_view(v, vocab)
     elif isinstance(obj, list):


### PR DESCRIPTION
## Summary
- collect scalar string values when extracting view vocab
- document that single string fields like `text` are included
- clarify in code that `_collect_view` handles lists and scalars

## Testing
- `python scripts/generate_metadata_vocab.py views data/views --output tmp_view_vocab.json`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_687e561669a8832eb8240504a1c58055