### PR TITLE
Handle list-style metadata vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ python scripts/generate_metadata_vocab.py graphs data/splits --output meta_vocab
 python scripts/generate_metadata_vocab.py views path/to/views --output view_vocab.json
 ```
 이 스크립트는 문자열 리스트뿐만 아니라 단일 문자열 필드(예: `"text"`)도
-사전에 포함합니다.
+사전에 포함합니다. 생성된 JSON은 노드별 메타 토큰 크기(`{"node": {"attr": 10}}`)
+또는 필드별 토큰 목록(`{"attr": ["a", "b"]}`) 두 형식을 모두 지원합니다.
 
 # GNN 학습
 

--- a/src/cli/build_ppo_dataset.py
+++ b/src/cli/build_ppo_dataset.py
@@ -88,7 +88,17 @@ def main(argv: List[str] | None = None) -> None:
 
     with args.metadata_vocab.open("r", encoding="utf-8") as f:
         vocab = json.load(f)
-    attr_names = {nt: sorted(attrs.keys()) for nt, attrs in vocab.items()}
+
+    attr_names: Dict[str, List[str]] = {}
+    for nt, attrs in vocab.items():
+        if isinstance(attrs, dict):
+            attr_names[nt] = sorted(attrs.keys())
+        elif isinstance(attrs, list):
+            attr_names.setdefault("", []).append(nt)
+        else:
+            raise TypeError(
+                f"Unsupported value type for {nt!r}: {type(attrs).__name__}"
+            )
 
     label_map = _load_labels(args.labels)
     clean_graphs: List[object] = []

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -476,7 +476,17 @@ class RuleGenEnv(gym.Env):
 
         with vocab_path.open("r", encoding="utf-8") as fp:
             vocab = json.load(fp)
-        attr_names = {nt: sorted(attrs.keys()) for nt, attrs in vocab.items()}
+
+        attr_names: Dict[str, List[str]] = {}
+        for nt, attrs in vocab.items():
+            if isinstance(attrs, dict):
+                attr_names[nt] = sorted(attrs.keys())
+            elif isinstance(attrs, list):
+                attr_names.setdefault("", []).append(nt)
+            else:
+                raise TypeError(
+                    f"Unsupported value type for {nt!r}: {type(attrs).__name__}"
+                )
 
         class _ListDS:
             def __init__(self, graphs):

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -355,3 +355,27 @@ def test_lookahead_reward(tmp_path):
     assert dummy_clf.calls == 1
     assert not done
     assert "lookahead_prob" in info
+
+
+def test_metadata_vocab_list_format(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    meta_vocab = tmp_path / "metadata_vocab.json"
+    json.dump({"foo": ["x", "y"]}, meta_vocab.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+    )
+
+    assert env.classifier.encoder.attr_names.get("") == ["foo"]


### PR DESCRIPTION
## Summary
- support list-based metadata vocab for PPO dataset creation and RL env
- document both metadata vocab formats in README
- test RL env metadata vocab list handling

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e5e0907d4832e941add7578f1499c