### PR TITLE
Update RL defaults for stronger FP penalty

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -7,9 +7,11 @@ run:
 env:
   mode: "yara"                   ## "capa" 로 변경 시 CAPA 룰 생성
   max_tokens: 512
+  fp_penalty_start: 0.1
+  fp_penalty_end: 0.5
   reward_weights:
-    clean_f1: 0.5
-    dummy_resist_f1: 0.4
+    clean_f1: 0.6
+    dummy_resist_f1: 0.3
     rule_length: -0.05
     robust_radius: 0.05
 

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -968,7 +968,7 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument(
         "--lagrange-lr",
         type=float,
-        default=0.01,
+        default=0.05,
         help="Lagrange multiplier learning rate",
     )
     pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -220,7 +220,7 @@ def load_agent(
     total_updates: int | None = None,
     seed: int | None = None,
     constraint_thresh: float = 0.5,
-    lagrange_lr: float = 0.01,
+    lagrange_lr: float = 0.05,
     agent_kwargs: Optional[Dict[str, Any]] = None,
     **env_kwargs: Any,
 ) -> PPORuleAgent:

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -282,7 +282,7 @@ class PPORuleAgent:
         lora_cfg: dict | None = None,
         seed: int = 2024,
         constraint_thresh: float = 0.5,
-        lagrange_lr: float = 0.01,
+        lagrange_lr: float = 0.05,
         init_lagrange_multiplier: float = 1.0,
     ):
         set_random_seed(seed)

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -109,8 +109,8 @@ class RuleGenEnv(gym.Env):
         use_adv_perturb: bool = False,
         use_lookahead: bool = False,
         reward_weights: dict | None = None,
-        fp_penalty_start: float = 0.0,
-        fp_penalty_end: float = 0.0,
+        fp_penalty_start: float = 0.1,
+        fp_penalty_end: float = 0.5,
         curriculum_steps: int = 100000,
     ):
         """


### PR DESCRIPTION
## Summary
- tune RuleGenEnv curriculum defaults for fp penalty
- emphasize clean_f1 reward in PPO config and add penalty schedule
- bump default lagrange multiplier lr
- expose new lagrange lr default via CLI and helper

## Testing
- `pytest tests/test_rl_env.py -q` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687e86cd286c832eba1633a07dff8de1