### PR TITLE
Fix reward weight key names

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -10,10 +10,10 @@ env:
   fp_penalty_start: 0.1
   fp_penalty_end: 0.5
   reward_weights:
-    clean_f1: 0.6
-    dummy_resist_f1: 0.3
-    rule_length: -0.05
-    robust_radius: 0.05
+    f1_clean: 0.6
+    f1_dummy: 0.3
+    rule_len: -0.05
+    certified_bonus: 0.05
 
 model:
   ## 정책 네트워크 종류: "gru" (default), "attn" 또는 GPT 모델명(e.g. "gpt2-small")


### PR DESCRIPTION
## Summary
- update reward weight names in PPO config

## Testing
- `pytest tests/test_rl_env.py::test_reward_weights_override -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_687e898c48a0832e8f248d9829a0b928