### PR TITLE
Add binary-dir to PPO dataset builder

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -4,6 +4,9 @@
 
 - **경로/레지스트리/URL 기반 특징도 추출한다.**
 - CLI: `python -m cli.rulegen_cli feature-mine` 으로 후보 특성을 수집할 수 있습니다.
+- PPO 학습용 데이터셋은 `python -m cli.rulegen_cli build-dataset`으로 생성합니다.
+  원본 바이너리 위치를 ``--binary-dir`` 옵션으로 전달하면 그래프의 ``file_path``가
+  해당 경로를 가리키도록 저장됩니다.
 
 ```python
 from rulegen import FeatureMiner

--- a/src/cli/build_ppo_dataset.py
+++ b/src/cli/build_ppo_dataset.py
@@ -27,6 +27,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--labels", type=Path, required=True, help="CSV or JSONL (sha256,label)")
     p.add_argument("--out-dir", type=Path, required=True, help="Output directory")
     p.add_argument("--metadata-vocab", type=Path, required=True, help="metadata_vocab.json path")
+    p.add_argument("--binary-dir", type=Path, help="Directory containing raw binaries")
     p.add_argument("--clean-label", type=int, default=0)
     p.add_argument("--dummy-label", type=int, default=1)
     return p.parse_args()
@@ -60,7 +61,7 @@ def _load_labels(path: Path) -> Dict[str, int]:
     return labels
 
 
-def _load_graph(graph_dir: Path, sha: str):
+def _load_graph(graph_dir: Path, sha: str, binary_dir: Path | None = None):
     path = _guess_graph_path(graph_dir, sha)
     if not path.is_file():
         raise FileNotFoundError(path)
@@ -74,7 +75,7 @@ def _load_graph(graph_dir: Path, sha: str):
 
     # attach metadata used by RuleEvaluator and other components
     try:
-        g.file_path = str(path)
+        g.file_path = str(binary_dir / sha) if binary_dir is not None else str(path)
         g.sha256 = sha
     except Exception:
         # non-data objects may not allow attribute assignment
@@ -106,7 +107,7 @@ def main(argv: List[str] | None = None) -> None:
 
     for sha, lab in label_map.items():
         try:
-            g = _load_graph(args.hetero_dir, sha)
+            g = _load_graph(args.hetero_dir, sha, args.binary_dir)
             g = GraphDataset._ensure_meta_ids(g, attr_names)
         except FileNotFoundError:
             LOGGER.warning("Graph for %s not found", sha)

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -419,9 +419,12 @@ class RuleGenEnv(gym.Env):
 
     # 데이터셋 로딩
     def _load_datasets(self, dataset_dir: Union[str, Path]) -> None:
-        """
-        • `dataset_dir/{clean,dummy}.pt`를 각각 로드
-        • 각 텐서는 복수 HeteroData 리스트
+        """Load clean/dummy graph datasets.
+
+        Graph objects must contain a ``file_path`` attribute pointing to the raw
+        binary so that :class:`RuleEvaluator` can scan files directly.
+        ``dataset_dir`` should contain ``clean.pt`` and ``dummy.pt`` saved by
+        ``build_ppo_dataset.py``.
         """
         ds_dir = Path(dataset_dir)
         self.clean_set: List[HeteroData] = torch.load(


### PR DESCRIPTION
## Summary
- allow specifying binary location when building PPO dataset
- expect dataset graphs to point to raw binaries when loading
- document binary-dir argument

## Testing
- `pytest tests/test_rl_env.py::test_env_instantiates` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_687e8c164340832ead69e4e4b4615264