### PR TITLE
Add lookahead reward flag to PPO training

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -75,3 +75,20 @@ agent.train(total_timesteps=50000,
             pretrain_epochs=3)
 ```
 
+### Lookahead 보상
+
+보상이 희소한 환경에서는 룰이 완성될 때까지 에이전트가 의미 있는 피드백을 받기
+어렵습니다. `RuleGenEnv`를 `use_lookahead=True` 로 생성하거나 CLI에서
+`--use-lookahead` 옵션을 지정하면 현재까지 생성한 토큰 시퀀스에 대한 분류기 예측
+확률을 임시 보상으로 사용합니다.
+
+```bash
+python -m cli.rulegen_cli ppo-train \
+    --train-features feats.json \
+    --dataset-dir data/splits \
+    --use-lookahead
+```
+
+이렇게 하면 룰이 완성되기 전에 얻는 보상을 통해 탐색이 촉진되어 보상 희소성을
+완화할 수 있습니다.
+

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -529,6 +529,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         classifier_device=args.classifier_device,
         seed=args.seed,
         reward_weights=args.reward_weights,
+        use_lookahead=getattr(args, "use_lookahead", False),
         tokenizer=policy_net,
     )
     sched_cfg = cfg.get("scheduler", {})
@@ -970,6 +971,11 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=0.05,
         help="Lagrange multiplier learning rate",
+    )
+    pt.add_argument(
+        "--use-lookahead",
+        action="store_true",
+        help="Use classifier probability as interim reward for partial rules",
     )
     pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")
     pt.add_argument("--minibatch-size", type=int, default=64)

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -159,6 +159,7 @@ def make_env(
     use_domain_rand: bool = False,
     edge_drop_range: tuple[float, float] = (0.0, 0.1),
     use_adv_perturb: bool = False,
+    use_lookahead: bool = False,
     **kwargs: Any,
 ) -> RuleGenEnv:
     """
@@ -173,6 +174,9 @@ def make_env(
     tokenizer : Optional transformers tokenizer
         If provided, custom rule tokens are added to this tokenizer and used
         by the environment.
+    use_lookahead : bool, default ``False``
+        When ``True``, classifier probabilities are used as interim rewards to
+        mitigate reward sparsity.
     """
     # Legacy argument mapping
     if "classifier_ckpt" in kwargs:
@@ -188,6 +192,7 @@ def make_env(
         classifier_checkpoint=classifier_checkpoint,
         seed=seed if seed is not None else 2024,
         tokenizer=tokenizer,
+        use_lookahead=use_lookahead,
         **kwargs,
     )
 

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -29,6 +29,7 @@ def test_ppo_train_checks_dataset(tmp_path, caplog, monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "torch", torch_stub)
     matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
     pyplot_stub = types.ModuleType("matplotlib.pyplot")
     monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
@@ -71,6 +72,7 @@ def test_hint_file_passed(tmp_path, monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "torch", torch_stub)
     matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
     pyplot_stub = types.ModuleType("matplotlib.pyplot")
     monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
@@ -164,6 +166,7 @@ def test_use_explainer_hints(tmp_path, monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "torch", torch_stub)
     matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
     pyplot_stub = types.ModuleType("matplotlib.pyplot")
     monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
@@ -251,6 +254,7 @@ def test_use_explainer_hints_env_instance(tmp_path, monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "torch", torch_stub)
     matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
     pyplot_stub = types.ModuleType("matplotlib.pyplot")
     monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
@@ -339,6 +343,7 @@ def test_reward_weights_cli(tmp_path, monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "torch", torch_stub)
     matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
     pyplot_stub = types.ModuleType("matplotlib.pyplot")
     monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
@@ -427,6 +432,7 @@ def test_amp_lora_cli(tmp_path, monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "torch", torch_stub)
     matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
     pyplot_stub = types.ModuleType("matplotlib.pyplot")
     monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
@@ -616,3 +622,93 @@ def test_agent_hyperparam_cli(tmp_path, monkeypatch):
     assert captured["agent_kwargs"]["n_steps"] == 2048
     assert captured["agent_kwargs"]["minibatch_size"] == 32
     assert captured["agent_kwargs"]["n_epochs"] == 8
+
+
+def test_use_lookahead_cli(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["agent_env"] = env
+
+        def train(self, **kw):
+            return []
+
+    def fake_load_agent(**kw):
+        return DummyAgent(kw.get("env"))
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = fake_load_agent
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner")
+    fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent")
+    ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod = types.ModuleType("rulegen.yara_builder")
+    y_mod.YaraBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder")
+    c_mod.CapaBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            str(train_fp),
+            "--dataset-dir",
+            str(ds),
+            "--use-lookahead",
+            "--epochs",
+            "1",
+            "--cpu",
+        ]
+    )
+
+    args.func(args)
+    assert captured["use_lookahead"] is True


### PR DESCRIPTION
## Summary
- add `--use-lookahead` flag to CLI and pass through `make_env`
- support `use_lookahead` parameter in `rulegen.make_env`
- document how the lookahead reward alleviates reward sparsity
- test that CLI forwards the flag to the environment

## Testing
- `pytest tests/test_ppo_train_cli.py::test_use_lookahead_cli -q`
- `pytest tests/test_rl_env.py::test_lookahead_reward -q` *(fails: no collectors / skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687e8dbee488832eb092197295c538fe