### PR TITLE
Add meta snapshot option for PPO dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,11 @@ python -m cli.rulegen_cli feature-mine \
 python -m cli.rulegen_cli build-dataset \
        --hetero-dir data/hetero_clean \
        --labels data/meta.csv \
-       --out-dir data/rulegen_dataset
+       --out-dir data/rulegen_dataset \
+       --meta-path models/gnn/encoder.meta.pkl
+
+If `--metadata-vocab` is omitted, the meta snapshot will be converted to
+`metadata_vocab.json` under the output directory.
 
 # 강화학습용 feature 추출
 

--- a/src/cli/build_ppo_dataset.py
+++ b/src/cli/build_ppo_dataset.py
@@ -26,7 +26,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--hetero-dir", type=Path, required=True, help="Directory of graph files")
     p.add_argument("--labels", type=Path, required=True, help="CSV or JSONL (sha256,label)")
     p.add_argument("--out-dir", type=Path, required=True, help="Output directory")
-    p.add_argument("--metadata-vocab", type=Path, required=True, help="metadata_vocab.json path")
+    p.add_argument("--metadata-vocab", type=Path, help="metadata_vocab.json path")
+    p.add_argument("--meta-path", type=Path, help="Path to encoder meta snapshot (.meta.pkl)")
     p.add_argument("--binary-dir", type=Path, help="Directory containing raw binaries")
     p.add_argument("--clean-label", type=int, default=0)
     p.add_argument("--dummy-label", type=int, default=1)
@@ -87,8 +88,25 @@ def main(argv: List[str] | None = None) -> None:
     args = parse_args() if argv is None else parse_args()
     ensure_dir(args.out_dir)
 
-    with args.metadata_vocab.open("r", encoding="utf-8") as f:
-        vocab = json.load(f)
+    if args.meta_path is not None:
+        meta = torch.load(args.meta_path, map_location="cpu")
+        attr_names_meta = meta.get("attr_names")
+        max_ids = meta.get("max_ids")
+        if attr_names_meta is None or max_ids is None:
+            raise RuntimeError("Meta snapshot missing attr_names or max_ids")
+        vocab = {
+            nt: {name: int(max_ids.get(name, 0)) for name in names}
+            for nt, names in attr_names_meta.items()
+        }
+        if args.metadata_vocab is None:
+            args.metadata_vocab = args.out_dir / "metadata_vocab.json"
+            with args.metadata_vocab.open("w", encoding="utf-8") as fp:
+                json.dump(vocab, fp)
+    else:
+        if args.metadata_vocab is None:
+            raise ValueError("Either --metadata-vocab or --meta-path is required")
+        with args.metadata_vocab.open("r", encoding="utf-8") as f:
+            vocab = json.load(f)
 
     attr_names: Dict[str, List[str]] = {}
     for nt, attrs in vocab.items():

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -825,8 +825,12 @@ def cmd_build_dataset(args: argparse.Namespace) -> None:
         args.labels,
         "--out-dir",
         args.out_dir,
-        "--metadata-vocab",
-        args.metadata_vocab,
+    ]
+    if args.metadata_vocab:
+        cmd += ["--metadata-vocab", args.metadata_vocab]
+    if args.meta_path:
+        cmd += ["--meta-path", args.meta_path]
+    cmd += [
         "--clean-label",
         str(args.clean_label),
         "--dummy-label",
@@ -888,7 +892,8 @@ def _build_parser() -> argparse.ArgumentParser:
     bd.add_argument("--hetero-dir", required=True, help="Directory of graph files")
     bd.add_argument("--labels", required=True, help="CSV or JSONL (sha256,label)")
     bd.add_argument("--out-dir", required=True, help="Output directory")
-    bd.add_argument("--metadata-vocab", required=True, help="metadata_vocab.json path")
+    bd.add_argument("--metadata-vocab", help="metadata_vocab.json path")
+    bd.add_argument("--meta-path", help="Path to encoder meta snapshot (.meta.pkl)")
     bd.add_argument("--clean-label", type=int, default=0, help="Label for clean graphs")
     bd.add_argument("--dummy-label", type=int, default=1, help="Label for dummy graphs")
     bd.set_defaults(func=cmd_build_dataset)


### PR DESCRIPTION
## Summary
- allow optional `--meta-path` in `build_ppo_dataset.py`
- support new argument in `rulegen_cli` and propagate to subprocess
- document metadata generation workflow in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil', 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687e954eb910832e8c000f29d765866f