### PR TITLE
Add meta snapshot loading for RuleGenEnv

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -530,6 +530,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         seed=args.seed,
         reward_weights=args.reward_weights,
         use_lookahead=getattr(args, "use_lookahead", False),
+        meta_path=getattr(args, "meta_path", None),
         tokenizer=policy_net,
     )
     sched_cfg = cfg.get("scheduler", {})
@@ -914,6 +915,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")
+    pt.add_argument("--meta-path", help="Path to encoder meta snapshot (.meta.pkl)")
     pt.add_argument(
         "--classifier-checkpoint",
         default="models/gnn/res_gcl.pt",

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -156,6 +156,7 @@ def make_env(
     classifier_checkpoint: str | Path = "models/gnn/res_gcl.pt",
     seed: int | None = None,
     tokenizer: Optional[PreTrainedTokenizer] = None,
+    meta_path: Optional[Path] = None,
     use_domain_rand: bool = False,
     edge_drop_range: tuple[float, float] = (0.0, 0.1),
     use_adv_perturb: bool = False,
@@ -174,6 +175,8 @@ def make_env(
     tokenizer : Optional transformers tokenizer
         If provided, custom rule tokens are added to this tokenizer and used
         by the environment.
+    meta_path : optional Path
+        Encoder meta snapshot used to reinitialize classifier input layers.
     use_lookahead : bool, default ``False``
         When ``True``, classifier probabilities are used as interim rewards to
         mitigate reward sparsity.
@@ -192,6 +195,7 @@ def make_env(
         classifier_checkpoint=classifier_checkpoint,
         seed=seed if seed is not None else 2024,
         tokenizer=tokenizer,
+        meta_path=meta_path,
         use_lookahead=use_lookahead,
         **kwargs,
     )

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -91,6 +91,7 @@ class RuleGenEnv(gym.Env):
         rule_type: str = "yara",  # or "capa"
         vocab_file: Optional[Union[str, Path]] = None,
         dataset_dir: Union[str, Path] = "data/splits",
+        meta_path: Optional[Path] = None,
         attr_dim: int = 16,
         max_len: int = 180,
         batch_size_eval: int = 128,
@@ -119,6 +120,7 @@ class RuleGenEnv(gym.Env):
         rule_type        : "yara" | "capa"
         vocab_file       : 사전 json (토큰 → id) 경로; 없으면 FeatureMiner로 동적 생성
         dataset_dir      : time‑split train/val/test parquet 경로
+        meta_path        : optional encoder meta snapshot (.meta.pkl)
         attr_dim         : metadata embedding dimension when reconfiguring encoder
         max_len          : 룰 최대 토큰 길이 (spec ≤ 512 제한 대비 여유)
         batch_size_eval  : 보상 산출 시 배치 추론 크기
@@ -266,13 +268,38 @@ class RuleGenEnv(gym.Env):
             dtype=np.int32,
         )
 
-        # ── 데이터셋 & 모델 로드 ───────────────────────────────
-        self._load_datasets(dataset_dir)
+        # ── 모델 로드 ───────────────────────────────────────────
         self.device = torch.device(device)
         self.classifier_device = torch.device(classifier_device)
         self.classifier: RESGCLClassifier = RESGCLClassifier.load_pretrained(
             Path(classifier_checkpoint), map_location=self.classifier_device
         )
+
+        meta_attr_names = None
+        if meta_path is not None:
+            try:
+                from torch.serialization import add_safe_globals
+                from src.graphs.normalizers.schema import NodeType
+
+                add_safe_globals([NodeType])
+                meta = torch.load(meta_path, weights_only=False)
+                if isinstance(meta, dict):
+                    meta_attr_names = meta.get("attr_names")
+                    meta_in_dims = {k: int(v) for k, v in meta.get("in_dims", {}).items()}
+                    meta_vocab = int(meta.get("vocab_size", 0))
+                    self.attr_dim = int(meta.get("attr_dim", self.attr_dim))
+                    if hasattr(self.classifier, "encoder"):
+                        self.classifier.encoder.attr_dim = self.attr_dim
+                    self.classifier.reinit_input_dims(
+                        in_dims=meta_in_dims,
+                        attr_names=meta_attr_names,
+                        vocab_size=meta_vocab,
+                    )
+            except Exception as exc:  # pragma: no cover - optional
+                _LOG.warning("Failed to load meta snapshot %s: %s", meta_path, exc)
+
+        # ── 데이터셋 로드 ───────────────────────────────────────
+        self._load_datasets(dataset_dir)
         self.batch_size_eval = batch_size_eval
 
         # 평가지표/보상 모듈
@@ -283,7 +310,7 @@ class RuleGenEnv(gym.Env):
         )
 
         meta_file = Path(dataset_dir) / "metadata_vocab.json"
-        if meta_file.is_file():
+        if meta_file.is_file() and meta_attr_names is None:
             try:
                 self._reconfigure_encoder_for_metadata(meta_file)
             except Exception as exc:  # pragma: no cover - optional

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -712,3 +712,96 @@ def test_use_lookahead_cli(tmp_path, monkeypatch):
 
     args.func(args)
     assert captured["use_lookahead"] is True
+
+
+def test_meta_path_cli(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["agent_env"] = env
+
+        def train(self, **kw):
+            return []
+
+    def fake_load_agent(**kw):
+        return DummyAgent(kw.get("env"))
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = fake_load_agent
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner")
+    fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent")
+    ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod = types.ModuleType("rulegen.yara_builder")
+    y_mod.YaraBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder")
+    c_mod.CapaBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+    meta_fp = tmp_path / "enc.meta.pkl"
+    meta_fp.write_text("x")
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            str(train_fp),
+            "--dataset-dir",
+            str(ds),
+            "--meta-path",
+            str(meta_fp),
+            "--epochs",
+            "1",
+            "--cpu",
+        ]
+    )
+
+    args.func(args)
+    assert captured["meta_path"] == str(meta_fp)

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import sys
+import types
 
 pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
@@ -26,10 +27,21 @@ class DummyClf(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.calls = 0
+        self.encoder = types.SimpleNamespace(
+            attr_names={},
+            attr_dim=1,
+            input_proj={},
+            meta_embed=None,
+        )
 
     def forward(self, data):
         self.calls += 1
         return torch.zeros(len(data), dtype=torch.float)
+
+    def reinit_input_dims(self, in_dims, attr_names=None, vocab_size=0):
+        self.encoder.attr_names = attr_names or {}
+        if vocab_size:
+            self.encoder.meta_embed = torch.nn.Embedding(vocab_size, self.encoder.attr_dim)
 
 
 dummy_clf = DummyClf()
@@ -379,3 +391,36 @@ def test_metadata_vocab_list_format(tmp_path):
     )
 
     assert env.classifier.encoder.attr_names.get("") == ["foo"]
+
+
+def test_meta_path_overrides_metadata(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    meta_vocab = tmp_path / "metadata_vocab.json"
+    json.dump({"bar": ["z"]}, meta_vocab.open("w"))
+
+    meta_path = tmp_path / "enc.meta.pkl"
+    torch.save(
+        {"attr_names": {"": ["foo"]}, "in_dims": {"": 4}, "vocab_size": 3, "attr_dim": 2},
+        meta_path,
+    )
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        meta_path=meta_path,
+    )
+
+    assert env.classifier.encoder.attr_names.get("") == ["foo"]
+    assert env.classifier.encoder.meta_embed is not None
+    assert env.classifier.encoder.meta_embed.num_embeddings == 3


### PR DESCRIPTION
## Summary
- allow RuleGenEnv to load encoder meta snapshots
- expose `--meta-path` in rulegen.make_env and CLI
- adjust CLI tests and RL environment tests for new behaviour

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e9698c500832e88113f4e689b6c8a