### PR TITLE
Add encoder meta snapshot logging

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -295,6 +295,10 @@ class RuleGenEnv(gym.Env):
                         attr_names=meta_attr_names,
                         vocab_size=meta_vocab,
                     )
+                    _LOG.info(
+                        "Loaded encoder attributes from meta snapshot: %s",
+                        self.classifier.encoder.attr_names,
+                    )
             except Exception as exc:  # pragma: no cover - optional
                 _LOG.warning("Failed to load meta snapshot %s: %s", meta_path, exc)
 


### PR DESCRIPTION
## Summary
- log classifier encoder attr names after reinitialising input dims
- show attributes loaded from meta snapshot

## Testing
- `PYTHONPATH=src pytest tests/test_rl_env.py::test_meta_path_overrides_metadata -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9db29948832e9a548ef549de9583