### PR TITLE
Fix attr_names restoration in checkpoint loader

### DIFF
--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -207,6 +207,9 @@ class RESGCLClassifier(nn.Module):
         else:
             LOGGER.warning("Meta snapshot %s not found", meta_path)
 
+        if attr_names is None and isinstance(meta, dict) and "attr_names" in meta:
+            attr_names = meta.get("attr_names")
+
         if meta is not None:
             node_types = list(meta.get("node_types", []))
             edge_types = [tuple(e) for e in meta.get("edge_types", [])]


### PR DESCRIPTION
## Summary
- use attr_names from metadata if not provided

## Testing
- `pytest -q` *(fails: missing torch_geometric and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ea0207fb8832eaa40ba82d615c2f7