### PR TITLE
Implement lookahead F1 reward

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -45,6 +45,13 @@ try:
 except Exception:  # pragma: no cover - optional dep
     PreTrainedTokenizer = None  # type: ignore
 import re
+import subprocess
+import tempfile
+
+try:
+    import yara  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yara = None
 
 import gymnasium as gym
 import numpy as np
@@ -303,8 +310,8 @@ class RuleGenEnv(gym.Env):
                 _LOG.warning("Failed to load meta snapshot %s: %s", meta_path, exc)
 
         # ── 데이터셋 로드 ───────────────────────────────────────
-        self._load_datasets(dataset_dir)
         self.batch_size_eval = batch_size_eval
+        self._load_datasets(dataset_dir)
 
         # 평가지표/보상 모듈
         self.evaluator = RuleEvaluator(
@@ -469,6 +476,48 @@ class RuleGenEnv(gym.Env):
             len(self.clean_set),
             len(self.dummy_set),
         )
+        if self.use_lookahead:
+            self._precompute_clf_probs()
+
+    def _precompute_clf_probs(self) -> None:
+        """Precompute classifier logits for every graph in the datasets."""
+        from src.graphs.dataset import GraphDataset
+
+        attr_names = getattr(self.classifier.encoder, "attr_names", None)
+
+        class _ListDS(torch.utils.data.Dataset):
+            def __init__(self, graphs: Sequence[HeteroData]):
+                self.graphs = list(graphs)
+
+            def __len__(self) -> int:
+                return len(self.graphs)
+
+            def __getitem__(self, idx: int):
+                g = self.graphs[idx]
+                sha = getattr(g, "sha256", str(idx))
+                return g, 0, sha
+
+        def _collect(ds_list: Sequence[HeteroData]) -> List[float]:
+            ds = _ListDS(ds_list)
+            loader = DataLoader(
+                ds,
+                batch_size=self.batch_size_eval,
+                shuffle=False,
+                collate_fn=lambda b: GraphDataset.collate_fn(b, attr_names=attr_names),
+            )
+            logits: List[float] = []
+            self.classifier.eval()
+            for batch in loader:
+                g = batch["graph"].to(self.classifier_device)
+                out = self.classifier(g, return_logits=True)
+                if isinstance(out, (list, tuple)):
+                    out = out[0]
+                out = out.view(-1)
+                logits.extend(out.detach().cpu().tolist())
+            return logits
+
+        self._clf_probs_clean = _collect(self.clean_set)
+        self._clf_probs_dummy = _collect(self.dummy_set)
 
     def _fgsm_graph(self, g: HeteroData, label: int, epsilon: float) -> HeteroData:
         g_adv = g.clone().to(self.classifier_device)
@@ -660,19 +709,78 @@ class RuleGenEnv(gym.Env):
 
     @torch.inference_mode()
     def _lookahead_prob(self, tokens: Sequence[int]) -> float:
-        """Return classifier probability for the current token sequence."""
+        """Return weighted F1 of rule matches against classifier predictions."""
         if not tokens:
             return 0.0
-        x = torch.tensor(
-            tokens, dtype=torch.long, device=self.classifier_device
-        ).unsqueeze(0)
-        out = self.classifier(x)
-        if isinstance(out, (tuple, list)):
-            out = out[0]
-        if out.ndim > 1:
-            out = out.squeeze(0)
-        prob = torch.sigmoid(out).squeeze().item()
-        return float(prob)
+
+        rule_text = self._tokens_to_rule(tokens)
+
+        try:
+            if self.rule_type == "yara":
+                if yara is None:
+                    return 0.0
+                compiled = yara.compile(source=rule_text)
+
+                def _match(path: Path) -> bool:
+                    try:
+                        return bool(compiled.match(str(path)))
+                    except Exception:
+                        return False
+
+            else:  # capa rule
+                with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as tmp:
+                    tmp.write(rule_text)
+                    tmp.flush()
+
+                def _match(path: Path) -> bool:
+                    try:
+                        proc = subprocess.run(
+                            ["capa", str(path), "-r", tmp.name, "--json"],
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                    except FileNotFoundError:
+                        return False
+                    if proc.returncode != 0:
+                        return False
+                    try:
+                        js = json.loads(proc.stdout)
+                    except Exception:
+                        return False
+                    return bool(js.get("rules"))
+        except Exception:
+            return 0.0
+
+        matches: List[int] = []
+        for g in self.clean_set:
+            p = getattr(g, "file_path", None) or getattr(g, "sha256", None)
+            matches.append(int(_match(Path(str(p))) if p is not None else False))
+        for g in self.dummy_set:
+            p = getattr(g, "file_path", None) or getattr(g, "sha256", None)
+            matches.append(int(_match(Path(str(p))) if p is not None else False))
+
+        labels = [1 if logit >= 0 else 0 for logit in self._clf_probs_clean]
+        labels += [1 if logit >= 0 else 0 for logit in self._clf_probs_dummy]
+
+        TP = FP = FN = TN = 0
+        for pred, lab in zip(matches, labels):
+            if pred and lab:
+                TP += 1
+            elif pred and not lab:
+                FP += 1
+            elif not pred and lab:
+                FN += 1
+            else:
+                TN += 1
+
+        denom_pos = 2 * TP + FP + FN
+        f1_dummy = 0.0 if denom_pos == 0 else 2 * TP / denom_pos
+        denom_neg = 2 * TN + FP + FN
+        f1_clean = 0.0 if denom_neg == 0 else 2 * TN / denom_neg
+
+        w = self.reward_weights
+        return float(w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy)
 
     # reward
     @torch.inference_mode()

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -364,7 +364,7 @@ def test_lookahead_reward(tmp_path):
     env.reset()
     dummy_clf.calls = 0
     _, r, done, tr, info = env.step(env.token2id["A"])
-    assert dummy_clf.calls == 1
+    assert dummy_clf.calls == 0
     assert not done
     assert "lookahead_prob" in info
 


### PR DESCRIPTION
## Summary
- precompute classifier logits for datasets in RuleGenEnv
- compute lookahead reward using rule matches vs classifier predictions
- adjust unit test for new lookahead behaviour

## Testing
- `ruff check src/rulegen/rl_env.py tests/test_rl_env.py`
- `pytest tests/test_rl_env.py::test_lookahead_reward -q` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_687ea8761198832eb7f057d85c70d1e2