### PR TITLE
Normalize graphs before adding to PPO dataset

### DIFF
--- a/src/cli/build_ppo_dataset.py
+++ b/src/cli/build_ppo_dataset.py
@@ -126,6 +126,10 @@ def main(argv: List[str] | None = None) -> None:
     for sha, lab in label_map.items():
         try:
             g = _load_graph(args.hetero_dir, sha, args.binary_dir)
+            g = GraphDataset._sanitize_attrs(g)
+            g = GraphDataset._ensure_num_nodes(g)
+            g = GraphDataset._ensure_x(g)
+            g = GraphDataset._sanitize_edges(g)
             g = GraphDataset._ensure_meta_ids(g, attr_names)
         except FileNotFoundError:
             LOGGER.warning("Graph for %s not found", sha)


### PR DESCRIPTION
## Summary
- sanitize and validate graphs when building PPO dataset

## Testing
- `pytest -k build_ppo_dataset -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_687eb4918804832e977c4f94dcd4e0bc