### PR TITLE
Handle edge feature padding in GraphDataset.collate_fn

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -225,11 +225,12 @@ class GraphDataset(Dataset):
             graphs = [GraphDataset._ensure_meta_ids(g, attr_names) for g in graphs]
 
         # --------------------------------------------------------------
-        # Determine max feature dimension for every (node_type, attr)
+        # Determine max feature dimension for every (node/edge_type, attr)
         # --------------------------------------------------------------
-        max_dim: Dict[Tuple[str, str], int] = defaultdict(int)
+        max_dim: Dict[Tuple[Any, str], int] = defaultdict(int)
         for g in graphs:
             if isinstance(g, HeteroData):
+                # node attributes
                 for ntype in g.node_types:
                     store = g[ntype]
                     for attr, val in store.items():
@@ -240,10 +241,29 @@ class GraphDataset(Dataset):
                         ):
                             key = (ntype, attr)
                             max_dim[key] = max(max_dim[key], val.size(1))
+                # edge attributes
+                for etype in g.edge_types:
+                    store = g[etype]
+                    for attr, val in store.items():
+                        if (
+                            attr != "edge_index"
+                            and isinstance(val, torch.Tensor)
+                            and val.dim() == 2
+                        ):
+                            key = (etype, attr)
+                            max_dim[key] = max(max_dim[key], val.size(1))
             else:  # Data
                 for attr, val in g.items():
                     if (
                         attr in {"x", "feat"}
+                        and isinstance(val, torch.Tensor)
+                        and val.dim() == 2
+                    ):
+                        key = ("", attr)
+                        max_dim[key] = max(max_dim[key], val.size(1))
+                for attr, val in g.items():
+                    if (
+                        attr not in {"x", "feat", "edge_index"}
                         and isinstance(val, torch.Tensor)
                         and val.dim() == 2
                     ):
@@ -275,6 +295,20 @@ class GraphDataset(Dataset):
                                 if val.size(1) < target:
                                     pad = target - val.size(1)
                                     store[attr] = F.pad(val, (0, pad))
+                for etype in g_clone.edge_types:
+                    store = g_clone[etype]
+                    for attr, val in list(store.items()):
+                        if attr == "edge_index" or not isinstance(val, torch.Tensor):
+                            continue
+                        if val.dim() == 1:
+                            val = val.unsqueeze(-1)
+                            store[attr] = val
+                        if val.dim() == 2:
+                            key = (etype, attr)
+                            target = max_dim[key]
+                            if val.size(1) < target:
+                                pad = target - val.size(1)
+                                store[attr] = F.pad(val, (0, pad))
             else:
                 for attr, val in list(g_clone.items()):
                     if attr in {"x", "feat"} and isinstance(val, torch.Tensor):
@@ -288,6 +322,18 @@ class GraphDataset(Dataset):
                             if val.size(1) < target:
                                 pad = target - val.size(1)
                                 g_clone[attr] = F.pad(val, (0, pad))
+                for attr, val in list(g_clone.items()):
+                    if attr in {"x", "feat", "edge_index"} or not isinstance(val, torch.Tensor):
+                        continue
+                    if val.dim() == 1:
+                        val = val.unsqueeze(-1)
+                        g_clone[attr] = val
+                    if val.dim() == 2:
+                        key = ("", attr)
+                        target = max_dim[key]
+                        if val.size(1) < target:
+                            pad = target - val.size(1)
+                            g_clone[attr] = F.pad(val, (0, pad))
             padded_graphs.append(g_clone)
 
         batch_graph = Batch.from_data_list(padded_graphs)

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -238,3 +238,36 @@ def test_dataset_sets_api_num_nodes(tmp_path):
     loaded, _, _ = ds[0]
 
     assert loaded["api"].num_nodes == 1
+
+
+def test_collate_pads_edge_attr_dim(tmp_path):
+    graph_dir = tmp_path / "train" / "graphs"
+    graph_dir.mkdir(parents=True)
+
+    from torch_geometric.data import Data
+
+    g1 = Data(
+        x=torch.tensor([[0.0]]),
+        edge_index=torch.tensor([[0], [0]]),
+        edge_attr=torch.tensor([[1.0, 2.0]]),
+        num_nodes=1,
+    )
+    g2 = Data(
+        x=torch.tensor([[0.0]]),
+        edge_index=torch.tensor([[0], [0]]),
+        edge_attr=torch.tensor([3.0]),
+        num_nodes=1,
+    )
+
+    torch.save(g1, graph_dir / "a.pt")
+    torch.save(g2, graph_dir / "b.pt")
+
+    ds = GraphDataset(tmp_path, split="train", label_file=None)
+    from torch.utils.data import DataLoader
+
+    loader = DataLoader(ds, batch_size=2, collate_fn=GraphDataset.collate_fn)
+    batch = next(iter(loader))
+
+    assert batch["graph"].edge_attr.shape == (2, 2)
+    assert torch.allclose(batch["graph"].edge_attr[0], torch.tensor([1.0, 2.0]))
+    assert torch.allclose(batch["graph"].edge_attr[1], torch.tensor([3.0, 0.0]))


### PR DESCRIPTION
## Summary
- pad edge features like node features in `GraphDataset.collate_fn`
- test padding of edge attributes with different dims

## Testing
- `pytest -k test_collate_pads_edge_attr_dim -q` *(fails: ModuleNotFoundError: No module named 'angr')*

------
https://chatgpt.com/codex/tasks/task_e_687ec5839c4c832e9302175c29d0f8e5