### PR TITLE
Fix padding for 1D features in GraphDataset.collate_fn

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -237,10 +237,11 @@ class GraphDataset(Dataset):
                         if (
                             attr in {"x", "feat"}
                             and isinstance(val, torch.Tensor)
-                            and val.dim() == 2
+                            and val.dim() in {1, 2}
                         ):
+                            dim = 1 if val.dim() == 1 else val.size(1)
                             key = (ntype, attr)
-                            max_dim[key] = max(max_dim[key], val.size(1))
+                            max_dim[key] = max(max_dim[key], dim)
                 # edge attributes
                 for etype in g.edge_types:
                     store = g[etype]
@@ -248,27 +249,30 @@ class GraphDataset(Dataset):
                         if (
                             attr != "edge_index"
                             and isinstance(val, torch.Tensor)
-                            and val.dim() == 2
+                            and val.dim() in {1, 2}
                         ):
+                            dim = 1 if val.dim() == 1 else val.size(1)
                             key = (etype, attr)
-                            max_dim[key] = max(max_dim[key], val.size(1))
+                            max_dim[key] = max(max_dim[key], dim)
             else:  # Data
                 for attr, val in g.items():
                     if (
                         attr in {"x", "feat"}
                         and isinstance(val, torch.Tensor)
-                        and val.dim() == 2
+                        and val.dim() in {1, 2}
                     ):
+                        dim = 1 if val.dim() == 1 else val.size(1)
                         key = ("", attr)
-                        max_dim[key] = max(max_dim[key], val.size(1))
+                        max_dim[key] = max(max_dim[key], dim)
                 for attr, val in g.items():
                     if (
                         attr not in {"x", "feat", "edge_index"}
                         and isinstance(val, torch.Tensor)
-                        and val.dim() == 2
+                        and val.dim() in {1, 2}
                     ):
+                        dim = 1 if val.dim() == 1 else val.size(1)
                         key = ("", attr)
-                        max_dim[key] = max(max_dim[key], val.size(1))
+                        max_dim[key] = max(max_dim[key], dim)
 
         # --------------------------------------------------------------
         # Pad features to the collected max dimension


### PR DESCRIPTION
## Summary
- update `collate_fn` to treat 1D tensors as `(N, 1)` when computing the maximum feature dimension
- pad node and edge attributes up to the collected maximum dimension

## Testing
- `pytest tests/test_graph_dataset_unsqueeze.py -q`
- `pytest tests/test_graph_dataset.py -k test_collate_pads_edge_attr_dim -q`

------
https://chatgpt.com/codex/tasks/task_e_687eca3e22b0832ea88759b74cabba86