### PR TITLE
Fix padding for 1D features in GraphDataset.collate_fn

### DIFF
--- a/src/graphs/dataset/graph_dataset.py
+++ b/src/graphs/dataset/graph_dataset.py
@@ -237,10 +237,14 @@ class GraphDataset(Dataset):
                         if (
                             attr in {"x", "feat"}
                             and isinstance(val, torch.Tensor)
-                            and val.dim() == 2
+                            and val.dim() <= 2
                         ):
+                            if val.dim() == 0 or val.numel() == 0:
+                                dim = 0
+                            else:
+                                dim = 1 if val.dim() == 1 else val.size(1)
                             key = (ntype, attr)
-                            max_dim[key] = max(max_dim[key], val.size(1))
+                            max_dim[key] = max(max_dim[key], dim)
                 # edge attributes
                 for etype in g.edge_types:
                     store = g[etype]
@@ -248,27 +252,39 @@ class GraphDataset(Dataset):
                         if (
                             attr != "edge_index"
                             and isinstance(val, torch.Tensor)
-                            and val.dim() == 2
+                            and val.dim() <= 2
                         ):
+                            if val.dim() == 0 or val.numel() == 0:
+                                dim = 0
+                            else:
+                                dim = 1 if val.dim() == 1 else val.size(1)
                             key = (etype, attr)
-                            max_dim[key] = max(max_dim[key], val.size(1))
+                            max_dim[key] = max(max_dim[key], dim)
             else:  # Data
                 for attr, val in g.items():
                     if (
                         attr in {"x", "feat"}
                         and isinstance(val, torch.Tensor)
-                        and val.dim() == 2
+                        and val.dim() <= 2
                     ):
+                        if val.dim() == 0 or val.numel() == 0:
+                            dim = 0
+                        else:
+                            dim = 1 if val.dim() == 1 else val.size(1)
                         key = ("", attr)
-                        max_dim[key] = max(max_dim[key], val.size(1))
+                        max_dim[key] = max(max_dim[key], dim)
                 for attr, val in g.items():
                     if (
                         attr not in {"x", "feat", "edge_index"}
                         and isinstance(val, torch.Tensor)
-                        and val.dim() == 2
+                        and val.dim() <= 2
                     ):
+                        if val.dim() == 0 or val.numel() == 0:
+                            dim = 0
+                        else:
+                            dim = 1 if val.dim() == 1 else val.size(1)
                         key = ("", attr)
-                        max_dim[key] = max(max_dim[key], val.size(1))
+                        max_dim[key] = max(max_dim[key], dim)
 
         # --------------------------------------------------------------
         # Pad features to the collected max dimension
@@ -285,7 +301,12 @@ class GraphDataset(Dataset):
                     store = g_clone[ntype]
                     for attr, val in list(store.items()):
                         if attr in {"x", "feat"} and isinstance(val, torch.Tensor):
-                            # 1D features are treated as (N,1) for padding.
+                            if val.dim() == 0 or val.numel() == 0:
+                                key = (ntype, attr)
+                                target = max_dim[key]
+                                n = store.num_nodes or 1
+                                store[attr] = val.new_zeros((n, target))
+                                continue
                             if val.dim() == 1:
                                 val = val.unsqueeze(-1)
                                 store[attr] = val
@@ -300,6 +321,12 @@ class GraphDataset(Dataset):
                     for attr, val in list(store.items()):
                         if attr == "edge_index" or not isinstance(val, torch.Tensor):
                             continue
+                        if val.dim() == 0 or val.numel() == 0:
+                            key = (etype, attr)
+                            target = max_dim[key]
+                            n = store.num_edges or (store.edge_index.size(1) if hasattr(store, "edge_index") else 1)
+                            store[attr] = val.new_zeros((n, target))
+                            continue
                         if val.dim() == 1:
                             val = val.unsqueeze(-1)
                             store[attr] = val
@@ -312,7 +339,12 @@ class GraphDataset(Dataset):
             else:
                 for attr, val in list(g_clone.items()):
                     if attr in {"x", "feat"} and isinstance(val, torch.Tensor):
-                        # 1D features are expanded to (N,1) for uniform padding.
+                        if val.dim() == 0 or val.numel() == 0:
+                            key = ("", attr)
+                            target = max_dim[key]
+                            n = g_clone.num_nodes or 1
+                            g_clone[attr] = val.new_zeros((n, target))
+                            continue
                         if val.dim() == 1:
                             val = val.unsqueeze(-1)
                             g_clone[attr] = val
@@ -324,6 +356,12 @@ class GraphDataset(Dataset):
                                 g_clone[attr] = F.pad(val, (0, pad))
                 for attr, val in list(g_clone.items()):
                     if attr in {"x", "feat", "edge_index"} or not isinstance(val, torch.Tensor):
+                        continue
+                    if val.dim() == 0 or val.numel() == 0:
+                        key = ("", attr)
+                        target = max_dim[key]
+                        n = g_clone.num_edges if hasattr(g_clone, "num_edges") else 1
+                        g_clone[attr] = val.new_zeros((n, target))
                         continue
                     if val.dim() == 1:
                         val = val.unsqueeze(-1)


### PR DESCRIPTION
## Summary
- update `collate_fn` to treat 1D tensors as `(N, 1)` when computing the maximum feature dimension
- pad node and edge attributes up to the collected maximum dimension
- handle empty or 0-D tensors during padding so missing features no longer cause errors

## Testing
- `pytest tests/test_graph_dataset_unsqueeze.py -q`
- `pytest tests/test_graph_dataset.py -k test_collate_pads_edge_attr_dim -q`


------
https://chatgpt.com/codex/tasks/task_e_687eca3e22b0832ea88759b74cabba86