### PR TITLE
Implement single target mode in RuleGenEnv

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -116,6 +116,7 @@ class RuleGenEnv(gym.Env):
         use_shaping: bool = False,
         use_adv_perturb: bool = False,
         use_lookahead: bool = False,
+        single_target_mode: bool = False,
         reward_weights: dict | None = None,
         fp_penalty_start: float = 0.1,
         fp_penalty_end: float = 0.5,
@@ -144,6 +145,7 @@ class RuleGenEnv(gym.Env):
         core_tokens      : shaping potential 계산에 사용할 핵심 토큰 시퀀스
         use_shaping      : ``True``면 potential based reward shaping 활성화
         use_lookahead   : ``True``면 룰 미완성 시 분류기 확률을 임시 보상으로 사용
+        single_target_mode : ``True``면 매 에피소드 하나의 더미 그래프를 무작위 선택해 해당 특성 토큰을 힌트로 제공
         reward_weights   : F1/길이/인증 보상 가중치 딕셔너리
         fp_penalty_start : 초기 False Positive 패널티 배율
         fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
@@ -312,6 +314,10 @@ class RuleGenEnv(gym.Env):
         # ── 데이터셋 로드 ───────────────────────────────────────
         self.batch_size_eval = batch_size_eval
         self._load_datasets(dataset_dir)
+        self.single_target_mode = bool(single_target_mode)
+        self.full_dummy_set = list(self.dummy_set)
+        if hasattr(self, "_clf_probs_dummy"):
+            self._clf_probs_full_dummy = list(self._clf_probs_dummy)
 
         # 평가지표/보상 모듈
         self.evaluator = RuleEvaluator(
@@ -339,13 +345,26 @@ class RuleGenEnv(gym.Env):
         hint_features: List[str] | None = None,
     ) -> Tuple[np.ndarray, dict]:
         super().reset(seed=seed)
-        feats = hint_features if hint_features is not None else self.hint_features
-        hint_tokens: List[int] = []
-        for feat in feats:
-            for tok in self._rule_tokenize(feat):
-                tok_id = self.token2id.get(tok)
-                if tok_id is not None:
-                    hint_tokens.append(tok_id)
+        info_extra: dict = {}
+        if self.single_target_mode:
+            idx = random.randrange(len(self.full_dummy_set))
+            target = self.full_dummy_set[idx]
+            self.dummy_set = [target]
+            if hasattr(self, "_clf_probs_full_dummy"):
+                self._clf_probs_dummy = [self._clf_probs_full_dummy[idx]]
+            hint_tokens = self._graph_hint_tokens(target)
+            info_extra["target_idx"] = idx
+            sha = getattr(target, "sha256", None)
+            if sha is not None:
+                info_extra["target_sha"] = sha
+        else:
+            feats = hint_features if hint_features is not None else self.hint_features
+            hint_tokens: List[int] = []
+            for feat in feats:
+                for tok in self._rule_tokenize(feat):
+                    tok_id = self.token2id.get(tok)
+                    if tok_id is not None:
+                        hint_tokens.append(tok_id)
 
         self._hint_tokens = list(hint_tokens)
         self._tokens = []
@@ -360,6 +379,7 @@ class RuleGenEnv(gym.Env):
         )
         obs = self._pad_obs(self._tokens)
         info = {"hint": np.array(self._hint_tokens, dtype=np.int32)}
+        info.update(info_extra)
         return obs, info
 
     def step(
@@ -626,6 +646,24 @@ class RuleGenEnv(gym.Env):
         if n:
             arr[:n] = all_toks[:n]
         return arr
+
+    def _graph_hint_tokens(self, g: HeteroData) -> List[int]:
+        """Extract hint token ids from a graph's features."""
+        feats = getattr(g, "features", None)
+        if not isinstance(feats, list):
+            try:
+                fm = FeatureMiner(top_k=20)
+                sal = torch.ones(sum(g[nt].num_nodes for nt in g.node_types))
+                feats = fm(g, sal)
+            except Exception:
+                feats = []
+        tokens: List[int] = []
+        for feat in feats:
+            for tok in self._rule_tokenize(str(feat)):
+                tid = self.token2id.get(tok)
+                if tid is not None:
+                    tokens.append(tid)
+        return tokens
 
     def get_action_mask(
         self,

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -1,4 +1,5 @@
 import json
+import random
 import pytest
 import sys
 import types
@@ -424,3 +425,32 @@ def test_meta_path_overrides_metadata(tmp_path):
     assert env.classifier.encoder.attr_names.get("") == ["foo"]
     assert env.classifier.encoder.meta_embed is not None
     assert env.classifier.encoder.meta_embed.num_embeddings == 3
+
+
+def test_single_target_mode_hints(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    d1 = HeteroData()
+    d1.features = ["A"]
+    d2 = HeteroData()
+    d2.features = ["B"]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save([d1, d2], tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "B": 1, "<PAD>": 2, "<END>": 3}, vocab_file.open("w"))
+
+    monkeypatch.setattr(random, "randrange", lambda n: 1)
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        single_target_mode=True,
+    )
+
+    obs, info = env.reset()
+    assert info.get("target_idx") == 1
+    assert list(info["hint"]) == [env.token2id["B"]]


### PR DESCRIPTION
## Summary
- add `single_target_mode` option to `RuleGenEnv`
- when enabled, choose one target graph per episode and use its features as hint tokens
- expose helper to extract hint tokens from a graph
- test that single target mode sets hints correctly

## Testing
- `pytest -q tests/test_rl_env.py`

------
https://chatgpt.com/codex/tasks/task_e_687f350486ac832e898ac20dc368ff1d