### PR TITLE
Update single target mode hints

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -319,6 +319,18 @@ class RuleGenEnv(gym.Env):
         if hasattr(self, "_clf_probs_dummy"):
             self._clf_probs_full_dummy = list(self._clf_probs_dummy)
 
+        # precompute target features for single target mode
+        self.target_features_list: List[List[str]] = []
+        if self.single_target_mode:
+            fm = FeatureMiner(top_k=50)
+            for g in self.full_dummy_set:
+                try:
+                    sal = torch.ones(sum(g[nt].num_nodes for nt in g.node_types))
+                    feats = fm(g, sal)
+                except Exception:
+                    feats = []
+                self.target_features_list.append(feats)
+
         # 평가지표/보상 모듈
         self.evaluator = RuleEvaluator(
             clf=self.classifier,
@@ -352,19 +364,20 @@ class RuleGenEnv(gym.Env):
             self.dummy_set = [target]
             if hasattr(self, "_clf_probs_full_dummy"):
                 self._clf_probs_dummy = [self._clf_probs_full_dummy[idx]]
-            hint_tokens = self._graph_hint_tokens(target)
+            feats = self.target_features_list[idx]
             info_extra["target_idx"] = idx
             sha = getattr(target, "sha256", None)
             if sha is not None:
                 info_extra["target_sha"] = sha
         else:
             feats = hint_features if hint_features is not None else self.hint_features
-            hint_tokens: List[int] = []
-            for feat in feats:
-                for tok in self._rule_tokenize(feat):
-                    tok_id = self.token2id.get(tok)
-                    if tok_id is not None:
-                        hint_tokens.append(tok_id)
+
+        hint_tokens: List[int] = []
+        for feat in feats:
+            for tok in self._rule_tokenize(feat):
+                tok_id = self.token2id.get(tok)
+                if tok_id is not None:
+                    hint_tokens.append(tok_id)
 
         self._hint_tokens = list(hint_tokens)
         self._tokens = []

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -20,6 +20,7 @@ if not hasattr(torch.serialization, "add_safe_globals"):
     setattr(torch.serialization, "add_safe_globals", lambda *a, **k: None)
 
 from src.rulegen.rl_env import RuleGenEnv
+import src.rulegen.rl_env as rl_env
 import src.models.gnn.res_wrapper as res_wrapper
 import models.gnn.res_wrapper as res_wrapper_pkg
 
@@ -440,6 +441,15 @@ def test_single_target_mode_hints(tmp_path, monkeypatch):
     json.dump({"A": 0, "B": 1, "<PAD>": 2, "<END>": 3}, vocab_file.open("w"))
 
     monkeypatch.setattr(random, "randrange", lambda n: 1)
+
+    class DummyFM:
+        def __init__(self, *a, **k):
+            pass
+
+        def __call__(self, g, sal):
+            return getattr(g, "features", [])
+
+    monkeypatch.setattr(rl_env, "FeatureMiner", DummyFM)
 
     env = RuleGenEnv(
         rule_type="yara",


### PR DESCRIPTION
## Summary
- compute features once per dummy graph in single target mode
- use those features as hint tokens in `reset`
- adjust test to stub `FeatureMiner`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_687f378a2330832ebdcc50cfa17145d0