### PR TITLE
Add single-target mode flag

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -530,6 +530,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         seed=args.seed,
         reward_weights=args.reward_weights,
         use_lookahead=getattr(args, "use_lookahead", False),
+        single_target_mode=getattr(args, "single_target_mode", False),
         meta_path=getattr(args, "meta_path", None),
         tokenizer=policy_net,
     )
@@ -545,6 +546,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         "minibatch_size": args.minibatch_size,
         "n_epochs": args.ppo_epochs,
         "accum_steps": args.accum_steps,
+        "use_hint": True,
     }
     if any(getattr(args, n) is not None for n in ["lora_r", "lora_alpha", "lora_dropout"]):
         agent_kwargs["lora_cfg"] = {
@@ -725,8 +727,9 @@ def cmd_generate(args: argparse.Namespace) -> None:
         hint_features=hint_feats,
         seed=args.seed,
         reward_weights=args.reward_weights,
+        single_target_mode=getattr(args, "single_target_mode", False),
     )
-    agent = PPORuleAgent(env, seed=args.seed)
+    agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
     agent.load(args.agent_checkpoint)
 
     builder = builder_cls()  # type: ignore[call-arg]
@@ -974,6 +977,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Use classifier probability as interim reward for partial rules",
     )
+    pt.add_argument(
+        "--single-target-mode",
+        action="store_true",
+        help="Use a single random dummy graph as target each episode",
+    )
     pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")
     pt.add_argument("--minibatch-size", type=int, default=64)
     pt.add_argument("--ppo-epochs", type=int, default=4)
@@ -1016,6 +1024,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     gen.add_argument(
         "--temperature", type=float, default=1.0, help="Sampling temperature"
+    )
+    gen.add_argument(
+        "--single-target-mode",
+        action="store_true",
+        help="Use a single random dummy graph as target each episode",
     )
     gen.add_argument("--rule-type", choices=["yara", "capa"], default="yara")
     gen.add_argument(

--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -161,6 +161,7 @@ def make_env(
     edge_drop_range: tuple[float, float] = (0.0, 0.1),
     use_adv_perturb: bool = False,
     use_lookahead: bool = False,
+    single_target_mode: bool = False,
     **kwargs: Any,
 ) -> RuleGenEnv:
     """
@@ -197,6 +198,7 @@ def make_env(
         tokenizer=tokenizer,
         meta_path=meta_path,
         use_lookahead=use_lookahead,
+        single_target_mode=single_target_mode,
         **kwargs,
     )
 


### PR DESCRIPTION
## Summary
- expose `single_target_mode` in `rulegen.make_env`
- support `--single-target-mode` in rulegen CLI
- always enable hint usage for PPO agent

## Testing
- `pytest -k 'nothing' -q` *(fails: ImportError: lief)*

------
https://chatgpt.com/codex/tasks/task_e_687f38e1975c832ea03c9f98d7a6349e