### PR TITLE
Update default reward weights

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -10,8 +10,8 @@ env:
   fp_penalty_start: 0.1
   fp_penalty_end: 0.5
   reward_weights:
-    f1_clean: 0.6
-    f1_dummy: 0.3
+    f1_clean: 0.4
+    f1_dummy: 0.5
     rule_len: -0.05
     certified_bonus: 0.05
 

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -36,7 +36,8 @@ env = RuleGenEnv(
 )
 ```
 
-CLI 사용 시 `--reward-weights` 옵션으로 JSON 문자열이나 파일 경로를 전달할 수 있습니다.
+CLI 사용 시 `--reward-weights` 옵션을 주면 YAML 설정의 기본값 대신
+외부에서 지정한 JSON 문자열이나 파일의 보상 가중치를 사용할 수 있습니다.
 
 ```bash
 python -m cli.rulegen_cli ppo-train \

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -233,8 +233,8 @@ class RuleGenEnv(gym.Env):
         self.normalize_reward = normalize_reward
 
         default_weights = {
-            "f1_clean": 0.5,
-            "f1_dummy": 0.4,
+            "f1_clean": 0.4,
+            "f1_dummy": 0.5,
             "rule_len": -0.05,
             "certified_bonus": 0.05,
         }


### PR DESCRIPTION
## Summary
- tune `RuleGenEnv` reward weights
- update default PPO config to match
- clarify in the quick start docs how to override weights via CLI

## Testing
- `pytest -k rl_env -q` *(fails: missing dependencies such as torch_geometric)*

------
https://chatgpt.com/codex/tasks/task_e_687f3e3931fc832eb0ba38dfd993b9a9