### PR TITLE
Add target-graph option to rulegen generate CLI

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -65,6 +65,7 @@ import pandas as pd
 import torch
 import pandas as pd
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from tqdm import tqdm
@@ -548,7 +549,9 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         "accum_steps": args.accum_steps,
         "use_hint": True,
     }
-    if any(getattr(args, n) is not None for n in ["lora_r", "lora_alpha", "lora_dropout"]):
+    if any(
+        getattr(args, n) is not None for n in ["lora_r", "lora_alpha", "lora_dropout"]
+    ):
         agent_kwargs["lora_cfg"] = {
             "r": args.lora_r,
             "alpha": args.lora_alpha,
@@ -720,34 +723,66 @@ def cmd_generate(args: argparse.Namespace) -> None:
     seen = set()
     hint_feats = [f for f in feats if not (f in seen or seen.add(f))]
 
-    # Load agent
-    env = rulegen.make_env(
-        dataset_dir=Path("data/rulegen_dataset"),
-        device="cpu",
-        hint_features=hint_feats,
-        seed=args.seed,
-        reward_weights=args.reward_weights,
-        single_target_mode=getattr(args, "single_target_mode", False),
-    )
-    agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
-    agent.load(args.agent_checkpoint)
+    if args.target_graph:
+        import tempfile
 
-    builder = builder_cls()  # type: ignore[call-arg]
-    rules = agent.sample_rules(n=args.n_rules, temperature=args.temperature)
-    rules_text = "\n\n".join(builder.build(r) for r in rules)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            g = torch.load(
+                Path(args.target_graph), map_location="cpu", weights_only=False
+            )
+            try:
+                g.file_path = str(args.target_graph)
+            except Exception:
+                pass
 
-    if args.out:
-        out_path = Path(args.out)
+            tmp_path = Path(tmp_dir)
+            torch.save([], tmp_path / "clean.pt")
+            torch.save([g], tmp_path / "dummy.pt")
+
+            env = rulegen.make_env(
+                dataset_dir=tmp_path,
+                device="cpu",
+                hint_features=hint_feats,
+                seed=args.seed,
+                reward_weights=args.reward_weights,
+                single_target_mode=True,
+            )
+            agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
+            agent.load(args.agent_checkpoint)
+
+            builder = builder_cls()  # type: ignore[call-arg]
+            rule = agent.sample_rules(n=1, temperature=args.temperature)[0]
+            rule_text = builder.build(rule)
+            print(rule_text)
     else:
-        ts = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
-        out_dir = Path("models") / "rulebank" / args.rule_type
-        out_path = out_dir / f"generated_{ts}.yar"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with out_path.open("w", encoding="utf-8") as fp:
-        fp.write(rules_text)
-    logger.info(
-        "Generated %d %s rules → %s", len(rules), args.rule_type.upper(), out_path
-    )
+        # Load agent with default dataset
+        env = rulegen.make_env(
+            dataset_dir=Path("data/rulegen_dataset"),
+            device="cpu",
+            hint_features=hint_feats,
+            seed=args.seed,
+            reward_weights=args.reward_weights,
+            single_target_mode=getattr(args, "single_target_mode", False),
+        )
+        agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
+        agent.load(args.agent_checkpoint)
+
+        builder = builder_cls()  # type: ignore[call-arg]
+        rules = agent.sample_rules(n=args.n_rules, temperature=args.temperature)
+        rules_text = "\n\n".join(builder.build(r) for r in rules)
+
+        if args.out:
+            out_path = Path(args.out)
+        else:
+            ts = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            out_dir = Path("models") / "rulebank" / args.rule_type
+            out_path = out_dir / f"generated_{ts}.yar"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as fp:
+            fp.write(rules_text)
+        logger.info(
+            "Generated %d %s rules → %s", len(rules), args.rule_type.upper(), out_path
+        )
 
 
 def _evaluate_metrics(preds: Sequence[int], labels: Sequence[int], metrics: List[str]):
@@ -825,10 +860,14 @@ def cmd_build_dataset(args: argparse.Namespace) -> None:
         hetero_dir=Path(args.hetero_dir).expanduser().resolve(),
         labels=Path(args.labels).expanduser().resolve(),
         out_dir=Path(args.out_dir).expanduser().resolve(),
-        metadata_vocab=Path(args.metadata_vocab).expanduser().resolve()
-        if args.metadata_vocab
-        else None,
-        meta_path=Path(args.meta_path).expanduser().resolve() if args.meta_path else None,
+        metadata_vocab=(
+            Path(args.metadata_vocab).expanduser().resolve()
+            if args.metadata_vocab
+            else None
+        ),
+        meta_path=(
+            Path(args.meta_path).expanduser().resolve() if args.meta_path else None
+        ),
         clean_label=args.clean_label,
         dummy_label=args.dummy_label,
     )
@@ -991,7 +1030,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Number of minibatches to accumulate gradients before optimizer step",
     )
-    pt.add_argument("--amp", action="store_true", help="Enable mixed precision training")
+    pt.add_argument(
+        "--amp", action="store_true", help="Enable mixed precision training"
+    )
     pt.add_argument(
         "--grad-checkpoint",
         action="store_true",
@@ -1000,8 +1041,12 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument("--lora-r", type=int, help="LoRA rank for GPT policies")
     pt.add_argument("--lora-alpha", type=float, help="LoRA alpha value")
     pt.add_argument("--lora-dropout", type=float, help="LoRA dropout")
-    pt.add_argument("--load-4bit", action="store_true", help="Load GPT policy in 4-bit mode")
-    pt.add_argument("--load-8bit", action="store_true", help="Load GPT policy in 8-bit mode")
+    pt.add_argument(
+        "--load-4bit", action="store_true", help="Load GPT policy in 4-bit mode"
+    )
+    pt.add_argument(
+        "--load-8bit", action="store_true", help="Load GPT policy in 8-bit mode"
+    )
     pt.add_argument(
         "--cpu", action="store_true", help="Force CPU even if CUDA available"
     )
@@ -1029,6 +1074,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--single-target-mode",
         action="store_true",
         help="Use a single random dummy graph as target each episode",
+    )
+    gen.add_argument(
+        "--target-graph",
+        help="Path to a single graph (.pt or .pyg.pkl) to target",
     )
     gen.add_argument("--rule-type", choices=["yara", "capa"], default="yara")
     gen.add_argument(

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -39,17 +39,19 @@ def test_build_parser_accepts_embed_dir(monkeypatch):
 
     rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
     parser = rulegen_cli._build_parser()
-    args = parser.parse_args([
-        "feature-mine",
-        "--graph-dir",
-        "d",
-        "--out",
-        "o.json",
-        "--embed-dir",
-        "embeds",
-        "--classifier-ckpt",
-        "clf.pt",
-    ])
+    args = parser.parse_args(
+        [
+            "feature-mine",
+            "--graph-dir",
+            "d",
+            "--out",
+            "o.json",
+            "--embed-dir",
+            "embeds",
+            "--classifier-ckpt",
+            "clf.pt",
+        ]
+    )
     assert args.embed_dir == "embeds"
     assert args.classifier_ckpt == Path("clf.pt")
     assert args.func == rulegen_cli.cmd_feature_mine
@@ -60,14 +62,35 @@ def test_generate_parser_accepts_features(monkeypatch):
 
     rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
     parser = rulegen_cli._build_parser()
-    args = parser.parse_args([
-        "generate",
-        "--agent-checkpoint",
-        "agent.pt",
-        "--out",
-        "rules.yar",
-        "--features",
-        "feats.json",
-    ])
+    args = parser.parse_args(
+        [
+            "generate",
+            "--agent-checkpoint",
+            "agent.pt",
+            "--out",
+            "rules.yar",
+            "--features",
+            "feats.json",
+        ]
+    )
     assert args.features == "feats.json"
+    assert args.func == rulegen_cli.cmd_generate
+
+
+def test_generate_parser_accepts_target_graph(monkeypatch, tmp_path):
+    import importlib
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+    parser = rulegen_cli._build_parser()
+    tg = tmp_path / "g.pt"
+    args = parser.parse_args(
+        [
+            "generate",
+            "--agent-checkpoint",
+            "agent.pt",
+            "--target-graph",
+            str(tg),
+        ]
+    )
+    assert args.target_graph == str(tg)
     assert args.func == rulegen_cli.cmd_generate


### PR DESCRIPTION
## Summary
- support `--target-graph` in the `generate` subcommand
- build a temporary single-graph dataset when the option is used
- print the rollout rule instead of saving to file
- test parser updates

## Testing
- `pytest tests/test_rulegen_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3f52ad5c832e871a1db1dfd9757f