### PR TITLE
Add off-target penalty for RL rule generation

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -9,6 +9,7 @@ env:
   max_tokens: 512
   fp_penalty_start: 0.1
   fp_penalty_end: 0.5
+  off_target_penalty: 0.25
   reward_weights:
     f1_clean: 0.4
     f1_dummy: 0.5

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -121,6 +121,7 @@ class RuleGenEnv(gym.Env):
         fp_penalty_start: float = 0.1,
         fp_penalty_end: float = 0.5,
         curriculum_steps: int = 100000,
+        off_target_penalty: float = 0.25,
     ):
         """
         Parameters
@@ -150,6 +151,7 @@ class RuleGenEnv(gym.Env):
         fp_penalty_start : 초기 False Positive 패널티 배율
         fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
         curriculum_steps : 패널티 스케줄 총 스텝 수
+        off_target_penalty : single_target_mode 시 비표적 매치 1건당 패널티
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -256,6 +258,7 @@ class RuleGenEnv(gym.Env):
         self.fp_penalty_start = float(fp_penalty_start)
         self.fp_penalty_end = float(fp_penalty_end)
         self.curriculum_steps = max(1, int(curriculum_steps))
+        self.off_target_penalty = float(off_target_penalty)
         self.total_steps = 0
 
         # Hint features / tokens
@@ -894,6 +897,20 @@ class RuleGenEnv(gym.Env):
         else:
             bonus = 0.0
         reward += bonus
+
+        # penalize off-target matches in single-target mode
+        off_target_pen = 0.0
+        off_matches = 0.0
+        if self.single_target_mode and len(self.full_dummy_set) > len(dummy_set):
+            off_targets = [g for g in self.full_dummy_set if g not in dummy_set]
+            if off_targets:
+                _, f1_ot, _ = self.evaluator.evaluate_rule(rule_text, [], off_targets)
+                m_off = len(off_targets)
+                if f1_ot > 0:
+                    off_matches = float(f1_ot * m_off / (2 - f1_ot))
+                off_target_pen = self.off_target_penalty * off_matches
+                reward -= off_target_pen
+
         metrics = dict(
             f1_clean=f1_clean,
             f1_dummy=f1_dummy,
@@ -904,6 +921,8 @@ class RuleGenEnv(gym.Env):
             fp_penalty=curr_penalty * fp_rate,
             fp_penalty_factor=curr_penalty,
             saliency_bonus=bonus,
+            off_target_matches=off_matches,
+            off_target_penalty=off_target_pen,
             reward=reward,
         )
         shaping = 0.0

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -464,3 +464,62 @@ def test_single_target_mode_hints(tmp_path, monkeypatch):
     obs, info = env.reset()
     assert info.get("target_idx") == 1
     assert list(info["hint"]) == [env.token2id["B"]]
+
+
+def test_off_target_penalty(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    d1 = HeteroData()
+    d2 = HeteroData()
+    d3 = HeteroData()
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save([d1, d2, d3], tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    monkeypatch.setattr(random, "randrange", lambda n: 0)
+
+    class DummyFM:
+        def __init__(self, *a, **k):
+            pass
+
+        def __call__(self, g, sal):
+            return []
+
+    monkeypatch.setattr(rl_env, "FeatureMiner", DummyFM)
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        single_target_mode=True,
+        off_target_penalty=1.0,
+    )
+
+    env.reset()
+
+    def eval_rule(rule, clean_set, dummy_set):
+        if clean_set:
+            return 1.0, 1.0, 3.0
+        else:
+            m = len(dummy_set)
+            f1 = 2.0 / (m + 1)
+            return 0.0, f1, 3.0
+
+    monkeypatch.setattr(env.evaluator, "evaluate_rule", eval_rule)
+    r1, m1, _ = env._compute_reward("A", update_stats=False)
+
+    def eval_rule_no_off(rule, clean_set, dummy_set):
+        if clean_set:
+            return 1.0, 1.0, 3.0
+        else:
+            return 0.0, 0.0, 3.0
+
+    monkeypatch.setattr(env.evaluator, "evaluate_rule", eval_rule_no_off)
+    r2, m2, _ = env._compute_reward("A", update_stats=False)
+
+    assert r1 < r2
+    assert m1["off_target_matches"] > 0


### PR DESCRIPTION
## Summary
- penalize rules that match off-target samples in `RuleGenEnv`
- expose `off_target_penalty` knob in config and env
- test that off-target matches reduce reward

## Testing
- `PYTHONPATH=src pytest tests/test_rl_env.py::test_off_target_penalty -q`

------
https://chatgpt.com/codex/tasks/task_e_687f420336c8832e8fa2b97233d0ec64