### PR TITLE
Add GPT vocab resize check and env token validation

### DIFF
--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -264,6 +264,16 @@ def load_agent(
         lagrange_lr=lagrange_lr,
         **(agent_kwargs or {}),
     )
+    if hasattr(agent.policy, "gpt"):
+        vocab_size = env.vocab_size
+        emb_size = agent.policy.gpt.get_input_embeddings().num_embeddings
+        if vocab_size != emb_size:
+            agent.policy.gpt.resize_token_embeddings(vocab_size)
+            _LOG.warning(
+                "Resized GPT embeddings: env vocab=%d, model=%d",
+                vocab_size,
+                emb_size,
+            )
     if ckpt_path:
         agent.load(ckpt_path)
         _LOG.info("Loaded PPO agent weights from '%s'", ckpt_path)

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -690,6 +690,10 @@ class RuleGenEnv(gym.Env):
         n = min(len(all_toks), obs_len)
         if n:
             arr[:n] = all_toks[:n]
+        if arr.max() >= self.vocab_size:
+            raise ValueError(
+                f"Observation token id out of range: {int(arr.max())} >= {self.vocab_size}"
+            )
         return arr
 
     def _graph_hint_tokens(self, g: HeteroData) -> List[int]:

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -805,3 +805,43 @@ def test_meta_path_cli(tmp_path, monkeypatch):
 
     args.func(args)
     assert captured["meta_path"] == str(meta_fp)
+
+
+def test_gpt_embedding_resize_warning(monkeypatch, caplog):
+    sys.modules.pop("rulegen", None)
+    sys.modules.pop("rulegen.rl_agent", None)
+    sys.modules.pop("src.rulegen", None)
+    sys.modules.pop("src.rulegen.rl_agent", None)
+
+    env = types.SimpleNamespace(vocab_size=5)
+
+    class DummyGPT:
+        def __init__(self):
+            self.emb_size = 3
+            self.resized_to = None
+
+        def get_input_embeddings(self):
+            return types.SimpleNamespace(num_embeddings=self.emb_size)
+
+        def resize_token_embeddings(self, n):
+            self.resized_to = n
+
+    class DummyAgent:
+        def __init__(self, env, **kw):
+            self.env = env
+            self.policy = types.SimpleNamespace(gpt=DummyGPT())
+
+        def load(self, *a, **k):
+            pass
+
+    import importlib
+    import src.rulegen as rg
+    rg.PPORuleAgent = DummyAgent
+    import rulegen as rg_root
+    rulegen = importlib.reload(rg_root)
+
+    caplog.set_level(logging.WARNING)
+    agent = rulegen.load_agent(env=env, policy_net="gpt2")
+
+    assert agent.policy.gpt.resized_to == env.vocab_size
+    assert any("Resized GPT embeddings" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- adjust `load_agent` to ensure GPT embeddings match env vocab
- warn when resizing GPT embeddings
- validate observations in `_pad_obs`
- test GPT embedding resize logic

## Testing
- `pytest tests/test_ppo_train_cli.py::test_gpt_embedding_resize_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa36f0c64832eabc359703574bcc7