### PR TITLE
Fix GPT vocab size mismatch on agent load

### DIFF
--- a/src/rulegen/__init__.py
+++ b/src/rulegen/__init__.py
@@ -264,19 +264,24 @@ def load_agent(
         lagrange_lr=lagrange_lr,
         **(agent_kwargs or {}),
     )
-    if hasattr(agent.policy, "gpt"):
-        vocab_size = env.vocab_size
-        emb_size = agent.policy.gpt.get_input_embeddings().num_embeddings
-        if vocab_size != emb_size:
-            agent.policy.gpt.resize_token_embeddings(vocab_size)
-            _LOG.warning(
-                "Resized GPT embeddings: env vocab=%d, model=%d",
-                vocab_size,
-                emb_size,
-            )
+
+    def _ensure_vocab_size() -> None:
+        if hasattr(agent.policy, "gpt"):
+            vocab_size = env.vocab_size
+            emb_size = agent.policy.gpt.get_input_embeddings().num_embeddings
+            if vocab_size != emb_size:
+                _LOG.warning(
+                    "Resized GPT embeddings: env vocab=%d, model=%d",
+                    vocab_size,
+                    emb_size,
+                )
+                agent.policy.gpt.resize_token_embeddings(vocab_size)
+
+    _ensure_vocab_size()
     if ckpt_path:
         agent.load(ckpt_path)
         _LOG.info("Loaded PPO agent weights from '%s'", ckpt_path)
+        _ensure_vocab_size()
     else:
         _LOG.info("Initialized fresh PPO agent (no checkpoint)")
     return agent


### PR DESCRIPTION
## Summary
- ensure the PPO agent's GPT embeddings match the environment vocabulary
- warn and resize embeddings whenever a mismatch is detected

## Testing
- `pytest tests/test_logger_memory.py::test_logger_adds_memory_usage tests/test_split_generator.py::test_split_by_time_missing_date_skip -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa957622c832e9635480673d44ad8