### PR TITLE
Add token range assertion in rl_env

### DIFF
--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -690,10 +690,11 @@ class RuleGenEnv(gym.Env):
         n = min(len(all_toks), obs_len)
         if n:
             arr[:n] = all_toks[:n]
-        if arr.max() >= self.vocab_size:
-            raise ValueError(
-                f"Observation token id out of range: {int(arr.max())} >= {self.vocab_size}"
-            )
+        max_id = int(arr.max())
+        min_id = int(arr.min())
+        assert max_id < self.vocab_size and min_id >= 0, (
+            f"Observation token ids out of range: min={min_id}, max={max_id}, vocab_size={self.vocab_size}"
+        )
         return arr
 
     def _graph_hint_tokens(self, g: HeteroData) -> List[int]:


### PR DESCRIPTION
## Summary
- check observation token indices in `_pad_obs`

## Testing
- `PYTHONPATH=src pytest tests/test_rl_env.py::test_reset_with_hints -q`

------
https://chatgpt.com/codex/tasks/task_e_687fabadb3fc832eb69cc98dedae387a