### PR TITLE
Add max hint tokens option

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,14 @@ python -m cli.rulegen_cli ppo-train \
        --train-features features.json \
        --val-features val_features.json \
        --hint-features hints.json \
+       --max-hint-tokens 128 \
        --max-vocab 500 \
        --config configs/rulegen/ppo.yaml \
        --checkpoint models/rulegen/ppo_agent.pt
 # Use `--max-vocab` to keep only the N most frequent tokens when
 # building the vocabulary from hint features.
+# `--max-hint-tokens` limits how many hint tokens are prepended to each
+# observation.
 # `--val-features` can point to a JSONL or JSON array.  When provided,
 # these features are loaded via `_read_json_lines` and used as hints when
 # sampling validation rules.
@@ -256,7 +259,10 @@ python -m cli.rulegen_cli ppo-train \
 python -m cli.rulegen_cli ppo-train \
        --train-features features.json \
        --policy gpt2 \
+       --max-hint-tokens 64 \
        --checkpoint models/rulegen/gpt2_agent.pt
+# When using GPT-based policies, ensure that `max_len + max_hint_tokens`
+# does not exceed 1024 so the prompt fits within the model context window.
 # 간단한 환경 생성 예시
 ```python
 from rulegen import make_env

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -534,6 +534,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         single_target_mode=getattr(args, "single_target_mode", False),
         meta_path=getattr(args, "meta_path", None),
         tokenizer=policy_net,
+        max_hint_tokens=getattr(args, "max_hint_tokens", None),
     )
     sched_cfg = cfg.get("scheduler", {})
     sched_name = sched_cfg.get("name")
@@ -991,6 +992,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--max-vocab",
         type=int,
         help="Keep only the N most frequent tokens from hints",
+    )
+    pt.add_argument(
+        "--max-hint-tokens",
+        type=int,
+        help="Maximum number of hint tokens to prepend to observations",
     )
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
     pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -141,6 +141,9 @@ class RuleGenEnv(gym.Env):
         tokenizer        : HuggingFace tokenizer to extend with rule tokens
         hint_features    : 초기 관측에 포함할 토큰 문자열 시퀀스
         max_hint_tokens  : 힌트 토큰 최대 길이. ``None``이면 기본 힌트 길이를 사용
+                          GPT 토크나이저가 주어지면 ``max_len + max_hint_tokens``
+                          가 ``tokenizer.model_max_length`` (기본 1024) 을
+                          넘지 않도록 자동 조정된다
         token_saliency   : 토큰별 중요도 가중치 딕셔너리
         step_penalty     : 매 스텝 적용할 패널티 (e.g. ``-0.01``)
         per_token_saliency : 선택한 토큰 saliency 가중치 배율
@@ -345,6 +348,15 @@ class RuleGenEnv(gym.Env):
                 self.max_hint_tokens,
                 *(len(t) for t in raw_target_tokens) if raw_target_tokens else [0],
             )
+
+        max_allowed = getattr(self.tokenizer, "model_max_length", 1024) - self.max_len
+        if self.max_hint_tokens > max_allowed:
+            logging.warning(
+                "max_hint_tokens (%d) clipped to %d due to GPT context limit",
+                self.max_hint_tokens,
+                max_allowed,
+            )
+            self.max_hint_tokens = max_allowed
 
         self._default_hint_tokens = (
             self._default_hint_tokens[: self.max_hint_tokens]

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -807,6 +807,97 @@ def test_meta_path_cli(tmp_path, monkeypatch):
     assert captured["meta_path"] == str(meta_fp)
 
 
+def test_max_hint_tokens_cli(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["agent_env"] = env
+
+        def train(self, **kw):
+            return []
+
+    def fake_load_agent(**kw):
+        return DummyAgent(kw.get("env"))
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = fake_load_agent
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner")
+    fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent")
+    ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod = types.ModuleType("rulegen.yara_builder")
+    y_mod.YaraBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder")
+    c_mod.CapaBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            str(train_fp),
+            "--dataset-dir",
+            str(ds),
+            "--max-hint-tokens",
+            "7",
+            "--epochs",
+            "1",
+            "--cpu",
+        ]
+    )
+
+    args.func(args)
+    assert captured["max_hint_tokens"] == 7
+
+
 def test_gpt_embedding_resize_warning(monkeypatch, caplog):
     sys.modules.pop("rulegen", None)
     sys.modules.pop("rulegen.rl_agent", None)


### PR DESCRIPTION
## Summary
- add `--max-hint-tokens` CLI arg for `ppo-train`
- forward the argument to `rulegen.make_env`
- clip `max_hint_tokens` in `RuleGenEnv` when GPT context length would be exceeded
- document new option and GPT context note
- test that CLI passes `--max-hint-tokens`

## Testing
- `pytest tests/test_ppo_train_cli.py::test_max_hint_tokens_cli -q`
- `pytest -q` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_687fb452debc832eae97bbd8c05e582d