### PR TITLE
Add explainer hint generation option

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -159,6 +159,55 @@ def _parse_reward_weights(text: str) -> dict:
         raise argparse.ArgumentTypeError(f"invalid JSON: {exc}") from exc
 
 
+def generate_explainer_hints(
+    dataset_dir: Path, classifier_ckpt: str, device: str
+) -> list[str]:
+    """Generate rule hints using gradients from a pretrained classifier."""
+
+    _lazy_imports()
+    from src.models.gnn.res_wrapper import RESGCLClassifier
+
+    graphs = torch.load(dataset_dir / "dummy.pt", weights_only=False)
+    classifier = RESGCLClassifier.load_pretrained(
+        classifier_ckpt, map_location=device
+    )
+    classifier.to(device).eval()
+
+    miner = FeatureMiner()
+    hints: list[str] = []
+
+    for g in graphs:
+        g = g.to(device)
+        for nt in g.node_types:
+            x = g[nt].get("x")
+            if x is not None and torch.is_floating_point(x):
+                g[nt].x = x.clone().detach().requires_grad_(True)
+
+        out = classifier(g, return_logits=True)
+        if isinstance(out, (list, tuple)):
+            out = out[0]
+        out = out.view(-1).sum()
+        classifier.zero_grad()
+        out.backward()
+
+        saliency: dict[str, torch.Tensor] = {}
+        for nt in g.node_types:
+            x = g[nt].get("x")
+            if x is not None and x.grad is not None:
+                saliency[nt] = x.grad.abs().sum(dim=1).detach().cpu()
+            else:
+                saliency[nt] = torch.zeros(g[nt].num_nodes)
+
+        g_cpu = g.cpu()
+        for nt in g_cpu.node_types:
+            if hasattr(g_cpu[nt], "x"):
+                g_cpu[nt].x = g_cpu[nt].x.detach()
+        hints.extend(miner.mine(g_cpu, saliency))
+
+    seen = set()
+    return [h for h in hints if not (h in seen or seen.add(h))]
+
+
 # ---------------------------------------------------------------------------
 # Sub‑command implementations
 # ---------------------------------------------------------------------------
@@ -480,6 +529,14 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         hint_feats = [f for f in feats if not (f in seen or seen.add(f))]
     elif getattr(args, "hint_features", None):
         hint_feats = _read_json_lines(Path(args.hint_features))
+    elif getattr(args, "generate_hints_from_explainer", False):
+        try:
+            hint_feats = generate_explainer_hints(
+                dataset_dir, args.classifier_checkpoint, args.classifier_device
+            )
+        except Exception as exc:
+            logger.error("Failed to generate explainer hints: %s", exc)
+            raise SystemExit(1)
     else:
         # Use train features as hints by default for vocab consistency
         feats: list[str] = []
@@ -941,6 +998,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--use-explainer-hints",
         action="store_true",
         help="Use mined train features as rule hints",
+    )
+    pt.add_argument(
+        "--generate-hints-from-explainer",
+        action="store_true",
+        help="Generate hint features via gradient-based explainer",
     )
     pt.add_argument(
         "--hint-file",

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -898,6 +898,94 @@ def test_max_hint_tokens_cli(tmp_path, monkeypatch):
     assert captured["max_hint_tokens"] == 7
 
 
+def test_generate_hints_from_explainer(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["env"] = env
+
+        def train(self, **kw):
+            return []
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = lambda env=None: DummyAgent(env)
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner")
+    fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent")
+    ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod = types.ModuleType("rulegen.yara_builder")
+    y_mod.YaraBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder")
+    c_mod.CapaBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+    monkeypatch.setattr(rulegen_cli, "generate_explainer_hints", lambda *a, **k: ["HX"])
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            str(train_fp),
+            "--dataset-dir",
+            str(ds),
+            "--generate-hints-from-explainer",
+            "--epochs",
+            "1",
+            "--cpu",
+        ]
+    )
+
+    args.func(args)
+    assert captured["hint_features"] == ["HX"]
+
+
 def test_gpt_embedding_resize_warning(monkeypatch, caplog):
     sys.modules.pop("rulegen", None)
     sys.modules.pop("rulegen.rl_agent", None)


### PR DESCRIPTION
## Summary
- implement `generate_explainer_hints` helper
- add option `--generate-hints-from-explainer` to CLI
- call helper in `cmd_ppo_train`
- test CLI hint generation via explainer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `pip install -r requirements.txt` *(failed to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687fb9be9b0c832e9b5054b792833786