### PR TITLE
Add explainer hints option

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -1002,7 +1002,10 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument(
         "--generate-hints-from-explainer",
         action="store_true",
-        help="Generate hint features via gradient-based explainer",
+        help=(
+            "학습 시작 전 classifier explainer로 각 악성 샘플의 saliency를 계산하여 "
+            "힌트를 자동 생성"
+        ),
     )
     pt.add_argument(
         "--hint-file",


### PR DESCRIPTION
## Summary
- in the `ppo-train` subcommand, allow generating hints with the classifier explainer

## Testing
- `pytest tests/test_ppo_train_cli.py::test_generate_hints_from_explainer -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbc6982c8832e8da1df9f24598d75