### PR TITLE
Add mutually exclusive hint options to PPO trainer CLI

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -993,23 +993,21 @@ def _build_parser() -> argparse.ArgumentParser:
     pt = sub.add_parser("ppo-train", help="Train PPO rule agent")
     pt.add_argument("--train-features", required=True, help="JSONL mined features")
     pt.add_argument("--val-features", help="Validation feature file (optional)")
-    pt.add_argument("--hint-features", help="Optional JSON with rule hints")
-    pt.add_argument(
+    hint_group = pt.add_mutually_exclusive_group()
+    hint_group.add_argument("--hint-file", help="Path to JSONL/JSON array with hint features")
+    hint_group.add_argument("--hint-features", help="Optional JSON with rule hints")
+    hint_group.add_argument(
         "--use-explainer-hints",
         action="store_true",
         help="Use mined train features as rule hints",
     )
-    pt.add_argument(
+    hint_group.add_argument(
         "--generate-hints-from-explainer",
         action="store_true",
         help=(
             "학습 시작 전 classifier explainer로 각 악성 샘플의 saliency를 계산하여 "
             "힌트를 자동 생성"
         ),
-    )
-    pt.add_argument(
-        "--hint-file",
-        help="Path to JSONL/JSON array with hint features",
     )
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -986,6 +986,49 @@ def test_generate_hints_from_explainer(tmp_path, monkeypatch):
     assert captured["hint_features"] == ["HX"]
 
 
+def test_hint_option_conflict(tmp_path, monkeypatch):
+    import importlib
+
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+    parser = rulegen_cli._build_parser()
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "ppo-train",
+                "--train-features",
+                str(train_fp),
+                "--dataset-dir",
+                str(ds),
+                "--hint-file",
+                "h.json",
+                "--use-explainer-hints",
+            ]
+        )
+
+
 def test_gpt_embedding_resize_warning(monkeypatch, caplog):
     sys.modules.pop("rulegen", None)
     sys.modules.pop("rulegen.rl_agent", None)


### PR DESCRIPTION
## Summary
- enforce that hint-related options to `ppo-train` are mutually exclusive
- test that providing multiple hint options causes an argparse error

## Testing
- `pytest tests/test_ppo_train_cli.py::test_hint_option_conflict tests/test_ppo_train_cli.py::test_gpt_embedding_resize_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbf9a5df8832e818e4a64a6930bba