### PR TITLE
Add explainer hint generation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ python -m cli.rulegen_cli ppo-train \
        --policy gpt2 \
        --max-hint-tokens 64 \
        --checkpoint models/rulegen/gpt2_agent.pt
+
+python -m cli.rulegen_cli ppo-train \
+       --train-features features.json \
+       --dataset-dir data/splits \
+       --generate-hints-from-explainer \
+       --explainer-checkpoint models/explainers/selector.pt
 # When using GPT-based policies, ensure that `max_len + max_hint_tokens`
 # does not exceed 1024 so the prompt fits within the model context window.
 # 간단한 환경 생성 예시

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -65,6 +65,14 @@ python -m cli.rulegen_cli ppo-train \
     --checkpoint models/rulegen/gpt2_agent.pt
 ```
 
+```bash
+python -m cli.rulegen_cli ppo-train \
+    --train-features feats.json \
+    --dataset-dir data/splits \
+    --generate-hints-from-explainer \
+    --explainer-checkpoint models/explainers/selector.pt
+```
+
 ## Warm-start
 
 `PPORuleAgent`는 GNN 분류기가 예측한 규칙 시퀀스와 라벨을 이용해 사전 학습할 수 있습니다.

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -160,9 +160,12 @@ def _parse_reward_weights(text: str) -> dict:
 
 
 def generate_explainer_hints(
-    dataset_dir: Path, classifier_ckpt: str, device: str
+    dataset_dir: Path,
+    classifier_ckpt: str,
+    device: str,
+    explainer_ckpt: str | None = None,
 ) -> list[str]:
-    """Generate rule hints using gradients from a pretrained classifier."""
+    """Generate rule hints using gradients or a pretrained explainer."""
 
     _lazy_imports()
     from src.models.gnn.res_wrapper import RESGCLClassifier
@@ -173,30 +176,51 @@ def generate_explainer_hints(
     )
     classifier.to(device).eval()
 
+    explainer = None
+    if explainer_ckpt:
+        try:
+            explainer = torch.load(explainer_ckpt, map_location=device, weights_only=False)
+            if hasattr(explainer, "eval"):
+                explainer.eval()
+        except Exception as exc:  # pragma: no cover - simple I/O errors
+            raise RuntimeError(f"failed to load explainer: {exc}")
+
     miner = FeatureMiner()
     hints: list[str] = []
 
     for g in graphs:
         g = g.to(device)
-        for nt in g.node_types:
-            x = g[nt].get("x")
-            if x is not None and torch.is_floating_point(x):
-                g[nt].x = x.clone().detach().requires_grad_(True)
 
-        out = classifier(g, return_logits=True)
-        if isinstance(out, (list, tuple)):
-            out = out[0]
-        out = out.view(-1).sum()
-        classifier.zero_grad()
-        out.backward()
+        if explainer is None:
+            for nt in g.node_types:
+                x = g[nt].get("x")
+                if x is not None and torch.is_floating_point(x):
+                    g[nt].x = x.clone().detach().requires_grad_(True)
 
-        saliency: dict[str, torch.Tensor] = {}
-        for nt in g.node_types:
-            x = g[nt].get("x")
-            if x is not None and x.grad is not None:
-                saliency[nt] = x.grad.abs().sum(dim=1).detach().cpu()
+            out = classifier(g, return_logits=True)
+            if isinstance(out, (list, tuple)):
+                out = out[0]
+            out = out.view(-1).sum()
+            classifier.zero_grad()
+            out.backward()
+
+            saliency: dict[str, torch.Tensor] = {}
+            for nt in g.node_types:
+                x = g[nt].get("x")
+                if x is not None and x.grad is not None:
+                    saliency[nt] = x.grad.abs().sum(dim=1).detach().cpu()
+                else:
+                    saliency[nt] = torch.zeros(g[nt].num_nodes)
+        else:
+            clf_for_embed = getattr(explainer, "model", None) or getattr(explainer, "classifier", None) or classifier
+            from src.cli.explainer_train import _compute_node_embeddings
+
+            embeds = _compute_node_embeddings(g, clf_for_embed.encoder)
+            mask_prob = explainer(g, embeddings=embeds)
+            if hasattr(explainer, "get_node_saliency"):
+                saliency = explainer.get_node_saliency(g, mask_prob)
             else:
-                saliency[nt] = torch.zeros(g[nt].num_nodes)
+                saliency = mask_prob
 
         g_cpu = g.cpu()
         for nt in g_cpu.node_types:
@@ -530,9 +554,15 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     elif getattr(args, "hint_features", None):
         hint_feats = _read_json_lines(Path(args.hint_features))
     elif getattr(args, "generate_hints_from_explainer", False):
+        if not getattr(args, "explainer_checkpoint", None):
+            logger.error("--generate-hints-from-explainer requires --explainer-checkpoint")
+            raise SystemExit(1)
         try:
             hint_feats = generate_explainer_hints(
-                dataset_dir, args.classifier_checkpoint, args.classifier_device
+                dataset_dir,
+                args.classifier_checkpoint,
+                args.classifier_device,
+                args.explainer_checkpoint,
             )
         except Exception as exc:
             logger.error("Failed to generate explainer hints: %s", exc)
@@ -1006,8 +1036,12 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "학습 시작 전 classifier explainer로 각 악성 샘플의 saliency를 계산하여 "
-            "힌트를 자동 생성"
+            "힌트를 자동 생성 (--explainer-checkpoint와 함께 사용)"
         ),
+    )
+    pt.add_argument(
+        "--explainer-checkpoint",
+        help="Pretrained explainer checkpoint used with --generate-hints-from-explainer",
     )
     pt.add_argument("--config", help="Path to PPO YAML config (Hydra style)")
     pt.add_argument("--dataset-dir", required=True, help="Path to env dataset")

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -130,6 +130,7 @@ def test_hint_file_passed(tmp_path, monkeypatch):
     ds.mkdir()
     (ds / "clean.pt").write_text("x")
     (ds / "dummy.pt").write_text("x")
+    (ds / "sel.pt").write_text("x")
 
     train_fp = tmp_path / "train.json"
     train_fp.write_text("[]")
@@ -976,6 +977,8 @@ def test_generate_hints_from_explainer(tmp_path, monkeypatch):
             "--dataset-dir",
             str(ds),
             "--generate-hints-from-explainer",
+            "--explainer-checkpoint",
+            str(ds / "sel.pt"),
             "--epochs",
             "1",
             "--cpu",


### PR DESCRIPTION
## Summary
- add `--explainer-checkpoint` CLI argument
- extend `generate_explainer_hints` to load an explainer
- ensure PPO training checks for explainer checkpoint
- document explainer hint workflow
- update CLI tests for new parameter

## Testing
- `pytest tests/test_ppo_train_cli.py::test_generate_hints_from_explainer -q`
- `pytest tests/test_ppo_train_cli.py::test_gpt_embedding_resize_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd09afba0832ea6ad6405f1f6d733