### PR TITLE
Adjust RL reward defaults

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -7,14 +7,15 @@ run:
 env:
   mode: "yara"                   ## "capa" 로 변경 시 CAPA 룰 생성
   max_tokens: 512
-  fp_penalty_start: 0.1
+  fp_penalty_start: 0.01
   fp_penalty_end: 0.5
+  curriculum_steps: 20000
   off_target_penalty: 0.25
   reward_weights:
-    f1_clean: 0.4
-    f1_dummy: 0.5
-    rule_len: -0.05
-    certified_bonus: 0.05
+    f1_clean: 0.5
+    f1_dummy: 0.4
+    rule_len: -0.02
+    certified_bonus: 0.1
 
 model:
   ## 정책 네트워크 종류: "gru" (default), "attn" 또는 GPT 모델명(e.g. "gpt2-small")

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -119,9 +119,9 @@ class RuleGenEnv(gym.Env):
         use_lookahead: bool = False,
         single_target_mode: bool = False,
         reward_weights: dict | None = None,
-        fp_penalty_start: float = 0.0,
+        fp_penalty_start: float = 0.01,
         fp_penalty_end: float = 0.5,
-        curriculum_steps: int = 100000,
+        curriculum_steps: int = 20000,
         off_target_penalty: float = 0.25,
     ):
         """
@@ -240,10 +240,10 @@ class RuleGenEnv(gym.Env):
         self.normalize_reward = normalize_reward
 
         default_weights = {
-            "f1_clean": 0.4,
-            "f1_dummy": 0.5,
-            "rule_len": -0.05,
-            "certified_bonus": 0.05,
+            "f1_clean": 0.5,
+            "f1_dummy": 0.4,
+            "rule_len": -0.02,
+            "certified_bonus": 0.1,
         }
         self.reward_weights = default_weights | (reward_weights or {})
 


### PR DESCRIPTION
## Summary
- tweak the RL environment defaults
- lower the false positive start penalty and curriculum steps
- update PPO config with new weights and curriculum setting

## Testing
- `pytest -k rl_env -q` *(fails: ModuleNotFoundError: No module named 'angr')*

------
https://chatgpt.com/codex/tasks/task_e_687fed641820832e8e1fddc2920d602b