### PR TITLE
Update entropy final value

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -266,7 +266,7 @@ class PPORuleAgent:
         total_updates: int | None = None,
         vf_coef: float = 0.5,
         entropy_coef: float = 0.05,
-        entropy_coef_final: float = 0.0,
+        entropy_coef_final: float = 0.01,
         max_grad_norm: float = 0.5,
         n_steps: int = 1024,
         n_epochs: int = 4,


### PR DESCRIPTION
## Summary
- adjust default `entropy_coef_final` in `PPORuleAgent`

## Testing
- `pytest -k 'ppo_train_cli' -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687fefb51af8832e986eefaf679c9bec