### PR TITLE
Add two-phase PPO reward schedule

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -46,3 +46,23 @@ scheduler:
 
 checkpoint:
   save_every_updates: 10_000
+
+# Optional two-phase curriculum schedule
+curriculum:
+  switch_step: 50000            # global step at which to switch to phase 2
+  phase1:
+    reward_weights:
+      f1_clean: 0.5
+      f1_dummy: 0.4
+      rule_len: -0.02
+      certified_bonus: 0.1
+    fp_penalty_start: 0.01
+    fp_penalty_end: 0.5
+  phase2:
+    reward_weights:
+      f1_clean: 0.6
+      f1_dummy: 0.3
+      rule_len: -0.02
+      certified_bonus: 0.1
+    fp_penalty_start: 0.05
+    fp_penalty_end: 0.25

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -609,14 +609,35 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # ------------------------------------------------------------------
     # 3) Environment & agent instantiation
     # ------------------------------------------------------------------
+    env_cfg = cfg.get("env", {})
+    curriculum_cfg = cfg.get("curriculum", {})
+
+    phase_sched = None
+    if curriculum_cfg:
+        phase_sched = OmegaConf.to_container(curriculum_cfg, resolve=True)
+        phase1 = phase_sched.get("phase1", {})
+        rw = phase1.get("reward_weights", env_cfg.get("reward_weights"))
+        fps = phase1.get("fp_penalty_start", env_cfg.get("fp_penalty_start", 0.01))
+        fpe = phase1.get("fp_penalty_end", env_cfg.get("fp_penalty_end", 0.5))
+    else:
+        rw = args.reward_weights or env_cfg.get("reward_weights")
+        fps = env_cfg.get("fp_penalty_start", 0.01)
+        fpe = env_cfg.get("fp_penalty_end", 0.5)
+
     env = rulegen.make_env(
+        rule_type=env_cfg.get("mode", "yara"),
+        max_len=int(env_cfg.get("max_tokens", 512)),
         dataset_dir=dataset_dir,
         device=device,
         hint_features=hint_tokens,
         classifier_ckpt=args.classifier_checkpoint,
         classifier_device=args.classifier_device,
         seed=args.seed,
-        reward_weights=args.reward_weights,
+        reward_weights=rw,
+        fp_penalty_start=fps,
+        fp_penalty_end=fpe,
+        curriculum_steps=int(env_cfg.get("curriculum_steps", 20000)),
+        off_target_penalty=float(env_cfg.get("off_target_penalty", 0.25)),
         use_lookahead=getattr(args, "use_lookahead", False),
         single_target_mode=getattr(args, "single_target_mode", False),
         meta_path=getattr(args, "meta_path", None),
@@ -728,6 +749,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
                 total_timesteps=seg,
                 log_interval=log_interval,
                 save_path=args.checkpoint,
+                phase_schedule=phase_sched,
             )
         )
         metrics = _evaluate_agent(

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -500,6 +500,7 @@ class PPORuleAgent:
         *,
         pretrain_dataset: Sequence[Tuple[Sequence[int], int]] | None = None,
         pretrain_epochs: int = 1,
+        phase_schedule: dict | None = None,
     ) -> List[Tuple[int, float]]:
         """Run the main PPO loop.
 
@@ -515,6 +516,26 @@ class PPORuleAgent:
         interval_returns: List[float] = []
         avg_history: List[Tuple[int, float]] = []
         ep_return = 0.0
+
+        switch_step = None
+        phase2 = {}
+        if phase_schedule:
+            switch_step = int(phase_schedule.get("switch_step", total_timesteps))
+            phase1 = phase_schedule.get("phase1", {})
+            phase2 = phase_schedule.get("phase2", {})
+            if "reward_weights" in phase1:
+                self.env.reward_weights = dict(phase1["reward_weights"])
+            if "fp_penalty_start" in phase1:
+                self.env.fp_penalty_start = float(phase1["fp_penalty_start"])
+            if "fp_penalty_end" in phase1:
+                self.env.fp_penalty_end = float(phase1["fp_penalty_end"])
+            _LOG.info(
+                "Phase 1: weights=%s fp_penalty=[%.3f, %.3f]",
+                self.env.reward_weights,
+                self.env.fp_penalty_start,
+                self.env.fp_penalty_end,
+            )
+        switched = False
 
         if pretrain_dataset is not None and pretrain_epochs > 0:
             _LOG.info(
@@ -548,6 +569,21 @@ class PPORuleAgent:
             ep_return += reward
             obs = next_obs
             global_step += 1
+            if switch_step is not None and not switched and global_step >= switch_step:
+                if "reward_weights" in phase2:
+                    self.env.reward_weights = dict(phase2["reward_weights"])
+                if "fp_penalty_start" in phase2:
+                    self.env.fp_penalty_start = float(phase2["fp_penalty_start"])
+                if "fp_penalty_end" in phase2:
+                    self.env.fp_penalty_end = float(phase2["fp_penalty_end"])
+                switched = True
+                _LOG.info(
+                    "Switched to phase 2 at step %d: weights=%s fp_penalty=[%.3f, %.3f]",
+                    global_step,
+                    self.env.reward_weights,
+                    self.env.fp_penalty_start,
+                    self.env.fp_penalty_end,
+                )
             if hasattr(pbar, "update"):
                 pbar.update(1)
 


### PR DESCRIPTION
## Summary
- update PPO config with optional two-phase curriculum
- read new schedule in CLI and pass to agent
- update PPORuleAgent to switch reward weights and FP penalties at configured step

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for psutil and torch)*

------
https://chatgpt.com/codex/tasks/task_e_687ff15622c0832e9605bfaf375eb260