### PR TITLE
Expose RL penalty CLI option

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -637,7 +637,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         fp_penalty_start=fps,
         fp_penalty_end=fpe,
         curriculum_steps=int(env_cfg.get("curriculum_steps", 20000)),
-        off_target_penalty=float(env_cfg.get("off_target_penalty", 0.25)),
+        off_target_penalty=float(
+            args.off_target_penalty
+            if args.off_target_penalty is not None
+            else env_cfg.get("off_target_penalty", 0.25)
+        ),
         use_lookahead=getattr(args, "use_lookahead", False),
         single_target_mode=getattr(args, "single_target_mode", False),
         meta_path=getattr(args, "meta_path", None),
@@ -856,6 +860,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
                 seed=args.seed,
                 reward_weights=args.reward_weights,
                 single_target_mode=True,
+                off_target_penalty=args.off_target_penalty,
             )
             agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
             agent.load(args.agent_checkpoint)
@@ -873,6 +878,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
             seed=args.seed,
             reward_weights=args.reward_weights,
             single_target_mode=getattr(args, "single_target_mode", False),
+            off_target_penalty=args.off_target_penalty,
         )
         agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
         agent.load(args.agent_checkpoint)
@@ -1146,6 +1152,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Use a single random dummy graph as target each episode",
     )
+    pt.add_argument(
+        "--off-target-penalty",
+        type=float,
+        help="Penalty per off-target match in single-target mode",
+    )
     pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")
     pt.add_argument("--minibatch-size", type=int, default=64)
     pt.add_argument("--ppo-epochs", type=int, default=4)
@@ -1199,6 +1210,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--single-target-mode",
         action="store_true",
         help="Use a single random dummy graph as target each episode",
+    )
+    gen.add_argument(
+        "--off-target-penalty",
+        type=float,
+        help="Penalty per off-target match in single-target mode",
     )
     gen.add_argument(
         "--target-graph",

--- a/src/graphs/dataset/__init__.py
+++ b/src/graphs/dataset/__init__.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 
 from typing import List
 
-from .graph_dataset import GraphDataset, collect_dataset_metadata
+try:  # optional heavy dependency on torch
+    from .graph_dataset import GraphDataset, collect_dataset_metadata
+except Exception:  # pragma: no cover - optional
+    GraphDataset = None  # type: ignore
+    def collect_dataset_metadata(*args, **kwargs):  # type: ignore
+        raise ImportError("GraphDataset requires torch and related packages")
 from .split_generator import split_by_time, split_random
 
 __all__: List[str] = [

--- a/src/graphs/utils.py
+++ b/src/graphs/utils.py
@@ -24,8 +24,14 @@ from time import perf_counter
 from typing import Iterator, Optional, Sequence
 
 import numpy as np
-import torch
-from torch_geometric.data import Data, HeteroData
+try:  # optional torch dependency
+    import torch
+except Exception:  # pragma: no cover - optional heavy dep
+    torch = None  # type: ignore
+try:  # optional dependency
+    from torch_geometric.data import Data, HeteroData
+except Exception:  # pragma: no cover - optional heavy dep
+    Data = HeteroData = object  # type: ignore
 
 # --------------------------------------------------------------------------- #
 # 1. 시드 고정
@@ -42,8 +48,10 @@ def set_random_seed(seed: int = 42, *, deterministic: bool = False) -> None:
     random.seed(seed)
     os.environ["PYTHONHASHSEED"] = str(seed)
     np.random.seed(seed)
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+        if hasattr(torch.cuda, "manual_seed_all"):
+            torch.cuda.manual_seed_all(seed)
 
     # PyG helper (≥2.3)
     try:
@@ -53,7 +61,7 @@ def set_random_seed(seed: int = 42, *, deterministic: bool = False) -> None:
     except Exception:  # pragma: no cover
         pass
 
-    if deterministic:
+    if deterministic and torch is not None:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
 

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -883,6 +883,21 @@ class RuleGenEnv(gym.Env):
         w = self.reward_weights
         return float(w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy)
 
+    def _compute_off_target_penalty(
+        self, rule_text: str, dummy_set: Sequence[HeteroData]
+    ) -> Tuple[float, float]:
+        """Compute penalty and match count for off-target graphs."""
+        if not self.single_target_mode or len(self.full_dummy_set) <= len(dummy_set):
+            return 0.0, 0.0
+        off_targets = [g for g in self.full_dummy_set if g not in dummy_set]
+        if not off_targets:
+            return 0.0, 0.0
+        _, f1_ot, _ = self.evaluator.evaluate_rule(rule_text, [], off_targets)
+        m_off = len(off_targets)
+        matches = float(f1_ot * m_off / (2 - f1_ot)) if f1_ot > 0 else 0.0
+        penalty = self.off_target_penalty * matches
+        return penalty, matches
+
     # reward
     @torch.inference_mode()
     def _compute_reward(
@@ -945,17 +960,10 @@ class RuleGenEnv(gym.Env):
         reward += bonus
 
         # penalize off-target matches in single-target mode
-        off_target_pen = 0.0
-        off_matches = 0.0
-        if self.single_target_mode and len(self.full_dummy_set) > len(dummy_set):
-            off_targets = [g for g in self.full_dummy_set if g not in dummy_set]
-            if off_targets:
-                _, f1_ot, _ = self.evaluator.evaluate_rule(rule_text, [], off_targets)
-                m_off = len(off_targets)
-                if f1_ot > 0:
-                    off_matches = float(f1_ot * m_off / (2 - f1_ot))
-                off_target_pen = self.off_target_penalty * off_matches
-                reward -= off_target_pen
+        off_target_pen, off_matches = self._compute_off_target_penalty(
+            rule_text, dummy_set
+        )
+        reward -= off_target_pen
 
         metrics = dict(
             f1_clean=f1_clean,


### PR DESCRIPTION
## Summary
- add `--off-target-penalty` argument to rulegen CLI
- make generate/ppo-train pass user penalty value
- factor out off-target penalty computation in RL environment
- allow dataset utils to load without heavy deps

## Testing
- `pytest tests/test_logger_memory.py tests/test_split_generator.py tests/test_ppo_train_cli.py::test_gpt_embedding_resize_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff386956c832e9cefeb2d27a1c3d2