### PR TITLE
Add dynamic reward weight adjustment

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -16,6 +16,11 @@ env:
     f1_dummy: 0.4
     rule_len: -0.02
     certified_bonus: 0.1
+  # dynamic weight adjustment during training
+  weight_adjust:
+    interval: 5000        # steps between updates
+    delta_f1_dummy: 0.1   # increment for f1_dummy weight
+    delta_f1_clean: -0.1  # decrement for f1_clean weight
 
 model:
   ## 정책 네트워크 종류: "gru" (default), "attn" 또는 GPT 모델명(e.g. "gpt2-small")

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -46,6 +46,25 @@ python -m cli.rulegen_cli ppo-train \
     --reward-weights '{"f1_clean":0.7,"f1_dummy":0.2,"rule_len":-0.05}'
 ```
 
+### 가중치 동적 조정
+
+`configs/rulegen/ppo.yaml` 의 `env.weight_adjust` 섹션을 이용하면 학습 중
+보상 가중치를 주기적으로 갱신할 수 있습니다.
+
+```yaml
+env:
+  reward_weights:
+    f1_clean: 0.5
+    f1_dummy: 0.4
+  weight_adjust:
+    interval: 5000        # 5000 스텝마다
+    delta_f1_dummy: 0.1   # f1_dummy 가중치 +0.1
+    delta_f1_clean: -0.1  # f1_clean 가중치 -0.1
+```
+
+학습 루프에서 지정한 주기마다 `env.update_reward_weights()`가 호출되어
+가중치가 갱신됩니다.
+
 PPO 하이퍼파라미터는 다음 옵션으로 조정할 수 있습니다.
 
 ```bash

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -611,6 +611,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     # ------------------------------------------------------------------
     env_cfg = cfg.get("env", {})
     curriculum_cfg = cfg.get("curriculum", {})
+    adjust_cfg = env_cfg.get("weight_adjust", {})
 
     phase_sched = None
     if curriculum_cfg:
@@ -648,6 +649,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         tokenizer=policy_net,
         max_hint_tokens=getattr(args, "max_hint_tokens", None),
     )
+
+    adjust_interval = int(adjust_cfg.get("interval", 0))
+    delta_dummy = float(adjust_cfg.get("delta_f1_dummy", 0.0))
+    delta_clean = float(adjust_cfg.get("delta_f1_clean", 0.0))
+    next_adjust = adjust_interval if adjust_interval > 0 else None
     sched_cfg = cfg.get("scheduler", {})
     sched_name = sched_cfg.get("name")
     total_steps = int(sched_cfg.get("total_updates", args.epochs))
@@ -756,6 +762,18 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
                 phase_schedule=phase_sched,
             )
         )
+        if next_adjust is not None:
+            while env.total_steps >= next_adjust:
+                env.update_reward_weights(
+                    f1_dummy=env.reward_weights.get("f1_dummy", 0.0) + delta_dummy,
+                    f1_clean=env.reward_weights.get("f1_clean", 0.0) + delta_clean,
+                )
+                logger.info(
+                    "Adjusted reward weights to %s at step %d",
+                    env.reward_weights,
+                    next_adjust,
+                )
+                next_adjust += adjust_interval
         metrics = _evaluate_agent(
             agent,
             env,

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -394,6 +394,23 @@ class RuleGenEnv(gym.Env):
         # 내부 상태
         self.reset()
 
+    def update_reward_weights(self, weights: dict | None = None, **kwargs) -> None:
+        """Update :attr:`reward_weights` in-place.
+
+        Parameters
+        ----------
+        weights : optional mapping of reward component names to new values.
+        **kwargs : additional key-value pairs overriding the weights.
+        """
+
+        if weights:
+            for k, v in weights.items():
+                if k in self.reward_weights:
+                    self.reward_weights[k] = float(v)
+        for k, v in kwargs.items():
+            if k in self.reward_weights:
+                self.reward_weights[k] = float(v)
+
     # ─────────────────────────────────────────────────── gym API —
     def reset(
         self,

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -564,3 +564,28 @@ def test_reset_constant_observation_length(tmp_path, monkeypatch):
         assert len(obs) == env.observation_space.shape[0]
         assert len(info["hint"]) == env.max_hint_tokens
     assert len(lens) == 1
+
+
+def test_update_reward_weights_method(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+    )
+
+    old = dict(env.reward_weights)
+    env.update_reward_weights(f1_dummy=old["f1_dummy"] + 0.1, f1_clean=old["f1_clean"] - 0.1)
+
+    assert env.reward_weights["f1_dummy"] == pytest.approx(old["f1_dummy"] + 0.1)
+    assert env.reward_weights["f1_clean"] == pytest.approx(old["f1_clean"] - 0.1)


### PR DESCRIPTION
## Summary
- allow dynamically updating reward weights in RuleGenEnv
- periodically adjust reward weights during PPO training
- provide new weight_adjust section in example config
- document dynamic weight adjustment usage
- test update_reward_weights helper

## Testing
- `pytest -k 'update_reward_weights_method or reward_weights_override' -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_687ff6a4d784832e8ba819210a7ddc51