### PR TITLE
Add f1_dummy logging in PPO agent

### DIFF
--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -415,6 +415,7 @@ class PPORuleAgent:
         if self.use_hint:
             self.hint_buf: List[np.ndarray] = []
         self.f1_buf: List[float] = []
+        self.f1_dummy_buf: List[float] = []
 
     def pretrain(
         self,
@@ -557,6 +558,7 @@ class PPORuleAgent:
             self.done_buf.append(done or trunc)
             metrics = info.get("metrics", {}) if isinstance(info, dict) else {}
             self.f1_buf.append(float(metrics.get("f1_clean", 0.0)))
+            self.f1_dummy_buf.append(float(metrics.get("f1_dummy", 0.0)))
             if self.use_hint:
                 if hint is not None:
                     self.hint_buf.append(hint)
@@ -616,16 +618,19 @@ class PPORuleAgent:
 
             if global_step % self.n_steps == 0:
                 # ── PPO Update
+                avg_f1_dummy = float(np.mean(self.f1_dummy_buf)) if self.f1_dummy_buf else 0.0
                 self._update()
 
                 if global_step % log_interval == 0:
                     avg_ret = float(np.mean(interval_returns)) if interval_returns else 0.0
                     avg_history.append((global_step, avg_ret))
                     _LOG.info(
-                        "[PPO] step:%d | avg_ep_return: %.4f | buffer:%d",
+                        "[PPO] step:%d | avg_ep_return: %.4f | buffer:%d | f1_dummy: %.4f | weights:%s",
                         global_step,
                         avg_ret,
                         len(self.obs_buf),
+                        avg_f1_dummy,
+                        self.env.reward_weights,
                     )
                     interval_returns.clear()
                     if save_path:

--- a/tests/test_train_loop.py
+++ b/tests/test_train_loop.py
@@ -7,6 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 pytest.importorskip("matplotlib")
+pytest.importorskip("gymnasium")
 
 import torch
 from torch.utils.data import DataLoader
@@ -65,3 +66,55 @@ def test_train_dict_batches():
     opt = torch.optim.SGD(model.parameters(), lr=0.1)
     loss = train_one_epoch(model, loader, opt, torch.device("cpu"))
     assert isinstance(loss, float)
+
+
+def test_ppo_train_logging(caplog):
+    import numpy as np
+    import gymnasium as gym
+    from src.rulegen.rl_agent import PPORuleAgent, _LOG as RL_LOG
+
+    class TinyEnv(gym.Env):
+        PAD = "<PAD>"
+        END = "<END>"
+
+        def __init__(self):
+            self.action_space = gym.spaces.Discrete(3)
+            self.observation_space = gym.spaces.Box(low=0, high=2, shape=(4,), dtype=np.int64)
+            self.token2id = {"A": 0, self.PAD: 1, self.END: 2}
+            self.id2token = {v: k for k, v in self.token2id.items()}
+            self.reward_weights = {
+                "f1_clean": 0.5,
+                "f1_dummy": 0.5,
+                "rule_len": 0.0,
+                "certified_bonus": 0.0,
+            }
+            self.max_len = 4
+
+        def reset(self, *, seed=None, options=None):
+            self._tokens = []
+            obs = np.full(self.max_len, self.token2id[self.PAD], dtype=np.int64)
+            return obs, {}
+
+        def step(self, action):
+            self._tokens.append(action)
+            obs = np.full(self.max_len, self.token2id[self.PAD], dtype=np.int64)
+            done = len(self._tokens) >= 1
+            info = {"metrics": {"f1_clean": 0.0, "f1_dummy": 0.1}}
+            return obs, 0.0, done, False, info
+
+        def get_action_mask(self, tokens=None, hint_tokens=None):
+            return np.ones(self.action_space.n, dtype=np.int8)
+
+    env = TinyEnv()
+    agent = PPORuleAgent(
+        env,
+        n_steps=1,
+        minibatch_size=1,
+        batch_size=1,
+        n_epochs=1,
+        device="cpu",
+    )
+    caplog.set_level("INFO", logger=RL_LOG.name)
+    agent.train(total_timesteps=1, log_interval=1)
+    messages = [rec.message for rec in caplog.records if rec.name == RL_LOG.name]
+    assert any("f1_dummy" in m and "weights" in m for m in messages)


### PR DESCRIPTION
## Summary
- log `f1_dummy` mean and reward weights in `PPORuleAgent.train`
- track `f1_dummy` values during rollouts
- cover new logging with a unit test

## Testing
- `pytest -k train_loop -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff9237500832eb8b4f7a040b413f9