### PR TITLE
Adjust rule evaluator return values

### DIFF
--- a/src/evaluation/rule_evaluator.py
+++ b/src/evaluation/rule_evaluator.py
@@ -30,7 +30,7 @@ class RuleEvaluator:
         rule_text: str,
         clean_set: Sequence[HeteroData],
         dummy_set: Sequence[HeteroData],
-    ) -> Tuple[float, float, float]:
+    ) -> Tuple[float, float, float, Tuple[int, int, int, int]]:
         """Evaluate ``rule_text`` on provided datasets.
 
         Parameters
@@ -41,6 +41,11 @@ class RuleEvaluator:
             Clean (negative) samples.
         dummy_set : sequence of :class:`HeteroData`
             Dummy/malicious (positive) samples.
+
+        Returns
+        -------
+        tuple
+            ``(f1_clean, f1_dummy, certified_r, (TP, FP, FN, TN))``
         """
 
         log = logging.getLogger(__name__)
@@ -85,7 +90,7 @@ class RuleEvaluator:
 
         except Exception as exc:
             log.warning("Rule compilation failed: %s", exc)
-            return 0.0, 0.0, -1.0
+            return 0.0, 0.0, -1.0, (0, 0, 0, 0)
 
         TP = FP = FN = TN = 0
 
@@ -132,7 +137,8 @@ class RuleEvaluator:
                     log.warning("certified radius computation failed: %s", exc)
                     certified_r = 0.0
 
-            return f1_clean, f1_dummy, certified_r
+            counts = (TP, FP, FN, TN)
+            return f1_clean, f1_dummy, certified_r, counts
         except Exception as exc:  # pragma: no cover - unexpected evaluation errors
             log.warning("rule evaluation failed: %s", exc)
-            return 0.0, 0.0, -1.0
+            return 0.0, 0.0, -1.0, (0, 0, 0, 0)

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -909,7 +909,7 @@ class RuleGenEnv(gym.Env):
         off_targets = [g for g in self.full_dummy_set if g not in dummy_set]
         if not off_targets:
             return 0.0, 0.0
-        _, f1_ot, _ = self.evaluator.evaluate_rule(rule_text, [], off_targets)
+        _, f1_ot, _, _ = self.evaluator.evaluate_rule(rule_text, [], off_targets)
         m_off = len(off_targets)
         matches = float(f1_ot * m_off / (2 - f1_ot)) if f1_ot > 0 else 0.0
         penalty = self.off_target_penalty * matches
@@ -926,7 +926,7 @@ class RuleGenEnv(gym.Env):
             clean_set = self._perturb_set(self.clean_set, 0, 0.2, 0.05)
             dummy_set = self._perturb_set(self.dummy_set, 1, 0.2, 0.05)
 
-        f1_clean, f1_dummy, certified_r = self.evaluator.evaluate_rule(
+        f1_clean, f1_dummy, certified_r, counts = self.evaluator.evaluate_rule(
             rule_text,
             clean_set,
             dummy_set,
@@ -943,18 +943,9 @@ class RuleGenEnv(gym.Env):
             + (self.fp_penalty_end - self.fp_penalty_start) * progress
         )
 
-        m = len(dummy_set)
+        _, FP, _, _ = counts
         n = len(clean_set)
-        denom = (2 - f1_dummy) - f1_clean
-        if denom == 0:
-            fp_count = 0.0
-        else:
-            fp_count = (
-                (2 - f1_dummy) * n
-                - f1_clean * (m * (1 - f1_dummy) + n * (2 - f1_dummy))
-            ) / denom
-            fp_count = max(fp_count, 0.0)
-        fp_rate = 0.0 if n == 0 else fp_count / n
+        fp_rate = 0.0 if n == 0 else FP / n
 
         w = self.reward_weights
         weighted_f1 = w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -222,7 +222,9 @@ def test_compute_reward_penalizes_invalid_rule(tmp_path, monkeypatch):
     )
 
     monkeypatch.setattr(
-        env.evaluator, "evaluate_rule", lambda *args, **kwargs: (0.0, 0.0, -1.0)
+        env.evaluator,
+        "evaluate_rule",
+        lambda *args, **kwargs: (0.0, 0.0, -1.0, (0, 0, 0, 0)),
     )
     reward, metrics, _ = env._compute_reward("", update_stats=False)
     assert metrics["invalid_rule"]
@@ -310,7 +312,9 @@ def test_reward_weights_override(tmp_path, monkeypatch):
             "certified_bonus": 0.0,
         },
     )
-    monkeypatch.setattr(env.evaluator, "evaluate_rule", lambda *a, **k: (0.5, 0.2, 3.0))
+    monkeypatch.setattr(
+        env.evaluator, "evaluate_rule", lambda *a, **k: (0.5, 0.2, 3.0, (0, 0, 0, 0))
+    )
     r, m, _ = env._compute_reward("", update_stats=False)
     assert pytest.approx(r) == 0.5
 
@@ -335,7 +339,9 @@ def test_fp_penalty_curriculum(tmp_path, monkeypatch):
         fp_penalty_end=0.0,
         curriculum_steps=10,
     )
-    monkeypatch.setattr(env.evaluator, "evaluate_rule", lambda *a, **k: (0.5, 0.5, 0.0))
+    monkeypatch.setattr(
+        env.evaluator, "evaluate_rule", lambda *a, **k: (0.5, 0.5, 0.0, (0, 1, 0, 0))
+    )
     env.total_steps = 0
     r1, m1, _ = env._compute_reward("", update_stats=False)
     env.total_steps = 10
@@ -503,20 +509,20 @@ def test_off_target_penalty(tmp_path, monkeypatch):
 
     def eval_rule(rule, clean_set, dummy_set):
         if clean_set:
-            return 1.0, 1.0, 3.0
+            return 1.0, 1.0, 3.0, (0, 0, 0, 0)
         else:
             m = len(dummy_set)
             f1 = 2.0 / (m + 1)
-            return 0.0, f1, 3.0
+            return 0.0, f1, 3.0, (0, 0, 0, 0)
 
     monkeypatch.setattr(env.evaluator, "evaluate_rule", eval_rule)
     r1, m1, _ = env._compute_reward("A", update_stats=False)
 
     def eval_rule_no_off(rule, clean_set, dummy_set):
         if clean_set:
-            return 1.0, 1.0, 3.0
+            return 1.0, 1.0, 3.0, (0, 0, 0, 0)
         else:
-            return 0.0, 0.0, 3.0
+            return 0.0, 0.0, 3.0, (0, 0, 0, 0)
 
     monkeypatch.setattr(env.evaluator, "evaluate_rule", eval_rule_no_off)
     r2, m2, _ = env._compute_reward("A", update_stats=False)

--- a/tests/test_rule_evaluator.py
+++ b/tests/test_rule_evaluator.py
@@ -17,8 +17,9 @@ def test_evaluate_rule_failure_returns_negative(tmp_path):
     evaluator = RuleEvaluator(clf=DummyClf())
     clean = [HeteroData()]
     dummy = [HeteroData()]
-    f1_clean, f1_dummy, certified_r = evaluator.evaluate_rule(
+    f1_clean, f1_dummy, certified_r, counts = evaluator.evaluate_rule(
         "rule foo { condition: true }", clean, dummy
     )
     assert (f1_clean, f1_dummy) == (0.0, 0.0)
     assert certified_r < 0
+    assert counts == (0, 0, 0, 0)


### PR DESCRIPTION
## Summary
- return confusion counts from `evaluate_rule`
- compute false positive rate directly in `RuleGenEnv`
- update RL environment tests and evaluator tests for new tuple

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_687ffae7e638832e80c81f3a80cab46e