### PR TITLE
Add rule length penalty schedule

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -620,10 +620,39 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         rw = phase1.get("reward_weights", env_cfg.get("reward_weights"))
         fps = phase1.get("fp_penalty_start", env_cfg.get("fp_penalty_start", 0.01))
         fpe = phase1.get("fp_penalty_end", env_cfg.get("fp_penalty_end", 0.5))
+        rlps = phase1.get(
+            "rule_len_penalty_start",
+            env_cfg.get("rule_len_penalty_start")
+        )
+        rlpe = phase1.get(
+            "rule_len_penalty_end",
+            env_cfg.get("rule_len_penalty_end")
+        )
+        rlstep = int(
+            phase1.get(
+                "rule_len_steps",
+                env_cfg.get("rule_len_steps", env_cfg.get("curriculum_steps", 20000)),
+            )
+        )
     else:
         rw = args.reward_weights or env_cfg.get("reward_weights")
         fps = env_cfg.get("fp_penalty_start", 0.01)
         fpe = env_cfg.get("fp_penalty_end", 0.5)
+        rlps = (
+            args.rule_len_penalty_start
+            if args.rule_len_penalty_start is not None
+            else env_cfg.get("rule_len_penalty_start")
+        )
+        rlpe = (
+            args.rule_len_penalty_end
+            if args.rule_len_penalty_end is not None
+            else env_cfg.get("rule_len_penalty_end")
+        )
+        rlstep = int(
+            args.rule_len_steps
+            if args.rule_len_steps is not None
+            else env_cfg.get("rule_len_steps", env_cfg.get("curriculum_steps", 20000))
+        )
 
     env = rulegen.make_env(
         rule_type=env_cfg.get("mode", "yara"),
@@ -638,6 +667,9 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         fp_penalty_start=fps,
         fp_penalty_end=fpe,
         curriculum_steps=int(env_cfg.get("curriculum_steps", 20000)),
+        rule_len_penalty_start=rlps,
+        rule_len_penalty_end=rlpe,
+        rule_len_steps=rlstep,
         off_target_penalty=float(
             args.off_target_penalty
             if args.off_target_penalty is not None
@@ -1174,6 +1206,21 @@ def _build_parser() -> argparse.ArgumentParser:
         "--off-target-penalty",
         type=float,
         help="Penalty per off-target match in single-target mode",
+    )
+    pt.add_argument(
+        "--rule-len-penalty-start",
+        type=float,
+        help="Initial weight for rule length penalty",
+    )
+    pt.add_argument(
+        "--rule-len-penalty-end",
+        type=float,
+        help="Final weight for rule length penalty",
+    )
+    pt.add_argument(
+        "--rule-len-steps",
+        type=int,
+        help="Steps over which to anneal the rule length penalty",
     )
     pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")
     pt.add_argument("--minibatch-size", type=int, default=64)

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -123,6 +123,9 @@ class RuleGenEnv(gym.Env):
         fp_penalty_end: float = 0.5,
         curriculum_steps: int = 20000,
         off_target_penalty: float = 0.25,
+        rule_len_penalty_start: float | None = None,
+        rule_len_penalty_end: float | None = None,
+        rule_len_steps: int | None = None,
     ):
         """
         Parameters
@@ -157,6 +160,9 @@ class RuleGenEnv(gym.Env):
         fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
         curriculum_steps : 패널티 스케줄 총 스텝 수
         off_target_penalty : single_target_mode 시 비표적 매치 1건당 패널티
+        rule_len_penalty_start : rule_len 패널티 초기 가중치 (기본 reward_weights['rule_len'])
+        rule_len_penalty_end   : rule_len_steps 소모 후 적용할 가중치
+        rule_len_steps : rule_len 패널티 스케줄 총 스텝 수
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -265,6 +271,14 @@ class RuleGenEnv(gym.Env):
         self.curriculum_steps = max(1, int(curriculum_steps))
         self.off_target_penalty = float(off_target_penalty)
         self.total_steps = 0
+
+        self.rule_len_penalty_start = (
+            float(self.reward_weights["rule_len"]) if rule_len_penalty_start is None else float(rule_len_penalty_start)
+        )
+        self.rule_len_penalty_end = (
+            float(self.reward_weights["rule_len"]) if rule_len_penalty_end is None else float(rule_len_penalty_end)
+        )
+        self.rule_len_steps = max(1, int(rule_len_steps if rule_len_steps is not None else self.curriculum_steps))
 
         # Hint features / tokens
         self.hint_features = hint_features or []
@@ -949,7 +963,13 @@ class RuleGenEnv(gym.Env):
 
         w = self.reward_weights
         weighted_f1 = w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy
-        reward = weighted_f1 + w["rule_len"] * rule_len
+
+        progress_len = min(self.total_steps, self.rule_len_steps) / self.rule_len_steps
+        curr_rule_len_w = self.rule_len_penalty_start + (
+            self.rule_len_penalty_end - self.rule_len_penalty_start
+        ) * progress_len
+
+        reward = weighted_f1 + curr_rule_len_w * rule_len
         if certified_r >= 2:
             reward += w["certified_bonus"]
 
@@ -977,6 +997,7 @@ class RuleGenEnv(gym.Env):
             f1_clean=f1_clean,
             f1_dummy=f1_dummy,
             rule_len=rule_len,
+            rule_len_weight=curr_rule_len_w,
             certified_r=certified_r,
             invalid_rule=invalid_rule,
             fp_rate=fp_rate,

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -899,6 +899,103 @@ def test_max_hint_tokens_cli(tmp_path, monkeypatch):
     assert captured["max_hint_tokens"] == 7
 
 
+def test_rule_len_penalty_cli(tmp_path, monkeypatch):
+    torch_stub = types.SimpleNamespace(
+        device=lambda *a, **k: None,
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot_stub)
+    om_conf = types.ModuleType("omegaconf")
+    om_conf.OmegaConf = types.SimpleNamespace(load=lambda *_: {}, create=lambda *_: {})
+    monkeypatch.setitem(sys.modules, "omegaconf", om_conf)
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda x, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_stub)
+
+    captured = {}
+    rulegen_stub = types.ModuleType("rulegen")
+
+    def fake_make_env(**kw):
+        captured.update(kw)
+        return "env"
+
+    class DummyAgent:
+        def __init__(self, env):
+            captured["agent_env"] = env
+
+        def train(self, **kw):
+            return []
+
+    def fake_load_agent(**kw):
+        return DummyAgent(kw.get("env"))
+
+    rulegen_stub.make_env = fake_make_env
+    rulegen_stub.load_agent = fake_load_agent
+    monkeypatch.setitem(sys.modules, "rulegen", rulegen_stub)
+    fm_mod = types.ModuleType("rulegen.feature_miner")
+    fm_mod.FeatureMiner = object
+    monkeypatch.setitem(sys.modules, "rulegen.feature_miner", fm_mod)
+    ra_mod = types.ModuleType("rulegen.rl_agent")
+    ra_mod.PPORuleAgent = object
+    monkeypatch.setitem(sys.modules, "rulegen.rl_agent", ra_mod)
+    class _DummyBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def build(self, *a, **k):
+            return ""
+
+    y_mod = types.ModuleType("rulegen.yara_builder")
+    y_mod.YaraBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.yara_builder", y_mod)
+    c_mod = types.ModuleType("rulegen.capa_builder")
+    c_mod.CapaBuilder = _DummyBuilder
+    monkeypatch.setitem(sys.modules, "rulegen.capa_builder", c_mod)
+    gd_mod = types.ModuleType("graphs.dataset.graph_dataset")
+    gd_mod.GraphDataset = object
+    monkeypatch.setitem(sys.modules, "graphs.dataset.graph_dataset", gd_mod)
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "clean.pt").write_text("x")
+    (ds / "dummy.pt").write_text("x")
+
+    train_fp = tmp_path / "train.json"
+    train_fp.write_text("[]")
+
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            str(train_fp),
+            "--dataset-dir",
+            str(ds),
+            "--rule-len-penalty-start",
+            "0.1",
+            "--rule-len-penalty-end",
+            "-0.1",
+            "--rule-len-steps",
+            "5",
+            "--epochs",
+            "1",
+            "--cpu",
+        ]
+    )
+
+    args.func(args)
+    assert captured["rule_len_penalty_start"] == 0.1
+    assert captured["rule_len_penalty_end"] == -0.1
+    assert captured["rule_len_steps"] == 5
+
+
 def test_generate_hints_from_explainer(tmp_path, monkeypatch):
     torch_stub = types.SimpleNamespace(
         device=lambda *a, **k: None,

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -350,6 +350,40 @@ def test_fp_penalty_curriculum(tmp_path, monkeypatch):
     assert m1["fp_penalty"] > m2["fp_penalty"]
 
 
+def test_rule_len_penalty_curriculum(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        rule_len_penalty_start=0.0,
+        rule_len_penalty_end=-1.0,
+        rule_len_steps=10,
+    )
+
+    monkeypatch.setattr(
+        env.evaluator,
+        "evaluate_rule",
+        lambda *a, **k: (0.0, 0.0, 0.0, (0, 0, 0, 0)),
+    )
+    env.total_steps = 0
+    r1, m1, _ = env._compute_reward("A", update_stats=False)
+    env.total_steps = 10
+    r2, m2, _ = env._compute_reward("A", update_stats=False)
+    assert r2 < r1
+    assert m1["rule_len_weight"] > m2["rule_len_weight"]
+
+
 def test_lookahead_reward(tmp_path):
     clean = [HeteroData()]
     dummy = [HeteroData()]


### PR DESCRIPTION
## Summary
- support scheduling the rule length penalty in `RuleGenEnv`
- expose new CLI options to tune the schedule in `cmd_ppo_train`
- test curriculum behavior for rule length penalty
- test CLI propagation of the new options

## Testing
- `pytest -q` *(fails: missing optional dependencies)*
- `pytest tests/test_rl_env.py -k rule_len_penalty_curriculum -q` *(skipped: missing torch_geometric/gymnasium)*

------
https://chatgpt.com/codex/tasks/task_e_687ffe4069c0832eab81d240d301fd86