### PR TITLE
Add stability and necessity loss options

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ python -m cli.explainer_train global \
        # beta will increase from 1e-4 to this value during training
        --soft-mask-epochs 5  # train with soft masks for the first N epochs
        --hard-mask-mode weight  # use straight-through weighted masking
+       --stability-weight 0.1 --stability-start 10 \
+       --necessity-weight 0.05 --necessity-start 20
 #
 # `gamma`는 마스크 확률의 엔트로피에 곱해지는 가중치로, 0보다 크게 설정하면
 # 탐색을 유도하는 항이 손실 함수에 추가됩니다. 기본값은 0.01이며 값이 너무

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -85,6 +85,66 @@ LOGGER = get_logger(__name__, level=logging.INFO)
 from src.models.gnn.res_wrapper import RESGCLClassifier
 
 
+def perturb_graph(g: HeteroData) -> HeteroData:
+    """Return a slightly perturbed clone of ``g``.
+
+    The current implementation randomly drops a small fraction of edges
+    to introduce structural noise. This helper is intentionally simple
+    and serves as a lightweight stand‑in for more advanced perturbation
+    routines that may be available in a full installation.
+    """
+
+    from src.augment.ops.drop_edge import EdgeDrop
+
+    drop = EdgeDrop(keep_prob=0.95)
+    return drop(g)
+
+
+def compute_stability_loss(
+    graph: HeteroData,
+    explainer: PGExplainer,
+    mask_prob: torch.Tensor,
+    use_hard_mask: bool,
+) -> torch.Tensor:
+    """Return MSE between current and perturbed masks."""
+
+    g_pert = perturb_graph(graph)
+    encoder = getattr(explainer.model, "encoder", None)
+    embeds = (
+        _compute_node_embeddings(g_pert, encoder) if encoder is not None else None
+    )
+    new_mask = explainer(g_pert, embeddings=embeds, hard=use_hard_mask)
+    if new_mask.numel() == 0:
+        return torch.tensor(0.0, device=mask_prob.device)
+    return F.mse_loss(new_mask, mask_prob.detach())
+
+
+def compute_necessity_loss(
+    graph: HeteroData,
+    mask_prob: torch.Tensor,
+    explainer: PGExplainer,
+    model: RESGCLClassifier,
+    full_score: torch.Tensor,
+) -> torch.Tensor:
+    """Return necessity loss based on dropping salient nodes."""
+
+    saliency = explainer.get_node_saliency(graph, mask_prob)
+    keep_idx: dict[str, torch.Tensor] = {}
+    for nt, score in saliency.items():
+        if score.numel() == 0:
+            continue
+        k = max(1, int(score.numel() * 0.2))
+        _, drop_idx = torch.topk(score, k)
+        mask = torch.ones(score.size(0), dtype=torch.bool, device=score.device)
+        mask[drop_idx] = False
+        keep_idx[nt] = mask.nonzero(as_tuple=False).view(-1)
+
+    pruned = drop_unselected_nodes(graph, keep_idx, explainer.view)
+    logits = model(pruned, return_logits=True).squeeze()
+    target = torch.sigmoid(full_score.detach()).clamp(1e-4, 1 - 1e-4)
+    return F.binary_cross_entropy_with_logits(logits, target)
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Train Gumbel-Mask selector",
@@ -402,6 +462,10 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Maximum value for beta under the schedule. Defaults to --beta.",
     )
+    g.add_argument("--stability-weight", type=float, default=0.0, help="Weight for stability loss")
+    g.add_argument("--stability-start", type=int, default=0, help="Epoch to start applying stability loss")
+    g.add_argument("--necessity-weight", type=float, default=0.0, help="Weight for necessity loss")
+    g.add_argument("--necessity-start", type=int, default=0, help="Epoch to start applying necessity loss")
     add_common(g)
     g.set_defaults(func=train_global)
 
@@ -1987,6 +2051,14 @@ def train_global(args: argparse.Namespace) -> None:
                         gamma=args.gamma,
                         loss_type=args.loss_type,
                     )
+                    if epoch >= args.stability_start and args.stability_weight > 0:
+                        loss = loss + args.stability_weight * compute_stability_loss(
+                            g, explainer, mask_prob, use_hard_mask
+                        )
+                    if epoch >= args.necessity_start and args.necessity_weight > 0:
+                        loss = loss + args.necessity_weight * compute_necessity_loss(
+                            g, mask_prob, explainer, model, full_score
+                        )
 
                 loss_item = loss.item()
                 scaler.scale(loss / args.grad_accum_steps).backward()

--- a/tests/test_explainer_train_global_cli.py
+++ b/tests/test_explainer_train_global_cli.py
@@ -1,9 +1,26 @@
 import importlib
 from pathlib import Path
 import types
+import sys
 import pytest
 
 pytest.importorskip("torch")
+aug = importlib.import_module("src.augment")
+sys.modules.setdefault("augment", aug)
+for n, m in list(sys.modules.items()):
+    if n.startswith("src.augment"):
+        sys.modules.setdefault(n.replace("src.", "", 1), m)
+exp = importlib.import_module("src.explain")
+sys.modules.setdefault("explain", exp)
+for n, m in list(sys.modules.items()):
+    if n.startswith("src.explain"):
+        sys.modules.setdefault(n.replace("src.", "", 1), m)
+if "pyarrow" not in sys.modules:
+    pa = types.ModuleType("pyarrow")
+    pa.__version__ = "0.0"
+    sys.modules["pyarrow"] = pa
+    sys.modules["pyarrow.feather"] = types.ModuleType("pyarrow.feather")
+    sys.modules["pyarrow.parquet"] = types.ModuleType("pyarrow.parquet")
 
 class DummyModel:
     def __init__(self):
@@ -30,6 +47,10 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
         captured["output"] = args.output
         captured["init_bias"] = args.init_bias
         captured["tau_start"] = args.tau_start
+        captured["stability_weight"] = args.stability_weight
+        captured["stability_start"] = args.stability_start
+        captured["necessity_weight"] = args.necessity_weight
+        captured["necessity_start"] = args.necessity_start
 
     import torch.serialization
     monkeypatch.setattr(
@@ -39,9 +60,15 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
         raising=False,
     )
     import types, sys
-    for mod in ["gensim", "gensim.downloader", "sentencepiece"]:
+    for mod in ["gensim", "gensim.downloader", "sentencepiece", "gensim.models"]:
         if mod not in sys.modules:
             sys.modules[mod] = types.ModuleType(mod)
+    sys.modules.setdefault("gensim.models", types.ModuleType("gensim.models"))
+    sys.modules["gensim.models"].Word2Vec = object
+    for mod in ["pefile", "lief", "capstone", "r2pipe", "ghidra_bridge", "angr", "archinfo"]:
+        if mod not in sys.modules:
+            sys.modules[mod] = types.ModuleType(mod)
+
     monkeypatch.setattr("src.cli.explainer_train.train_global", fake_train)
     mod = importlib.import_module("src.cli.explainer_train")
 
@@ -60,3 +87,7 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
     assert captured["output"] == out
     assert captured["init_bias"] == 1.0
     assert captured["tau_start"] == 1.0
+    assert captured["stability_weight"] == 0.0
+    assert captured["stability_start"] == 0
+    assert captured["necessity_weight"] == 0.0
+    assert captured["necessity_start"] == 0


### PR DESCRIPTION
## Summary
- add perturb-based stability and necessity loss functions
- expose stability & necessity options in CLI and training loop
- document new flags in README
- ensure CLI parser handles defaults with updated test

## Testing
- `pytest -q tests/test_explainer_train_global_cli.py`
- `pytest -q` *(fails: ImportError: No module named 'gensim')*

------
https://chatgpt.com/codex/tasks/task_e_688000263798832eb019927e1f29927c