### PR TITLE
Extend global explainer metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,9 @@ python -m cli.explainer_train feature-mine \
 `global` 하위 명령에서는 검증 그래프를 지정해 학습 중 성능을 확인할 수 있습니다.
 `--val-graph-dir`와 `--val-meta-csv` 옵션을 사용하며 기본값은 각각
 `<graph_dir>/../val/graphs`, `<graph_dir>/../val/labels.csv` 입니다.
-각 에폭이 끝나면 평균 Fidelity와 Sparsity가 다음과 같이 출력됩니다.
+각 에폭이 끝나면 평균 Fidelity, Sparsity, Stability, Necessity가 다음과 같이 출력됩니다.
 
 ```
-Epoch 1 Val Fidelity: 0.9123  Val Sparsity: 0.0731
+Epoch 1 Val Fidelity: 0.9123  Val Sparsity: 0.0731  Val Stability: 0.0321  Val Necessity: 0.1452
 ```
+`--plot-path` 옵션으로 저장되는 학습 곡선 그래프에도 Stability와 Necessity 추이가 함께 표시됩니다.

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1711,14 +1711,16 @@ def _evaluate_global(
     args: argparse.Namespace,
     all_node_types: list[str],
     current_beta: float,
-) -> tuple[float, float, float]:
-    """Return average loss, fidelity, and sparsity on validation graphs."""
+) -> tuple[float, float, float, float, float]:
+    """Return average loss, fidelity, sparsity, stability and necessity."""
     if not paths:
-        return 0.0, 0.0, 0.0
+        return 0.0, 0.0, 0.0, 0.0, 0.0
 
     total_loss = 0.0
     total_fid = 0.0
     total_spars = 0.0
+    total_stab = 0.0
+    total_nec = 0.0
     count = 0
     param_dtype = next(model.parameters()).dtype
 
@@ -1749,6 +1751,8 @@ def _evaluate_global(
             avg_fidelity = 0.0
             avg_sparsity = 0.0
             avg_loss = 0.0
+            avg_stab = 0.0
+            avg_nec = 0.0
 
             for _ in range(args.val_samples):
                 mask_prob = explainer(g, embeddings=embeds, hard=True)
@@ -1764,6 +1768,12 @@ def _evaluate_global(
                     masked_score, target_prob
                 )
                 sparsity = mask_prob.mean()
+                stab_loss = compute_stability_loss(
+                    g, explainer, mask_prob, True
+                )
+                nec_loss = compute_necessity_loss(
+                    g, mask_prob, explainer, model, full_score
+                )
                 loss = explainer.loss(
                     full_score,
                     masked_score,
@@ -1776,20 +1786,32 @@ def _evaluate_global(
                 avg_fidelity += float(fidelity)
                 avg_sparsity += float(sparsity)
                 avg_loss += float(loss)
+                avg_stab += float(stab_loss)
+                avg_nec += float(nec_loss)
 
             if args.val_samples > 0:
                 fidelity = avg_fidelity / args.val_samples
                 sparsity = avg_sparsity / args.val_samples
                 loss = avg_loss / args.val_samples
+                stab_loss = avg_stab / args.val_samples
+                nec_loss = avg_nec / args.val_samples
 
         total_loss += float(loss)
         total_fid += float(fidelity)
         total_spars += float(sparsity)
+        total_stab += float(stab_loss)
+        total_nec += float(nec_loss)
         count += 1
 
     if count == 0:
-        return 0.0, 0.0, 0.0
-    return total_loss / count, total_fid / count, total_spars / count
+        return 0.0, 0.0, 0.0, 0.0, 0.0
+    return (
+        total_loss / count,
+        total_fid / count,
+        total_spars / count,
+        total_stab / count,
+        total_nec / count,
+    )
 
 
 def _schedule_beta(current: float, args: argparse.Namespace, cap: float) -> float:
@@ -1812,8 +1834,8 @@ def save_plot(history: dict, plot_path: Path):
         LOGGER.warning("matplotlib not found, skipping plot generation.")
         return
 
-    # Create a figure with 3 subplots in a single column
-    fig, axes = plt.subplots(3, 1, figsize=(12, 18), sharex=True)
+    # Create a figure with 5 subplots in a single column
+    fig, axes = plt.subplots(5, 1, figsize=(12, 30), sharex=True)
     epochs_r = range(1, len(history["train_loss"]) + 1)
 
     # Subplot 1: Training and Validation Loss
@@ -1861,10 +1883,38 @@ def save_plot(history: dict, plot_path: Path):
             marker="s",
         )
         axes[2].set_ylabel("Sparsity")
-        axes[2].set_xlabel("Epoch")
         axes[2].set_title("Validation Sparsity over Epochs")
         axes[2].grid(True)
         axes[2].legend()
+
+    # Subplot 4: Validation Stability
+    if history.get("val_stab"):
+        axes[3].plot(
+            epochs_r,
+            history["val_stab"],
+            label="Validation Stability",
+            color="tab:purple",
+            marker="^",
+        )
+        axes[3].set_ylabel("Stability")
+        axes[3].set_title("Validation Stability over Epochs")
+        axes[3].grid(True)
+        axes[3].legend()
+
+    # Subplot 5: Validation Necessity
+    if history.get("val_nec"):
+        axes[4].plot(
+            epochs_r,
+            history["val_nec"],
+            label="Validation Necessity",
+            color="tab:brown",
+            marker="v",
+        )
+        axes[4].set_ylabel("Necessity")
+        axes[4].set_xlabel("Epoch")
+        axes[4].set_title("Validation Necessity over Epochs")
+        axes[4].grid(True)
+        axes[4].legend()
 
     fig.tight_layout()
     plot_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1967,7 +2017,14 @@ def train_global(args: argparse.Namespace) -> None:
             )
     param_dtype = next(model.parameters()).dtype
 
-    history = {"train_loss": [], "val_loss": [], "val_fid": [], "val_spars": []}
+    history = {
+        "train_loss": [],
+        "val_loss": [],
+        "val_fid": [],
+        "val_spars": [],
+        "val_stab": [],
+        "val_nec": [],
+    }
     best_val_fid = float("inf")
     log_dir = args.output.parent
     log_dir.mkdir(parents=True, exist_ok=True)
@@ -2098,7 +2155,7 @@ def train_global(args: argparse.Namespace) -> None:
 
                 if val_graph_paths:
                     explainer.eval()
-                    val_loss, val_fid, val_spars = _evaluate_global(
+                    val_loss, val_fid, val_spars, val_stab, val_nec = _evaluate_global(
                         explainer,
                         model,
                         val_graph_paths,
@@ -2110,7 +2167,13 @@ def train_global(args: argparse.Namespace) -> None:
                     history["val_loss"].append(val_loss)
                     history["val_fid"].append(val_fid)
                     history["val_spars"].append(val_spars)
-                    log_msg += f" Val Loss: {val_loss:.4f}, Val Fidelity: {val_fid:.4f}, Val Sparsity: {val_spars:.4f}."
+                    history["val_stab"].append(val_stab)
+                    history["val_nec"].append(val_nec)
+                    log_msg += (
+                        f" Val Loss: {val_loss:.4f}, Val Fidelity: {val_fid:.4f}, "
+                        f"Val Sparsity: {val_spars:.4f}, Val Stability: {val_stab:.4f}, "
+                        f"Val Necessity: {val_nec:.4f}."
+                    )
 
                     if val_fid < best_val_fid:
                         best_val_fid = val_fid


### PR DESCRIPTION
## Summary
- compute stability and necessity metrics during global explainer evaluation
- log the new metrics in `train_global`
- show stability and necessity curves in training plots
- document new metrics in README

## Testing
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68808e6f5db0832eb47de109ef9890c3