### PR TITLE
Add penalty for rules with no true positives

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -11,6 +11,7 @@ env:
   fp_penalty_end: 0.5
   curriculum_steps: 20000
   off_target_penalty: 0.25
+  no_tp_penalty: 0.2
   reward_weights:
     f1_clean: 0.5
     f1_dummy: 0.4

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -33,8 +33,13 @@ env = RuleGenEnv(
         "rule_len": -0.05,
         "certified_bonus": 0.1,
     },
+    no_tp_penalty=0.2,
 )
 ```
+
+`no_tp_penalty`는 룰이 더미 그래프를 한 건도 매치하지 못했을 때 적용되는
+패널티의 크기를 조절합니다. 기본값은 `0.2`이며 CLI에서는 `--no-tp-penalty`
+옵션으로 설정할 수 있습니다.
 
 CLI 사용 시 `--reward-weights` 옵션을 주면 YAML 설정의 기본값 대신
 외부에서 지정한 JSON 문자열이나 파일의 보상 가중치를 사용할 수 있습니다.

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -675,6 +675,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             if args.off_target_penalty is not None
             else env_cfg.get("off_target_penalty", 0.25)
         ),
+        no_tp_penalty=float(
+            args.no_tp_penalty
+            if args.no_tp_penalty is not None
+            else env_cfg.get("no_tp_penalty", 0.2)
+        ),
         use_lookahead=getattr(args, "use_lookahead", False),
         single_target_mode=getattr(args, "single_target_mode", False),
         meta_path=getattr(args, "meta_path", None),
@@ -911,6 +916,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
                 reward_weights=args.reward_weights,
                 single_target_mode=True,
                 off_target_penalty=args.off_target_penalty,
+                no_tp_penalty=args.no_tp_penalty,
             )
             agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
             agent.load(args.agent_checkpoint)
@@ -929,6 +935,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
             reward_weights=args.reward_weights,
             single_target_mode=getattr(args, "single_target_mode", False),
             off_target_penalty=args.off_target_penalty,
+            no_tp_penalty=args.no_tp_penalty,
         )
         agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
         agent.load(args.agent_checkpoint)
@@ -1208,6 +1215,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Penalty per off-target match in single-target mode",
     )
     pt.add_argument(
+        "--no-tp-penalty",
+        type=float,
+        help="Penalty when rule matches no dummy samples",
+    )
+    pt.add_argument(
         "--rule-len-penalty-start",
         type=float,
         help="Initial weight for rule length penalty",
@@ -1280,6 +1292,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--off-target-penalty",
         type=float,
         help="Penalty per off-target match in single-target mode",
+    )
+    gen.add_argument(
+        "--no-tp-penalty",
+        type=float,
+        help="Penalty when rule matches no dummy samples",
     )
     gen.add_argument(
         "--target-graph",

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -123,6 +123,7 @@ class RuleGenEnv(gym.Env):
         fp_penalty_end: float = 0.5,
         curriculum_steps: int = 20000,
         off_target_penalty: float = 0.25,
+        no_tp_penalty: float = 0.2,
         rule_len_penalty_start: float | None = None,
         rule_len_penalty_end: float | None = None,
         rule_len_steps: int | None = None,
@@ -160,6 +161,7 @@ class RuleGenEnv(gym.Env):
         fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
         curriculum_steps : 패널티 스케줄 총 스텝 수
         off_target_penalty : single_target_mode 시 비표적 매치 1건당 패널티
+        no_tp_penalty : TP가 0일 때 부여할 패널티 크기
         rule_len_penalty_start : rule_len 패널티 초기 가중치 (기본 reward_weights['rule_len'])
         rule_len_penalty_end   : rule_len_steps 소모 후 적용할 가중치
         rule_len_steps : rule_len 패널티 스케줄 총 스텝 수
@@ -270,6 +272,7 @@ class RuleGenEnv(gym.Env):
         self.fp_penalty_end = float(fp_penalty_end)
         self.curriculum_steps = max(1, int(curriculum_steps))
         self.off_target_penalty = float(off_target_penalty)
+        self.no_tp_penalty = float(no_tp_penalty)
         self.total_steps = 0
 
         self.rule_len_penalty_start = (
@@ -993,6 +996,10 @@ class RuleGenEnv(gym.Env):
         )
         reward -= off_target_pen
 
+        no_tp = counts[0] == 0 and len(dummy_set) > 0
+        if no_tp:
+            reward -= self.no_tp_penalty
+
         metrics = dict(
             f1_clean=f1_clean,
             f1_dummy=f1_dummy,
@@ -1006,6 +1013,8 @@ class RuleGenEnv(gym.Env):
             saliency_bonus=bonus,
             off_target_matches=off_matches,
             off_target_penalty=off_target_pen,
+            no_tp=no_tp,
+            no_tp_penalty=self.no_tp_penalty if no_tp else 0.0,
             reward=reward,
         )
         shaping = 0.0

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -565,6 +565,43 @@ def test_off_target_penalty(tmp_path, monkeypatch):
     assert m1["off_target_matches"] > 0
 
 
+def test_no_tp_penalty(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        no_tp_penalty=0.5,
+    )
+
+    monkeypatch.setattr(
+        env.evaluator,
+        "evaluate_rule",
+        lambda *a, **k: (0.0, 0.0, 0.0, (0, 0, 0, 0)),
+    )
+    r1, m1, _ = env._compute_reward("A", update_stats=False)
+
+    monkeypatch.setattr(
+        env.evaluator,
+        "evaluate_rule",
+        lambda *a, **k: (0.0, 0.0, 0.0, (1, 0, 0, 0)),
+    )
+    r2, m2, _ = env._compute_reward("A", update_stats=False)
+
+    assert m1["no_tp"] and not m2["no_tp"]
+    assert pytest.approx(r2 - r1) == env.no_tp_penalty
+
+
 def test_reset_constant_observation_length(tmp_path, monkeypatch):
     clean = [HeteroData()]
     d1 = HeteroData()


### PR DESCRIPTION
## Summary
- support `no_tp_penalty` in `RuleGenEnv`
- expose the option through the CLI and default config
- document the new parameter
- test penalty when there are zero true positives

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6880931f4a4c832ea98d6123094cff4d