### PR TITLE
Add off-target penalty scheduling in RuleGenEnv

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -11,6 +11,9 @@ env:
   fp_penalty_end: 0.5
   curriculum_steps: 20000
   off_target_penalty: 0.25
+  off_target_penalty_start: 0.25
+  off_target_penalty_end: 0.25
+  off_target_steps: 20000
   no_tp_penalty: 0.2
   reward_weights:
     f1_clean: 0.5

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -41,6 +41,18 @@ env = RuleGenEnv(
 패널티의 크기를 조절합니다. 기본값은 `0.2`이며 CLI에서는 `--no-tp-penalty`
 옵션으로 설정할 수 있습니다.
 
+오프타깃 매치에 대한 패널티 역시 스케줄을 줄 수 있습니다.
+
+```python
+env = RuleGenEnv(
+    vocab_file="vocab.json",
+    dataset_dir="data/splits",
+    off_target_penalty_start=0.1,
+    off_target_penalty_end=0.5,
+    off_target_steps=10000,
+)
+```
+
 CLI 사용 시 `--reward-weights` 옵션을 주면 YAML 설정의 기본값 대신
 외부에서 지정한 JSON 문자열이나 파일의 보상 가중치를 사용할 수 있습니다.
 

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -675,6 +675,24 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             if args.off_target_penalty is not None
             else env_cfg.get("off_target_penalty", 0.25)
         ),
+        off_target_penalty_start=(
+            args.off_target_penalty_start
+            if args.off_target_penalty_start is not None
+            else env_cfg.get("off_target_penalty_start")
+        ),
+        off_target_penalty_end=(
+            args.off_target_penalty_end
+            if args.off_target_penalty_end is not None
+            else env_cfg.get("off_target_penalty_end")
+        ),
+        off_target_steps=int(
+            args.off_target_steps
+            if args.off_target_steps is not None
+            else env_cfg.get(
+                "off_target_steps",
+                env_cfg.get("curriculum_steps", 20000),
+            )
+        ),
         no_tp_penalty=float(
             args.no_tp_penalty
             if args.no_tp_penalty is not None
@@ -916,6 +934,9 @@ def cmd_generate(args: argparse.Namespace) -> None:
                 reward_weights=args.reward_weights,
                 single_target_mode=True,
                 off_target_penalty=args.off_target_penalty,
+                off_target_penalty_start=args.off_target_penalty_start,
+                off_target_penalty_end=args.off_target_penalty_end,
+                off_target_steps=args.off_target_steps,
                 no_tp_penalty=args.no_tp_penalty,
             )
             agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
@@ -935,6 +956,9 @@ def cmd_generate(args: argparse.Namespace) -> None:
             reward_weights=args.reward_weights,
             single_target_mode=getattr(args, "single_target_mode", False),
             off_target_penalty=args.off_target_penalty,
+            off_target_penalty_start=args.off_target_penalty_start,
+            off_target_penalty_end=args.off_target_penalty_end,
+            off_target_steps=args.off_target_steps,
             no_tp_penalty=args.no_tp_penalty,
         )
         agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
@@ -1215,6 +1239,21 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Penalty per off-target match in single-target mode",
     )
     pt.add_argument(
+        "--off-target-penalty-start",
+        type=float,
+        help="Initial weight for off-target penalty",
+    )
+    pt.add_argument(
+        "--off-target-penalty-end",
+        type=float,
+        help="Final weight for off-target penalty",
+    )
+    pt.add_argument(
+        "--off-target-steps",
+        type=int,
+        help="Steps over which to anneal the off-target penalty",
+    )
+    pt.add_argument(
         "--no-tp-penalty",
         type=float,
         help="Penalty when rule matches no dummy samples",
@@ -1292,6 +1331,21 @@ def _build_parser() -> argparse.ArgumentParser:
         "--off-target-penalty",
         type=float,
         help="Penalty per off-target match in single-target mode",
+    )
+    gen.add_argument(
+        "--off-target-penalty-start",
+        type=float,
+        help="Initial weight for off-target penalty",
+    )
+    gen.add_argument(
+        "--off-target-penalty-end",
+        type=float,
+        help="Final weight for off-target penalty",
+    )
+    gen.add_argument(
+        "--off-target-steps",
+        type=int,
+        help="Steps over which to anneal the off-target penalty",
     )
     gen.add_argument(
         "--no-tp-penalty",

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -123,6 +123,9 @@ class RuleGenEnv(gym.Env):
         fp_penalty_end: float = 0.5,
         curriculum_steps: int = 20000,
         off_target_penalty: float = 0.25,
+        off_target_penalty_start: float | None = None,
+        off_target_penalty_end: float | None = None,
+        off_target_steps: int | None = None,
         no_tp_penalty: float = 0.2,
         rule_len_penalty_start: float | None = None,
         rule_len_penalty_end: float | None = None,
@@ -161,6 +164,9 @@ class RuleGenEnv(gym.Env):
         fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
         curriculum_steps : 패널티 스케줄 총 스텝 수
         off_target_penalty : single_target_mode 시 비표적 매치 1건당 패널티
+        off_target_penalty_start : 오프 타깃 패널티 초기 가중치
+        off_target_penalty_end   : off_target_steps 소모 후 적용할 가중치
+        off_target_steps : 오프 타깃 패널티 스케줄 총 스텝 수
         no_tp_penalty : TP가 0일 때 부여할 패널티 크기
         rule_len_penalty_start : rule_len 패널티 초기 가중치 (기본 reward_weights['rule_len'])
         rule_len_penalty_end   : rule_len_steps 소모 후 적용할 가중치
@@ -271,7 +277,20 @@ class RuleGenEnv(gym.Env):
         self.fp_penalty_start = float(fp_penalty_start)
         self.fp_penalty_end = float(fp_penalty_end)
         self.curriculum_steps = max(1, int(curriculum_steps))
-        self.off_target_penalty = float(off_target_penalty)
+        self.off_target_penalty_start = (
+            float(off_target_penalty)
+            if off_target_penalty_start is None
+            else float(off_target_penalty_start)
+        )
+        self.off_target_penalty_end = (
+            float(off_target_penalty)
+            if off_target_penalty_end is None
+            else float(off_target_penalty_end)
+        )
+        self.off_target_steps = max(
+            1,
+            int(off_target_steps if off_target_steps is not None else self.curriculum_steps),
+        )
         self.no_tp_penalty = float(no_tp_penalty)
         self.total_steps = 0
 
@@ -918,7 +937,10 @@ class RuleGenEnv(gym.Env):
         return float(w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy)
 
     def _compute_off_target_penalty(
-        self, rule_text: str, dummy_set: Sequence[HeteroData]
+        self,
+        rule_text: str,
+        dummy_set: Sequence[HeteroData],
+        penalty_factor: float,
     ) -> Tuple[float, float]:
         """Compute penalty and match count for off-target graphs."""
         if not self.single_target_mode or len(self.full_dummy_set) <= len(dummy_set):
@@ -929,7 +951,7 @@ class RuleGenEnv(gym.Env):
         _, f1_ot, _, _ = self.evaluator.evaluate_rule(rule_text, [], off_targets)
         m_off = len(off_targets)
         matches = float(f1_ot * m_off / (2 - f1_ot)) if f1_ot > 0 else 0.0
-        penalty = self.off_target_penalty * matches
+        penalty = penalty_factor * matches
         return penalty, matches
 
     # reward
@@ -991,8 +1013,14 @@ class RuleGenEnv(gym.Env):
         reward += bonus
 
         # penalize off-target matches in single-target mode
+        progress_off = min(self.total_steps, self.off_target_steps) / self.off_target_steps
+        curr_off_penalty = self.off_target_penalty_start + (
+            self.off_target_penalty_end - self.off_target_penalty_start
+        ) * progress_off
         off_target_pen, off_matches = self._compute_off_target_penalty(
-            rule_text, dummy_set
+            rule_text,
+            dummy_set,
+            curr_off_penalty,
         )
         reward -= off_target_pen
 
@@ -1013,6 +1041,7 @@ class RuleGenEnv(gym.Env):
             saliency_bonus=bonus,
             off_target_matches=off_matches,
             off_target_penalty=off_target_pen,
+            off_target_penalty_factor=curr_off_penalty,
             no_tp=no_tp,
             no_tp_penalty=self.no_tp_penalty if no_tp else 0.0,
             reward=reward,

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -565,6 +565,46 @@ def test_off_target_penalty(tmp_path, monkeypatch):
     assert m1["off_target_matches"] > 0
 
 
+def test_off_target_penalty_schedule(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    d1 = HeteroData()
+    d2 = HeteroData()
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save([d1, d2], tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        single_target_mode=True,
+        off_target_penalty_start=0.0,
+        off_target_penalty_end=1.0,
+        off_target_steps=10,
+    )
+
+    env.reset()
+
+    monkeypatch.setattr(
+        env.evaluator,
+        "evaluate_rule",
+        lambda *a, **k: (0.0, 1.0, 3.0, (0, 0, 0, 0)),
+    )
+
+    env.total_steps = 0
+    r1, m1, _ = env._compute_reward("A", update_stats=False)
+    env.total_steps = 10
+    r2, m2, _ = env._compute_reward("A", update_stats=False)
+
+    assert m1["off_target_penalty"] < m2["off_target_penalty"]
+    assert r1 > r2
+
+
 def test_no_tp_penalty(tmp_path, monkeypatch):
     clean = [HeteroData()]
     dummy = [HeteroData()]


### PR DESCRIPTION
## Summary
- schedule off-target penalty using start/end weights
- expose new schedule options in rulegen CLI
- document penalty schedule usage in Quick Start guide
- update PPO config with example schedule fields
- test off-target penalty schedule behavior

## Testing
- `pytest tests/test_rl_env.py -k test_off_target_penalty_schedule -vv`
- `pytest -q` *(fails: missing optional dependencies such as capstone, gensim, transformers)*

------
https://chatgpt.com/codex/tasks/task_e_688096d96064832e91d30d3d7e52ed84