### PR TITLE
Reduce PPO weight adjust interval

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -22,7 +22,7 @@ env:
     certified_bonus: 0.1
   # dynamic weight adjustment during training
   weight_adjust:
-    interval: 5000        # steps between updates
+    interval: 2000        # steps between updates
     delta_f1_dummy: 0.1   # increment for f1_dummy weight
     delta_f1_clean: -0.1  # decrement for f1_clean weight
 


### PR DESCRIPTION
## Summary
- speed up reward weight adjustment by setting `interval: 2000`

## Testing
- `pytest -k rulegen_cli -q`


------
https://chatgpt.com/codex/tasks/task_e_6880999b63e4832e8a56a06da3618e39