### PR TITLE
Add F1 dummy improvement bonus in RL env

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -15,6 +15,7 @@ env:
   off_target_penalty_end: 0.25
   off_target_steps: 20000
   no_tp_penalty: 0.2
+  improve_bonus: 0.1
   reward_weights:
     f1_clean: 0.5
     f1_dummy: 0.4

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -130,6 +130,7 @@ class RuleGenEnv(gym.Env):
         rule_len_penalty_start: float | None = None,
         rule_len_penalty_end: float | None = None,
         rule_len_steps: int | None = None,
+        improve_bonus: float = 0.1,
     ):
         """
         Parameters
@@ -293,6 +294,9 @@ class RuleGenEnv(gym.Env):
         )
         self.no_tp_penalty = float(no_tp_penalty)
         self.total_steps = 0
+
+        self.improve_bonus = float(improve_bonus)
+        self.prev_f1_dummy = 0.0
 
         self.rule_len_penalty_start = (
             float(self.reward_weights["rule_len"]) if rule_len_penalty_start is None else float(rule_len_penalty_start)
@@ -1027,6 +1031,10 @@ class RuleGenEnv(gym.Env):
         no_tp = counts[0] == 0 and len(dummy_set) > 0
         if no_tp:
             reward -= self.no_tp_penalty
+
+        if f1_dummy > self.prev_f1_dummy:
+            reward += self.improve_bonus * (f1_dummy - self.prev_f1_dummy)
+        self.prev_f1_dummy = f1_dummy
 
         metrics = dict(
             f1_clean=f1_clean,

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -706,3 +706,40 @@ def test_update_reward_weights_method(tmp_path):
 
     assert env.reward_weights["f1_dummy"] == pytest.approx(old["f1_dummy"] + 0.1)
     assert env.reward_weights["f1_clean"] == pytest.approx(old["f1_clean"] - 0.1)
+
+
+def test_f1_dummy_improve_bonus(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        improve_bonus=1.0,
+    )
+
+    monkeypatch.setattr(
+        env.evaluator,
+        "evaluate_rule",
+        lambda *a, **k: (0.0, 0.0, 0.0, (0, 0, 0, 0)),
+    )
+    env._compute_reward("", update_stats=False)
+
+    monkeypatch.setattr(
+        env.evaluator,
+        "evaluate_rule",
+        lambda *a, **k: (0.0, 0.2, 0.0, (0, 0, 0, 0)),
+    )
+    r2, _, _ = env._compute_reward("", update_stats=False)
+    expected = env.reward_weights["f1_dummy"] * 0.2 - env.no_tp_penalty
+    expected += env.improve_bonus * 0.2
+    assert pytest.approx(r2, rel=1e-6) == expected


### PR DESCRIPTION
## Summary
- add `improve_bonus` to `RuleGenEnv` for bonus reward when F1 on dummy improves
- update PPO config with new parameter
- test the improvement bonus reward behaviour

## Testing
- `PYTHONPATH=src pytest tests/test_rl_env.py::test_f1_dummy_improve_bonus -q`

------
https://chatgpt.com/codex/tasks/task_e_68809b4eae5c832e821a9b09487bcdd6