### PR TITLE
Add auto reward adjustment in PPO agent

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -27,6 +27,11 @@ env:
     delta_f1_dummy: 0.1   # increment for f1_dummy weight
     delta_f1_clean: -0.1  # decrement for f1_clean weight
 
+auto_adjust:
+  threshold: 0.1
+  delta_f1_dummy: 0.1
+  delta_f1_clean: -0.1
+
 model:
   ## 정책 네트워크 종류: "gru" (default), "attn" 또는 GPT 모델명(e.g. "gpt2-small")
   policy_net: "gru"

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -82,6 +82,18 @@ env:
 학습 루프에서 지정한 주기마다 `env.update_reward_weights()`가 호출되어
 가중치가 갱신됩니다.
 
+### 자동 보상 조정
+
+`auto_adjust` 섹션을 사용하면 최근 롤아웃의 평균 `f1_dummy` 값이 임계치보다
+낮을 때 보상 가중치를 자동으로 보정합니다.
+
+```yaml
+auto_adjust:
+  threshold: 0.1
+  delta_f1_dummy: 0.1
+  delta_f1_clean: -0.1
+```
+
 PPO 하이퍼파라미터는 다음 옵션으로 조정할 수 있습니다.
 
 ```bash

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -612,6 +612,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     env_cfg = cfg.get("env", {})
     curriculum_cfg = cfg.get("curriculum", {})
     adjust_cfg = env_cfg.get("weight_adjust", {})
+    auto_adjust_cfg = cfg.get("auto_adjust")
+    if auto_adjust_cfg:
+        auto_adjust_cfg = OmegaConf.to_container(auto_adjust_cfg, resolve=True)
+    else:
+        auto_adjust_cfg = None
 
     phase_sched = None
     if curriculum_cfg:
@@ -815,6 +820,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
                 log_interval=log_interval,
                 save_path=args.checkpoint,
                 phase_schedule=phase_sched,
+                auto_adjust=auto_adjust_cfg,
             )
         )
         if next_adjust is not None:

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -502,12 +502,19 @@ class PPORuleAgent:
         pretrain_dataset: Sequence[Tuple[Sequence[int], int]] | None = None,
         pretrain_epochs: int = 1,
         phase_schedule: dict | None = None,
+        auto_adjust: dict | None = None,
     ) -> List[Tuple[int, float]]:
         """Run the main PPO loop.
 
         Returns
         -------
         List of ``(step, avg_return)`` logged at each ``log_interval``.
+
+        Parameters
+        ----------
+        auto_adjust : optional mapping
+            If provided, automatically adjust reward weights when the average
+            ``f1_dummy`` from the recent rollout falls below ``threshold``.
         """
         obs, info = self.env.reset()
         hint = info.get("hint")
@@ -517,6 +524,14 @@ class PPORuleAgent:
         interval_returns: List[float] = []
         avg_history: List[Tuple[int, float]] = []
         ep_return = 0.0
+
+        threshold = None
+        delta_dummy = 0.0
+        delta_clean = 0.0
+        if auto_adjust:
+            threshold = float(auto_adjust.get("threshold", 0.0))
+            delta_dummy = float(auto_adjust.get("delta_f1_dummy", 0.0))
+            delta_clean = float(auto_adjust.get("delta_f1_clean", 0.0))
 
         switch_step = None
         phase2 = {}
@@ -620,6 +635,16 @@ class PPORuleAgent:
                 # ── PPO Update
                 avg_f1_dummy = float(np.mean(self.f1_dummy_buf)) if self.f1_dummy_buf else 0.0
                 self._update()
+                if threshold is not None and avg_f1_dummy < threshold:
+                    new_dummy = self.env.reward_weights.get("f1_dummy", 0.0) + delta_dummy
+                    new_clean = self.env.reward_weights.get("f1_clean", 0.0) + delta_clean
+                    self.env.update_reward_weights(f1_dummy=new_dummy, f1_clean=new_clean)
+                    _LOG.info(
+                        "Auto-adjust reward weights to %s (avg_f1_dummy=%.4f < %.4f)",
+                        self.env.reward_weights,
+                        avg_f1_dummy,
+                        threshold,
+                    )
 
                 if global_step % log_interval == 0:
                     avg_ret = float(np.mean(interval_returns)) if interval_returns else 0.0


### PR DESCRIPTION
## Summary
- make PPO agent adjust reward weights when f1_dummy remains low
- expose auto_adjust setting in CLI and config
- document automatic reward adjustment in quick start guide

## Testing
- `pytest -q` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68809d2ee7f8832e9cf60a86343ea557