### PR TITLE
Implement stability perturb mask and tests

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -85,19 +85,50 @@ LOGGER = get_logger(__name__, level=logging.INFO)
 from src.models.gnn.res_wrapper import RESGCLClassifier
 
 
-def perturb_graph(g: HeteroData) -> HeteroData:
+def perturb_graph(g: HeteroData, return_mask: bool = False):
     """Return a slightly perturbed clone of ``g``.
 
-    The current implementation randomly drops a small fraction of edges
-    to introduce structural noise. This helper is intentionally simple
-    and serves as a lightweight stand‑in for more advanced perturbation
-    routines that may be available in a full installation.
+    The current implementation randomly drops a small fraction of edges to
+    introduce structural noise.  When ``return_mask`` is ``True`` the boolean
+    mask indicating which edges were kept is also returned.
     """
 
     from src.augment.ops.drop_edge import EdgeDrop
 
     drop = EdgeDrop(keep_prob=0.95)
-    return drop(g)
+
+    if not return_mask:
+        return drop(g)
+
+    # Manual edge drop to capture the keep mask
+    sg = g.clone()
+    masks = []
+    for etype in sg.edge_types:
+        rel_type = etype[1]
+        keep_p = drop.keep_prob.get(rel_type, drop.keep_prob.get("*", 1.0))
+        store = sg[etype]
+        num_e = store.num_edges
+        if num_e == 0:
+            mask = torch.zeros(0, dtype=torch.bool)
+        elif math.isclose(keep_p, 1.0):
+            mask = torch.ones(num_e, dtype=torch.bool)
+        else:
+            mask_np = drop._rng.rand(num_e) < keep_p
+            if not mask_np.any():
+                mask_np[drop._rng.randint(0, num_e)] = True
+            mask = torch.from_numpy(mask_np).to(torch.bool)
+
+        edge_index = store.edge_index
+        store.edge_index = edge_index[:, mask]
+        for key, val in list(store.items()):
+            if key == "edge_index":
+                continue
+            if torch.is_tensor(val) and val.size(0) == num_e:
+                store[key] = val[mask]
+        masks.append(mask)
+
+    keep_mask = torch.cat(masks) if masks else torch.tensor([], dtype=torch.bool)
+    return sg, keep_mask
 
 
 def compute_stability_loss(
@@ -108,7 +139,7 @@ def compute_stability_loss(
 ) -> torch.Tensor:
     """Return MSE between current and perturbed masks."""
 
-    g_pert = perturb_graph(graph)
+    g_pert, keep_mask = perturb_graph(graph, return_mask=True)
     encoder = getattr(explainer.model, "encoder", None)
     embeds = (
         _compute_node_embeddings(g_pert, encoder) if encoder is not None else None
@@ -116,7 +147,8 @@ def compute_stability_loss(
     new_mask = explainer(g_pert, embeddings=embeds, hard=use_hard_mask)
     if new_mask.numel() == 0:
         return torch.tensor(0.0, device=mask_prob.device)
-    return F.mse_loss(new_mask, mask_prob.detach())
+    mask_prob_filtered = mask_prob[keep_mask.to(mask_prob.device)]
+    return F.mse_loss(new_mask, mask_prob_filtered.detach())
 
 
 def compute_necessity_loss(

--- a/tests/test_stability_loss.py
+++ b/tests/test_stability_loss.py
@@ -1,0 +1,62 @@
+import importlib
+import types
+import sys
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+aug = importlib.import_module("src.augment")
+sys.modules.setdefault("augment", aug)
+for n, m in list(sys.modules.items()):
+    if n.startswith("src.augment"):
+        sys.modules.setdefault(n.replace("src.", "", 1), m)
+exp = importlib.import_module("src.explain")
+sys.modules.setdefault("explain", exp)
+for n, m in list(sys.modules.items()):
+    if n.startswith("src.explain"):
+        sys.modules.setdefault(n.replace("src.", "", 1), m)
+for mod_name in ["gensim", "gensim.downloader", "sentencepiece"]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+if "pandas" not in sys.modules:
+    sys.modules["pandas"] = types.ModuleType("pandas")
+if "pyarrow" not in sys.modules:
+    pa = types.ModuleType("pyarrow")
+    sys.modules["pyarrow"] = pa
+    sys.modules["pyarrow.feather"] = types.ModuleType("pyarrow.feather")
+    sys.modules["pyarrow.parquet"] = types.ModuleType("pyarrow.parquet")
+sys.modules.setdefault("gensim.models", types.ModuleType("gensim.models"))
+sys.modules["gensim.models"].Word2Vec = object
+for mod in ["pefile", "lief", "capstone", "r2pipe", "ghidra_bridge", "angr", "archinfo"]:
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+from robust_malware_graph.explain import PGExplainer
+from src.cli.explainer_train import compute_stability_loss
+
+class DummyModel(torch.nn.Module):
+    def forward(self, graph, return_logits=False):
+        return torch.tensor([0.0])
+
+
+def build_graph():
+    g = HeteroData()
+    g["n"].x = torch.zeros(2, 1)
+    g["n"].num_nodes = 2
+    ei = torch.tensor([[0, 1], [1, 0]])
+    g[("n", "r", "n")].edge_index = ei
+    g[("n", "r", "n")].edge_type = torch.zeros(2, dtype=torch.long)
+    return g
+
+
+def test_compute_stability_loss_runs():
+    g = build_graph()
+    model = DummyModel()
+    explainer = PGExplainer(model, {"n": 1}, [("n", "r", "n")], view="r")
+    mask_prob = explainer(g)
+    loss = compute_stability_loss(g, explainer, mask_prob, False)
+    assert isinstance(loss, torch.Tensor)
+    assert loss.numel() == 1


### PR DESCRIPTION
## Summary
- allow perturb_graph to optionally return edge mask used during random drop
- filter original mask probabilities in compute_stability_loss
- add regression test for compute_stability_loss

## Testing
- `pytest tests/test_stability_loss.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68809f169a50832eb7bdd241e4e05ad2