### PR TITLE
Fix GPU device handling in pruner and hetero utils

### DIFF
--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -31,7 +31,10 @@ def get_edge_store(
                 break
             offset += g[key].edge_index.size(1)
         global_idx = torch.arange(
-            offset, offset + edge_index.size(1), dtype=torch.long, device=edge_index.device
+            offset,
+            offset + edge_index.size(1),
+            dtype=torch.long,
+            device=edge_index.device,
         )
     return edge_index, store, global_idx
 
@@ -94,25 +97,38 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str | None) -> Heter
 
     if isinstance(node_idx, Mapping):
         for ntype in data.node_types:
-            idx = torch.as_tensor(node_idx.get(ntype, []), dtype=torch.long)
-            mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float)
+            device = data[ntype].edge_index.device
+            idx = torch.as_tensor(
+                node_idx.get(ntype, []), dtype=torch.long, device=device
+            )
+            mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float, device=device)
             if idx.numel() > 0:
                 mask[idx] = 1.0
             selected[ntype] = mask
     else:
         # infer node type from view edge types
-        types = {et[0] for et in iter_edge_types(data, view)} | {et[2] for et in iter_edge_types(data, view)}
+        types = {et[0] for et in iter_edge_types(data, view)} | {
+            et[2] for et in iter_edge_types(data, view)
+        }
         if len(types) != 1:
             raise ValueError("Ambiguous node types; provide mapping per type")
         ntype = next(iter(types))
-        mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float)
-        idx = torch.as_tensor(node_idx, dtype=torch.long)
+        device = data[ntype].edge_index.device
+        mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float, device=device)
+        idx = torch.as_tensor(node_idx, dtype=torch.long, device=device)
         if idx.numel() > 0:
             mask[idx] = 1.0
         selected = {ntype: mask}
         for other in data.node_types:
             if other != ntype:
-                selected.setdefault(other, torch.zeros(data[other].num_nodes, dtype=torch.float))
+                selected.setdefault(
+                    other,
+                    torch.zeros(
+                        data[other].num_nodes,
+                        dtype=torch.float,
+                        device=data[other].edge_index.device,
+                    ),
+                )
 
     pruner = GraphPruner(selected, thresh=0.5)
     out = pruner.apply(data)

--- a/src/graphs/transforms/pruner.py
+++ b/src/graphs/transforms/pruner.py
@@ -83,7 +83,7 @@ class GraphPruner:
         if not inplace:
             g = g.clone()
 
-        score = self.scores
+        score = self.scores.to(g.edge_index.device)
         if self.mode == "threshold":
             keep = score >= self.thresh
         else:  # top-k
@@ -120,7 +120,7 @@ class GraphPruner:
 
         # 1) 노드 필터링
         for ntype in g.node_types:
-            score = self.scores[ntype]
+            score = self.scores[ntype].to(g[ntype].device)
             if self.mode == "threshold":
                 keep = score >= self.thresh
             else:
@@ -133,11 +133,9 @@ class GraphPruner:
             _reindex_node_attrs(g[ntype], id_maps[ntype])
 
         # 2) 엣지 리매핑 & 필터
-        for (src_t, rel, dst_t) in g.edge_types:
+        for src_t, rel, dst_t in g.edge_types:
             store = g[(src_t, rel, dst_t)]
-            ei_new = _apply_reindex(
-                store.edge_index, id_maps[src_t], id_maps[dst_t]
-            )
+            ei_new = _apply_reindex(store.edge_index, id_maps[src_t], id_maps[dst_t])
             keep_edge = ei_new[0] >= 0  # src/dst 정상인 엣지
             store.edge_index = ei_new[:, keep_edge]
 

--- a/tests/test_drop_unselected_nodes.py
+++ b/tests/test_drop_unselected_nodes.py
@@ -1,4 +1,5 @@
 import pytest
+
 pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
@@ -29,3 +30,11 @@ def test_drop_nodes_none_view():
     assert out["bb"].num_nodes == 2
     assert out[("bb", "cfg", "bb")].edge_index.tolist() == [[1], [0]]
 
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_drop_nodes_cuda():
+    g = build_graph().to("cuda")
+    out = drop_unselected_nodes(g, [0, 2], "cfg")
+    assert out["bb"].num_nodes == 2
+    assert out[("bb", "cfg", "bb")].edge_index.device.type == "cuda"
+    assert out[("bb", "cfg", "bb")].edge_index.tolist() == [[1], [0]]


### PR DESCRIPTION
## Summary
- ensure drop_unselected_nodes creates tensors on the correct device
- move GraphPruner scores to graph device before filtering
- test drop_unselected_nodes with CUDA

## Testing
- `pytest tests/test_drop_unselected_nodes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a5751da0832eb155dad6e3521bc8