### PR TITLE
Fix device retrieval in drop_unselected_nodes

### DIFF
--- a/src/explain/utils/hetero.py
+++ b/src/explain/utils/hetero.py
@@ -97,11 +97,20 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str | None) -> Heter
 
     if isinstance(node_idx, Mapping):
         for ntype in data.node_types:
-            device = data[ntype].edge_index.device
+            device = getattr(data[ntype], "device", None)
+            if device is None:
+                for val in data[ntype].values():
+                    if isinstance(val, torch.Tensor):
+                        device = val.device
+                        break
+            if device is None:
+                device = torch.device("cpu")
             idx = torch.as_tensor(
                 node_idx.get(ntype, []), dtype=torch.long, device=device
             )
-            mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float, device=device)
+            mask = torch.zeros(
+                data[ntype].num_nodes, dtype=torch.float, device=device
+            )
             if idx.numel() > 0:
                 mask[idx] = 1.0
             selected[ntype] = mask
@@ -113,8 +122,17 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str | None) -> Heter
         if len(types) != 1:
             raise ValueError("Ambiguous node types; provide mapping per type")
         ntype = next(iter(types))
-        device = data[ntype].edge_index.device
-        mask = torch.zeros(data[ntype].num_nodes, dtype=torch.float, device=device)
+        device = getattr(data[ntype], "device", None)
+        if device is None:
+            for val in data[ntype].values():
+                if isinstance(val, torch.Tensor):
+                    device = val.device
+                    break
+        if device is None:
+            device = torch.device("cpu")
+        mask = torch.zeros(
+            data[ntype].num_nodes, dtype=torch.float, device=device
+        )
         idx = torch.as_tensor(node_idx, dtype=torch.long, device=device)
         if idx.numel() > 0:
             mask[idx] = 1.0
@@ -126,7 +144,18 @@ def drop_unselected_nodes(data: HeteroData, node_idx, view: str | None) -> Heter
                     torch.zeros(
                         data[other].num_nodes,
                         dtype=torch.float,
-                        device=data[other].edge_index.device,
+                        device=getattr(
+                            data[other],
+                            "device",
+                            next(
+                                (
+                                    v.device
+                                    for v in data[other].values()
+                                    if isinstance(v, torch.Tensor)
+                                ),
+                                torch.device("cpu"),
+                            ),
+                        ),
                     ),
                 )
 

--- a/src/graphs/transforms/pruner.py
+++ b/src/graphs/transforms/pruner.py
@@ -120,7 +120,15 @@ class GraphPruner:
 
         # 1) 노드 필터링
         for ntype in g.node_types:
-            score = self.scores[ntype].to(g[ntype].device)
+            device = getattr(g[ntype], "device", None)
+            if device is None:
+                for val in g[ntype].values():
+                    if isinstance(val, torch.Tensor):
+                        device = val.device
+                        break
+            if device is None:
+                device = torch.device("cpu")
+            score = self.scores[ntype].to(device)
             if self.mode == "threshold":
                 keep = score >= self.thresh
             else:


### PR DESCRIPTION
## Summary
- ensure device retrieval works even when NodeStorage lacks `.device`
- adjust GraphPruner to use same fallback logic
- add fallback in `drop_unselected_nodes` for mask creation

## Testing
- `pytest tests/test_drop_unselected_nodes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880aa24ec84832ea325d67ebc2ac4b1