### PR TITLE
Fix device usage when generating new IDs

### DIFF
--- a/src/graphs/builders/relabeler.py
+++ b/src/graphs/builders/relabeler.py
@@ -55,7 +55,11 @@ def relabel(
 def _make_new_ids(mask: torch.Tensor) -> torch.Tensor:
     """True→ keep. False→ drop(→-1)."""
     new_id = torch.full_like(mask, -1, dtype=torch.long)
-    new_id[mask] = torch.arange(mask.sum(), dtype=torch.long)
+    new_id[mask] = torch.arange(
+        mask.sum(),
+        dtype=torch.long,
+        device=mask.device,
+    )
     return new_id
 
 


### PR DESCRIPTION
## Summary
- ensure new IDs are created on the same device as the mask in `_make_new_ids`
- run the full test suite

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6880affc8ffc832eae3c04e28ce2b9d3