### PR TITLE
Add fp_penalty_delay scheduling option

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -9,6 +9,7 @@ env:
   max_tokens: 512
   fp_penalty_start: 0.01
   fp_penalty_end: 0.5
+  fp_penalty_delay: 0
   curriculum_steps: 20000
   off_target_penalty: 0.25
   off_target_penalty_start: 0.25

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -625,6 +625,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         rw = phase1.get("reward_weights", env_cfg.get("reward_weights"))
         fps = phase1.get("fp_penalty_start", env_cfg.get("fp_penalty_start", 0.01))
         fpe = phase1.get("fp_penalty_end", env_cfg.get("fp_penalty_end", 0.5))
+        fpd = phase1.get("fp_penalty_delay", env_cfg.get("fp_penalty_delay", 0))
         rlps = phase1.get(
             "rule_len_penalty_start",
             env_cfg.get("rule_len_penalty_start")
@@ -643,6 +644,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         rw = args.reward_weights or env_cfg.get("reward_weights")
         fps = env_cfg.get("fp_penalty_start", 0.01)
         fpe = env_cfg.get("fp_penalty_end", 0.5)
+        fpd = env_cfg.get("fp_penalty_delay", 0)
         rlps = (
             args.rule_len_penalty_start
             if args.rule_len_penalty_start is not None
@@ -671,6 +673,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         reward_weights=rw,
         fp_penalty_start=fps,
         fp_penalty_end=fpe,
+        fp_penalty_delay=int(fpd),
         curriculum_steps=int(env_cfg.get("curriculum_steps", 20000)),
         rule_len_penalty_start=rlps,
         rule_len_penalty_end=rlpe,
@@ -938,6 +941,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
                 hint_features=hint_feats,
                 seed=args.seed,
                 reward_weights=args.reward_weights,
+                fp_penalty_delay=0,
                 single_target_mode=True,
                 off_target_penalty=args.off_target_penalty,
                 off_target_penalty_start=args.off_target_penalty_start,
@@ -960,6 +964,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
             hint_features=hint_feats,
             seed=args.seed,
             reward_weights=args.reward_weights,
+            fp_penalty_delay=0,
             single_target_mode=getattr(args, "single_target_mode", False),
             off_target_penalty=args.off_target_penalty,
             off_target_penalty_start=args.off_target_penalty_start,

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -121,6 +121,7 @@ class RuleGenEnv(gym.Env):
         reward_weights: dict | None = None,
         fp_penalty_start: float = 0.01,
         fp_penalty_end: float = 0.5,
+        fp_penalty_delay: int = 0,
         curriculum_steps: int = 20000,
         off_target_penalty: float = 0.25,
         off_target_penalty_start: float | None = None,
@@ -163,6 +164,7 @@ class RuleGenEnv(gym.Env):
         reward_weights   : F1/길이/인증 보상 가중치 딕셔너리
         fp_penalty_start : 초기 False Positive 패널티 배율
         fp_penalty_end   : curriculum_steps 소모 후 적용할 배율
+        fp_penalty_delay : 일정 스텝 동안 FP 패널티를 적용하지 않음
         curriculum_steps : 패널티 스케줄 총 스텝 수
         off_target_penalty : single_target_mode 시 비표적 매치 1건당 패널티
         off_target_penalty_start : 오프 타깃 패널티 초기 가중치
@@ -277,6 +279,7 @@ class RuleGenEnv(gym.Env):
 
         self.fp_penalty_start = float(fp_penalty_start)
         self.fp_penalty_end = float(fp_penalty_end)
+        self.fp_penalty_delay = int(fp_penalty_delay)
         self.curriculum_steps = max(1, int(curriculum_steps))
         self.off_target_penalty_start = (
             float(off_target_penalty)
@@ -980,11 +983,17 @@ class RuleGenEnv(gym.Env):
         rule_len = len(self._rule_tokenize(rule_text))
 
         # dynamic FP penalty schedule
-        progress = min(self.total_steps, self.curriculum_steps) / self.curriculum_steps
-        curr_penalty = (
-            self.fp_penalty_start
-            + (self.fp_penalty_end - self.fp_penalty_start) * progress
-        )
+        if self.total_steps < self.fp_penalty_delay:
+            curr_penalty = 0.0
+        else:
+            progress = min(
+                self.total_steps - self.fp_penalty_delay,
+                self.curriculum_steps,
+            ) / self.curriculum_steps
+            curr_penalty = (
+                self.fp_penalty_start
+                + (self.fp_penalty_end - self.fp_penalty_start) * progress
+            )
 
         _, FP, _, _ = counts
         n = len(clean_set)

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -338,16 +338,20 @@ def test_fp_penalty_curriculum(tmp_path, monkeypatch):
         fp_penalty_start=1.0,
         fp_penalty_end=0.0,
         curriculum_steps=10,
+        fp_penalty_delay=5,
     )
     monkeypatch.setattr(
         env.evaluator, "evaluate_rule", lambda *a, **k: (0.5, 0.5, 0.0, (0, 1, 0, 0))
     )
-    env.total_steps = 0
+    env.total_steps = 5
     r1, m1, _ = env._compute_reward("", update_stats=False)
-    env.total_steps = 10
+    env.total_steps = 15
     r2, m2, _ = env._compute_reward("", update_stats=False)
     assert r2 > r1
     assert m1["fp_penalty"] > m2["fp_penalty"]
+    env.total_steps = 3
+    _, m0, _ = env._compute_reward("", update_stats=False)
+    assert m0["fp_penalty"] == 0.0
 
 
 def test_rule_len_penalty_curriculum(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `fp_penalty_delay` parameter to `RuleGenEnv`
- skip FP penalty until delay steps pass
- propagate new option through CLI and config
- update unit test for the new behaviour

## Testing
- `pytest tests/test_rl_env.py::test_fp_penalty_curriculum -q` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_6880b9329340832e9743f38d392bc392