### PR TITLE
Update rulegen defaults

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -15,8 +15,8 @@ env:
   off_target_penalty_start: 0.25
   off_target_penalty_end: 0.25
   off_target_steps: 20000
-  no_tp_penalty: 0.2
-  improve_bonus: 0.1
+  no_tp_penalty: 1.0
+  improve_bonus: 0.2
   reward_weights:
     f1_clean: 0.5
     f1_dummy: 0.4

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -704,8 +704,9 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         no_tp_penalty=float(
             args.no_tp_penalty
             if args.no_tp_penalty is not None
-            else env_cfg.get("no_tp_penalty", 0.2)
+            else env_cfg.get("no_tp_penalty", 1.0)
         ),
+        improve_bonus=float(env_cfg.get("improve_bonus", 0.2)),
         use_lookahead=getattr(args, "use_lookahead", False),
         single_target_mode=getattr(args, "single_target_mode", False),
         meta_path=getattr(args, "meta_path", None),
@@ -947,7 +948,8 @@ def cmd_generate(args: argparse.Namespace) -> None:
                 off_target_penalty_start=args.off_target_penalty_start,
                 off_target_penalty_end=args.off_target_penalty_end,
                 off_target_steps=args.off_target_steps,
-                no_tp_penalty=args.no_tp_penalty,
+                no_tp_penalty=args.no_tp_penalty if args.no_tp_penalty is not None else 1.0,
+                improve_bonus=0.2,
             )
             agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
             agent.load(args.agent_checkpoint)
@@ -970,7 +972,8 @@ def cmd_generate(args: argparse.Namespace) -> None:
             off_target_penalty_start=args.off_target_penalty_start,
             off_target_penalty_end=args.off_target_penalty_end,
             off_target_steps=args.off_target_steps,
-            no_tp_penalty=args.no_tp_penalty,
+            no_tp_penalty=args.no_tp_penalty if args.no_tp_penalty is not None else 1.0,
+            improve_bonus=0.2,
         )
         agent = PPORuleAgent(env, seed=args.seed, use_hint=True)
         agent.load(args.agent_checkpoint)
@@ -1267,6 +1270,7 @@ def _build_parser() -> argparse.ArgumentParser:
     pt.add_argument(
         "--no-tp-penalty",
         type=float,
+        default=1.0,
         help="Penalty when rule matches no dummy samples",
     )
     pt.add_argument(
@@ -1361,6 +1365,7 @@ def _build_parser() -> argparse.ArgumentParser:
     gen.add_argument(
         "--no-tp-penalty",
         type=float,
+        default=1.0,
         help="Penalty when rule matches no dummy samples",
     )
     gen.add_argument(


### PR DESCRIPTION
## Summary
- raise `no_tp_penalty` and `improve_bonus` defaults in PPO config
- propagate new defaults through `rulegen_cli`

## Testing
- `pytest tests/test_rulegen_cli.py::test_build_parser_accepts_embed_dir -q`

------
https://chatgpt.com/codex/tasks/task_e_6880bbd3f754832e9443a699918bda1c