### PR TITLE
Enable PPO reward auto-adjust

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -29,9 +29,9 @@ env:
     delta_f1_clean: -0.1  # decrement for f1_clean weight
 
 auto_adjust:
-  threshold: 0.1
-  delta_f1_dummy: 0.1
-  delta_f1_clean: -0.1
+  threshold: 0.15
+  delta_f1_dummy: 0.05
+  delta_f1_clean: -0.05
 
 model:
   ## 정책 네트워크 종류: "gru" (default), "attn" 또는 GPT 모델명(e.g. "gpt2-small")

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -903,7 +903,25 @@ def _cli():
     parser.add_argument("--save", type=str, default=None)
     parser.add_argument("--smoke_test", action="store_true")
     parser.add_argument("--accum-steps", type=int, default=1)
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Optional YAML config with auto_adjust settings",
+    )
     args = parser.parse_args()
+
+    auto_adjust = None
+    if args.config:
+        try:
+            import yaml  # type: ignore
+
+            with open(args.config, "r", encoding="utf-8") as f:
+                cfg = yaml.safe_load(f)
+            if isinstance(cfg, dict):
+                auto_adjust = cfg.get("auto_adjust")
+        except Exception:
+            _LOG.warning("Failed to load config: %s", args.config, exc_info=True)
 
     env = RuleGenEnv(
         rule_type="yara",
@@ -921,7 +939,11 @@ def _cli():
 
     if args.smoke_test:
         _LOG.info("Running smoke‑test (%d timesteps) …", args.timesteps)
-    agent.train(total_timesteps=args.timesteps, save_path=args.save)
+    agent.train(
+        total_timesteps=args.timesteps,
+        save_path=args.save,
+        auto_adjust=auto_adjust,
+    )
 
     if args.save:
         agent.save(args.save)


### PR DESCRIPTION
## Summary
- tweak `configs/rulegen/ppo.yaml` to enable automatic reward adjustments
- allow `rulegen.rl_agent` CLI to load `auto_adjust` config and pass it to `PPORuleAgent.train()`

## Testing
- `pytest tests/test_logger_memory.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: yara-python)*

------
https://chatgpt.com/codex/tasks/task_e_6880bec58650832eb49b83deb3bbb307