### PR TITLE
Enable reward shaping option

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -150,3 +150,17 @@ python -m cli.rulegen_cli ppo-train \
 이렇게 하면 룰이 완성되기 전에 얻는 보상을 통해 탐색이 촉진되어 보상 희소성을
 완화할 수 있습니다.
 
+### Reward Shaping
+
+초기 학습 단계에서 유용한 토큰을 모두 포함한 규칙 작성을 유도하기 위해
+잠재 보상 shaping 을 사용할 수 있습니다. CLI에서 `--use-shaping` 옵션을
+주면 힌트 토큰이 핵심 토큰(`core_tokens`)으로 설정되어 shaping 보상이
+활성화됩니다.
+
+```bash
+python -m cli.rulegen_cli ppo-train \
+    --train-features feats.json \
+    --dataset-dir data/splits \
+    --use-shaping
+```
+

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -708,10 +708,12 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         ),
         improve_bonus=float(env_cfg.get("improve_bonus", 0.2)),
         use_lookahead=getattr(args, "use_lookahead", False),
+        use_shaping=getattr(args, "use_shaping", False),
         single_target_mode=getattr(args, "single_target_mode", False),
         meta_path=getattr(args, "meta_path", None),
         tokenizer=policy_net,
         max_hint_tokens=getattr(args, "max_hint_tokens", None),
+        core_tokens=hint_tokens if getattr(args, "use_shaping", False) else None,
     )
 
     adjust_interval = int(adjust_cfg.get("interval", 0))
@@ -1241,6 +1243,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--use-lookahead",
         action="store_true",
         help="Use classifier probability as interim reward for partial rules",
+    )
+    pt.add_argument(
+        "--use-shaping",
+        action="store_true",
+        help="Enable potential based reward shaping using hint tokens as core tokens",
     )
     pt.add_argument(
         "--single-target-mode",


### PR DESCRIPTION
## Summary
- add `--use-shaping` CLI flag
- pass `core_tokens` to env when shaping is enabled
- document reward shaping usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6880c15a58c0832ea81b1016bfff8f65