### PR TITLE
Add rule length penalty delay

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -16,6 +16,7 @@ env:
   off_target_penalty_end: 0.25
   off_target_steps: 20000
   no_tp_penalty: 1.0
+  rule_len_penalty_delay: 0
   improve_bonus: 0.2
   reward_weights:
     f1_clean: 0.5

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -640,6 +640,12 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
                 env_cfg.get("rule_len_steps", env_cfg.get("curriculum_steps", 20000)),
             )
         )
+        rldelay = int(
+            phase1.get(
+                "rule_len_penalty_delay",
+                env_cfg.get("rule_len_penalty_delay", 0),
+            )
+        )
     else:
         rw = args.reward_weights or env_cfg.get("reward_weights")
         fps = env_cfg.get("fp_penalty_start", 0.01)
@@ -660,6 +666,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             if args.rule_len_steps is not None
             else env_cfg.get("rule_len_steps", env_cfg.get("curriculum_steps", 20000))
         )
+        rldelay = int(
+            args.rule_len_penalty_delay
+            if args.rule_len_penalty_delay is not None
+            else env_cfg.get("rule_len_penalty_delay", 0)
+        )
 
     env = rulegen.make_env(
         rule_type=env_cfg.get("mode", "yara"),
@@ -678,6 +689,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         rule_len_penalty_start=rlps,
         rule_len_penalty_end=rlpe,
         rule_len_steps=rlstep,
+        rule_len_penalty_delay=rldelay,
         off_target_penalty=float(
             args.off_target_penalty
             if args.off_target_penalty is not None
@@ -1294,6 +1306,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--rule-len-steps",
         type=int,
         help="Steps over which to anneal the rule length penalty",
+    )
+    pt.add_argument(
+        "--rule-len-penalty-delay",
+        type=int,
+        help="Steps to delay application of rule length penalty",
     )
     pt.add_argument("--num-steps", type=int, default=1024, help="PPO rollout 길이")
     pt.add_argument("--minibatch-size", type=int, default=64)

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -604,6 +604,18 @@ class PPORuleAgent:
             if hasattr(pbar, "update"):
                 pbar.update(1)
 
+            # ── max_len schedule ─────────────────────────────
+            delay_active = (
+                self.env.total_steps < getattr(self.env, "rule_len_penalty_delay", 0)
+            )
+            if delay_active:
+                if not getattr(self.env, "_delay_active", False):
+                    self.env._delay_active = True
+                    self.env.max_len = 50
+            elif getattr(self.env, "_delay_active", False):
+                self.env._delay_active = False
+                self.env.max_len = getattr(self.env, "_orig_max_len", self.env.max_len)
+
             # ── dynamic max_len schedule
             progress_ratio = global_step / float(total_timesteps)
             self.entropy_coef = self.entropy_coef_init + (
@@ -611,6 +623,7 @@ class PPORuleAgent:
             ) * progress_ratio
             if (
                 not self._max_len_updated
+                and not getattr(self.env, "_delay_active", False)
                 and global_step >= 50_000
                 and self.env.max_len < 128
             ):

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -131,6 +131,7 @@ class RuleGenEnv(gym.Env):
         rule_len_penalty_start: float | None = None,
         rule_len_penalty_end: float | None = None,
         rule_len_steps: int | None = None,
+        rule_len_penalty_delay: int = 0,
         improve_bonus: float = 0.1,
     ):
         """
@@ -174,6 +175,7 @@ class RuleGenEnv(gym.Env):
         rule_len_penalty_start : rule_len 패널티 초기 가중치 (기본 reward_weights['rule_len'])
         rule_len_penalty_end   : rule_len_steps 소모 후 적용할 가중치
         rule_len_steps : rule_len 패널티 스케줄 총 스텝 수
+        rule_len_penalty_delay : 일정 스텝 이후부터 rule_len 패널티 스케줄 적용
         """
         super().__init__()
         torch.manual_seed(seed)
@@ -225,6 +227,7 @@ class RuleGenEnv(gym.Env):
         self.id2token = {i: t for t, i in self.token2id.items()}
         self.vocab_size = len(self.token2id)
         self.max_len = max_len
+        self._orig_max_len = max_len
 
         # categorize tokens for action masking
         self._colon_id = self.token2id.get(":")
@@ -308,6 +311,7 @@ class RuleGenEnv(gym.Env):
             float(self.reward_weights["rule_len"]) if rule_len_penalty_end is None else float(rule_len_penalty_end)
         )
         self.rule_len_steps = max(1, int(rule_len_steps if rule_len_steps is not None else self.curriculum_steps))
+        self.rule_len_penalty_delay = int(rule_len_penalty_delay)
 
         # Hint features / tokens
         self.hint_features = hint_features or []
@@ -1002,7 +1006,13 @@ class RuleGenEnv(gym.Env):
         w = self.reward_weights
         weighted_f1 = w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy
 
-        progress_len = min(self.total_steps, self.rule_len_steps) / self.rule_len_steps
+        if self.total_steps < self.rule_len_penalty_delay:
+            progress_len = 0.0
+        else:
+            progress_len = min(
+                self.total_steps - self.rule_len_penalty_delay,
+                self.rule_len_steps,
+            ) / self.rule_len_steps
         curr_rule_len_w = self.rule_len_penalty_start + (
             self.rule_len_penalty_end - self.rule_len_penalty_start
         ) * progress_len

--- a/tests/test_ppo_train_cli.py
+++ b/tests/test_ppo_train_cli.py
@@ -984,6 +984,8 @@ def test_rule_len_penalty_cli(tmp_path, monkeypatch):
             "-0.1",
             "--rule-len-steps",
             "5",
+            "--rule-len-penalty-delay",
+            "3",
             "--epochs",
             "1",
             "--cpu",
@@ -994,6 +996,7 @@ def test_rule_len_penalty_cli(tmp_path, monkeypatch):
     assert captured["rule_len_penalty_start"] == 0.1
     assert captured["rule_len_penalty_end"] == -0.1
     assert captured["rule_len_steps"] == 5
+    assert captured["rule_len_penalty_delay"] == 3
 
 
 def test_generate_hints_from_explainer(tmp_path, monkeypatch):

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -388,6 +388,41 @@ def test_rule_len_penalty_curriculum(tmp_path, monkeypatch):
     assert m1["rule_len_weight"] > m2["rule_len_weight"]
 
 
+def test_rule_len_penalty_delay(tmp_path, monkeypatch):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    torch.save(clean, tmp_path / "clean.pt")
+    torch.save(dummy, tmp_path / "dummy.pt")
+
+    vocab_file = tmp_path / "vocab.json"
+    json.dump({"A": 0, "<PAD>": 1, "<END>": 2}, vocab_file.open("w"))
+
+    env = RuleGenEnv(
+        rule_type="yara",
+        vocab_file=vocab_file,
+        dataset_dir=tmp_path,
+        max_len=4,
+        classifier_checkpoint=tmp_path / "clf.pt",
+        device="cpu",
+        rule_len_penalty_start=0.0,
+        rule_len_penalty_end=-1.0,
+        rule_len_steps=10,
+        rule_len_penalty_delay=5,
+    )
+
+    monkeypatch.setattr(
+        env.evaluator,
+        "evaluate_rule",
+        lambda *a, **k: (0.0, 0.0, 0.0, (0, 0, 0, 0)),
+    )
+    env.total_steps = 2
+    _, m_before, _ = env._compute_reward("A", update_stats=False)
+    env.total_steps = 7
+    _, m_after, _ = env._compute_reward("A", update_stats=False)
+    assert m_before["rule_len_weight"] == 0.0
+    assert m_after["rule_len_weight"] < m_before["rule_len_weight"]
+
+
 def test_lookahead_reward(tmp_path):
     clean = [HeteroData()]
     dummy = [HeteroData()]


### PR DESCRIPTION
## Summary
- expose `rule_len_penalty_delay` in `RuleGenEnv`
- respect the delay when scheduling rule length penalty
- set short `max_len` until the delay expires in training loop
- support new option in CLI and config
- test coverage for the delay feature

## Testing
- `pip install -q transformers==4.38.2`
- `pytest -k rule_len_penalty_delay -vv` *(fails: ModuleNotFoundError: No module named 'models.contrast')*

------
https://chatgpt.com/codex/tasks/task_e_6880c4392ef4832e80ba4bdb34f097e1