### PR TITLE
Adjust entropy scheduling

### DIFF
--- a/configs/rulegen/ppo.yaml
+++ b/configs/rulegen/ppo.yaml
@@ -47,8 +47,9 @@ ppo:
   lam: 0.9
   clip_eps: 0.1
   kl_target: 0.02
-  entropy_coef: 0.05
+  entropy_coef: 0.01
   entropy_coef_final: 0.0
+  entropy_coef_steps: 700000
   vf_coef: 0.5
   rollout_steps: 2048
   minibatch_size: 256

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -735,6 +735,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
     sched_cfg = cfg.get("scheduler", {})
     sched_name = sched_cfg.get("name")
     total_steps = int(sched_cfg.get("total_updates", args.epochs))
+    ppo_cfg = cfg.get("ppo", {})
     agent_kwargs = {
         "use_amp": getattr(args, "amp", False),
         "checkpoint_layers": getattr(args, "grad_checkpoint", False),
@@ -746,6 +747,12 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         "accum_steps": args.accum_steps,
         "use_hint": True,
     }
+    if "entropy_coef" in ppo_cfg:
+        agent_kwargs["entropy_coef"] = float(ppo_cfg["entropy_coef"])
+    if "entropy_coef_final" in ppo_cfg:
+        agent_kwargs["entropy_coef_final"] = float(ppo_cfg["entropy_coef_final"])
+    if "entropy_coef_steps" in ppo_cfg:
+        agent_kwargs["entropy_coef_steps"] = int(ppo_cfg["entropy_coef_steps"])
     if any(
         getattr(args, n) is not None for n in ["lora_r", "lora_alpha", "lora_dropout"]
     ):

--- a/src/rulegen/rl_agent.py
+++ b/src/rulegen/rl_agent.py
@@ -267,6 +267,7 @@ class PPORuleAgent:
         vf_coef: float = 0.5,
         entropy_coef: float = 0.05,
         entropy_coef_final: float = 0.01,
+        entropy_coef_steps: int | None = None,
         max_grad_norm: float = 0.5,
         n_steps: int = 1024,
         n_epochs: int = 4,
@@ -294,6 +295,9 @@ class PPORuleAgent:
         self.entropy_coef = entropy_coef
         self.entropy_coef_init = entropy_coef
         self.entropy_coef_final = entropy_coef_final
+        self.entropy_coef_steps = (
+            int(entropy_coef_steps) if entropy_coef_steps is not None else None
+        )
         self.max_grad_norm = max_grad_norm
         self.n_steps = n_steps
         self.n_epochs = n_epochs
@@ -616,8 +620,13 @@ class PPORuleAgent:
                 self.env._delay_active = False
                 self.env.max_len = getattr(self.env, "_orig_max_len", self.env.max_len)
 
-            # ── dynamic max_len schedule
-            progress_ratio = global_step / float(total_timesteps)
+            # ── entropy coefficient schedule
+            progress_limit = (
+                self.entropy_coef_steps
+                if self.entropy_coef_steps is not None
+                else total_timesteps
+            )
+            progress_ratio = min(global_step, progress_limit) / float(progress_limit)
             self.entropy_coef = self.entropy_coef_init + (
                 self.entropy_coef_final - self.entropy_coef_init
             ) * progress_ratio


### PR DESCRIPTION
## Summary
- lower PPO entropy_coef to 0.01 and set entropy_coef_steps to 700k so entropy decay completes at 70% of training
- add support for entropy_coef_steps in `PPORuleAgent`
- read PPO entropy settings from YAML config in CLI

## Testing
- `pytest -q` *(fails: 7 failed, 29 passed, 69 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6880c9b3ad20832eb01ceb32c246949c