### PR TITLE
Add CLI for explainer rule evaluation

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -52,6 +52,7 @@ _COMMANDS: Final[Dict[str, str]] = {
     "train-resgcl": "train_res_gcl",
     "train-explainer": "explainer_train",
     "explain-refine": "explain_refine",
+    "explainer-rule-eval": "explainer_rule_eval",
 }
 
 # Expose publicly in case external plugins need to introspect

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Generate and evaluate a YARA rule from an explainer output."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import torch
+from torch_geometric.data import HeteroData
+
+from rulegen.feature_miner import FeatureMiner
+from rulegen.yara_builder import YaraBuilder
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+def _load_saliency(path: Path) -> Dict[str, torch.Tensor] | torch.Tensor:
+    """Load saliency tensor from ``.pt`` or JSON."""
+    if path.suffix == ".pt":
+        sal = torch.load(path, map_location="cpu", weights_only=False)
+    else:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(obj, list):
+            sal = torch.tensor(obj)
+        elif isinstance(obj, dict):
+            sal = {k: torch.tensor(v) for k, v in obj.items()}
+        else:
+            raise TypeError("saliency json must be list or dict")
+    return sal
+
+
+def _compute_saliency_with_explainer(
+    graph: HeteroData,
+    classifier_ckpt: Path,
+    explainer_ckpt: Path | None,
+    device: torch.device,
+) -> Dict[str, torch.Tensor]:
+    """Return node saliency from an explainer or plain gradients."""
+    from src.models.gnn.res_wrapper import RESGCLClassifier
+
+    clf = RESGCLClassifier.load_pretrained(str(classifier_ckpt), map_location=device)
+    clf.to(device).eval()
+
+    g = graph.to(device)
+
+    if explainer_ckpt is not None:
+        explainer = torch.load(explainer_ckpt, map_location=device, weights_only=False)
+        if hasattr(explainer, "eval"):
+            explainer.eval()
+        clf_for_embed = (
+            getattr(explainer, "model", None)
+            or getattr(explainer, "classifier", None)
+            or clf
+        )
+        from src.cli.explainer_train import _compute_node_embeddings
+
+        embeds = _compute_node_embeddings(g, clf_for_embed.encoder)
+        mask_prob = explainer(g, embeddings=embeds)
+        if hasattr(explainer, "get_node_saliency"):
+            saliency = explainer.get_node_saliency(g, mask_prob)
+        else:
+            saliency = mask_prob  # type: ignore[assignment]
+    else:
+        for nt in g.node_types:
+            x = g[nt].get("x")
+            if x is not None and torch.is_floating_point(x):
+                g[nt].x = x.clone().detach().requires_grad_(True)
+        out = clf(g)
+        out = out if not isinstance(out, (list, tuple)) else out[0]
+        out = out.view(-1).sum()
+        clf.zero_grad()
+        out.backward()
+        saliency = {}
+        for nt in g.node_types:
+            x = g[nt].get("x")
+            if x is not None and x.grad is not None:
+                saliency[nt] = x.grad.abs().sum(dim=1).detach().cpu()
+            else:
+                saliency[nt] = torch.zeros(g[nt].num_nodes)
+    return saliency
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Evaluate explainer output by generating a YARA rule",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--graph", type=Path, required=True, help="HeteroData graph")
+    p.add_argument("--sample", type=Path, required=True, help="Binary to scan")
+    p.add_argument("--saliency", type=Path, help="Precomputed node saliency (.pt or json)")
+    p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
+    p.add_argument("--classifier", type=Path, required=True, help="Classifier checkpoint")
+    p.add_argument("--device", type=str, default="cpu")
+    p.add_argument("--top-k", type=int, default=40)
+    p.add_argument("--min-saliency", type=float, default=1e-3)
+    p.add_argument(
+        "--condition-type",
+        choices=["any", "all", "percentage"],
+        default="any",
+        help="YARA condition type",
+    )
+    p.add_argument("--percentage", type=int, default=70, help="Percentage value if using percentage condition")
+    p.add_argument("--clean-sample", type=Path, help="Optional clean sample for FP check")
+    p.add_argument("--out", type=Path, help="Save JSON result path")
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+
+    device = torch.device(args.device)
+
+    graph: HeteroData = torch.load(args.graph, map_location="cpu", weights_only=False)
+
+    if args.saliency:
+        saliency = _load_saliency(args.saliency)
+    else:
+        saliency = _compute_saliency_with_explainer(
+            graph, args.classifier, args.explainer, device
+        )
+
+    miner = FeatureMiner(top_k=args.top_k, min_saliency=args.min_saliency)
+    features = miner.mine(graph, saliency)
+
+    builder = YaraBuilder(condition_type=args.condition_type, percentage=args.percentage)
+    rule_text = builder.build(features)
+    builder.validate(rule_text)
+
+    import yara
+
+    compiled = yara.compile(source=rule_text)
+    matches = compiled.match(str(args.sample))
+    detected = bool(matches)
+
+    # coverage based on matched string lengths
+    coverage = 0.0
+    if detected:
+        total = sum(len(s[2]) for s in matches[0].strings)
+        try:
+            size = args.sample.stat().st_size
+            coverage = float(total) / float(size) if size > 0 else 0.0
+        except Exception:
+            coverage = 0.0
+
+    # compute saliency stats
+    if isinstance(saliency, dict):
+        flat = torch.cat(list(saliency.values()))
+    else:
+        flat = saliency
+    num_selected = min(len(features), flat.numel())
+    avg_importance = float(flat.topk(num_selected).values.mean().item()) if num_selected > 0 else 0.0
+    mask_sparsity = float(1.0 - num_selected / flat.numel()) if flat.numel() > 0 else 0.0
+
+    result: Dict[str, Any] = {
+        "detected": detected,
+        "rule_length": len(features),
+        "avg_importance": avg_importance,
+        "mask_sparsity": mask_sparsity,
+        "coverage": coverage,
+    }
+
+    if args.clean_sample:
+        result["false_positive"] = bool(compiled.match(str(args.clean_sample)))
+
+    text = json.dumps(result, ensure_ascii=False, indent=2)
+    if args.out:
+        args.out.write_text(text, encoding="utf-8")
+    print(text)
+
+
+__all__ = ["main"]
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1,0 +1,44 @@
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+
+def test_cli_runs_and_writes_json(tmp_path):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(2, 1)
+    g["bb"].num_nodes = 2
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [1]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.5, 0.1])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    out = tmp_path / "res.json"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--out",
+        str(out),
+    ])
+
+    data = json.loads(out.read_text())
+    assert "detected" in data


### PR DESCRIPTION
## Summary
- implement `explainer_rule_eval` command
- register it in the main CLI mapping
- test that the CLI runs and writes JSON

## Testing
- `pytest -q tests/test_explainer_rule_eval_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d7e7bd84832e8729bf3683c9772d