### PR TITLE
Improve logging in explainer rule CLI

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -7,11 +7,16 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
+import logging
+from src.common.utils import get_logger
+
 import torch
 from torch_geometric.data import HeteroData
 
 from rulegen.feature_miner import FeatureMiner
 from rulegen.yara_builder import YaraBuilder
+
+LOGGER = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -42,12 +47,19 @@ def _compute_saliency_with_explainer(
     """Return node saliency from an explainer or plain gradients."""
     from src.models.gnn.res_wrapper import RESGCLClassifier
 
+    LOGGER.info(f"Loading classifier from {classifier_ckpt}")
     clf = RESGCLClassifier.load_pretrained(str(classifier_ckpt), map_location=device)
     clf.to(device).eval()
 
     g = graph.to(device)
 
+    LOGGER.info(
+        "Generating saliency via %s",
+        "explainer" if explainer_ckpt is not None else "gradients",
+    )
+
     if explainer_ckpt is not None:
+        LOGGER.info(f"Loading explainer from {explainer_ckpt}")
         explainer = torch.load(explainer_ckpt, map_location=device, weights_only=False)
         if hasattr(explainer, "eval"):
             explainer.eval()
@@ -110,17 +122,26 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--percentage", type=int, default=70, help="Percentage value if using percentage condition")
     p.add_argument("--clean-sample", type=Path, help="Optional clean sample for FP check")
     p.add_argument("--out", type=Path, help="Save JSON result path")
+    p.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
     return p
 
 
 def main(argv: list[str] | None = None) -> None:
     args = build_parser().parse_args(argv)
 
+    if args.verbose:
+        LOGGER.setLevel(logging.DEBUG)
+
     device = torch.device(args.device)
 
+    LOGGER.info(f"Loading graph from {args.graph}")
     graph: HeteroData = torch.load(args.graph, map_location="cpu", weights_only=False)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        node_counts = {nt: int(graph[nt].num_nodes) for nt in graph.node_types}
+        LOGGER.debug("Node counts: %s", node_counts)
 
     if args.saliency:
+        LOGGER.info(f"Loading saliency from {args.saliency}")
         saliency = _load_saliency(args.saliency)
     else:
         saliency = _compute_saliency_with_explainer(
@@ -129,7 +150,10 @@ def main(argv: list[str] | None = None) -> None:
 
     miner = FeatureMiner(top_k=args.top_k, min_saliency=args.min_saliency)
     features = miner.mine(graph, saliency)
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.debug("Mined %d features", len(features))
 
+    LOGGER.info("Building YARA rule")
     builder = YaraBuilder(condition_type=args.condition_type, percentage=args.percentage)
     rule_text = builder.build(features)
     builder.validate(rule_text)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -10,7 +10,7 @@ import torch
 from torch_geometric.data import HeteroData
 
 
-def test_cli_runs_and_writes_json(tmp_path):
+def test_cli_runs_and_writes_json(tmp_path, caplog):
     g = HeteroData()
     g["bb"].x = torch.zeros(2, 1)
     g["bb"].num_nodes = 2
@@ -27,6 +27,7 @@ def test_cli_runs_and_writes_json(tmp_path):
 
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     out = tmp_path / "res.json"
+    caplog.set_level("INFO")
     mod.main([
         "--graph",
         str(gpath),
@@ -42,3 +43,5 @@ def test_cli_runs_and_writes_json(tmp_path):
 
     data = json.loads(out.read_text())
     assert "detected" in data
+    assert any("Building YARA rule" in rec.message for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- add structured logger to `explainer_rule_eval`
- log model loading, saliency generation, and rule building steps
- support `--verbose` option and emit debug details
- update test to confirm CLI works with logging enabled

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880de304ac0832e8dc56b6ec0d73f50