### PR TITLE
Fix saliency tuple output

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -72,6 +72,8 @@ def _compute_saliency_with_explainer(
 
         embeds = _compute_node_embeddings(g, clf_for_embed.encoder)
         mask_prob = explainer(g, embeddings=embeds)
+        if isinstance(mask_prob, (tuple, list)):
+            mask_prob = mask_prob[0]
         if hasattr(explainer, "get_node_saliency"):
             saliency = explainer.get_node_saliency(g, mask_prob)
         else:

--- a/tests/test_explainer_rule_eval_saliency.py
+++ b/tests/test_explainer_rule_eval_saliency.py
@@ -1,0 +1,70 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+import types
+import sys
+
+
+class DummyClassifier:
+    def __init__(self):
+        self.encoder = object()
+
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+
+class DummyExplainer:
+    def __init__(self, classifier):
+        self.model = classifier
+        self.last_mask = None
+
+    def eval(self):
+        return self
+
+    def __call__(self, g, embeddings=None):
+        return torch.tensor([0.5]), {"aux": True}
+
+    def get_node_saliency(self, g, mask):
+        self.last_mask = mask
+        return {nt: torch.ones(g[nt].num_nodes) for nt in g.node_types}
+
+
+def test_compute_saliency_handles_tuple(monkeypatch):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    for h in mod.LOGGER.handlers:
+        h.filters.clear()
+
+    g = HeteroData()
+    g["n"].x = torch.zeros(1, 1)
+    g["n"].num_nodes = 1
+    g[("n", "r", "n")].edge_index = torch.tensor([[0], [0]])
+
+    classifier = DummyClassifier()
+    explainer = DummyExplainer(classifier)
+
+    monkeypatch.setattr(
+        "src.models.gnn.res_wrapper.RESGCLClassifier.load_pretrained",
+        lambda *a, **k: classifier,
+    )
+    monkeypatch.setattr(torch, "load", lambda *a, **k: explainer)
+    stub = types.ModuleType("src.cli.explainer_train")
+    stub._compute_node_embeddings = lambda g, enc: {"n": torch.zeros(g["n"].num_nodes, 1)}
+    sys.modules["src.cli.explainer_train"] = stub
+
+    sal = mod._compute_saliency_with_explainer(
+        g, Path("clf.pt"), Path("exp.pt"), torch.device("cpu")
+    )
+
+    assert isinstance(sal, dict)
+    assert sal["n"].tolist() == [1.0]
+    assert isinstance(explainer.last_mask, torch.Tensor)


### PR DESCRIPTION
## Summary
- handle tuple outputs from explainers
- test saliency computation when explainer returns extra output

## Testing
- `pytest tests/test_explainer_rule_eval_saliency.py::test_compute_saliency_handles_tuple -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e02edb20832eb06b3dafb68ef1cf