### PR TITLE
Fix MemoryUsageFilter log formatting

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -73,7 +73,10 @@ class MemoryUsageFilter(logging.Filter):
         else:
             record.vram = "n/a"
         if "RAM" not in record.getMessage():
-            record.msg = f"RAM {record.ram} | VRAM {record.vram} | {record.getMessage()}"
+            record.msg = (
+                f"RAM {record.ram} | VRAM {record.vram} | {record.getMessage()}"
+            )
+            record.args = None
         return True
 
 


### PR DESCRIPTION
## Summary
- fix `MemoryUsageFilter` to clear `record.args` after updating message
- ensure logging works with placeholder-based log messages

## Testing
- `pytest -q tests/test_logger_memory.py::test_logger_adds_memory_usage`


------
https://chatgpt.com/codex/tasks/task_e_6880e5cb88a8832eb6c9560d8e25dfde