### PR TITLE
Add GraphConv fallback in explainer embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,3 +354,9 @@ python -m cli.explainer_train feature-mine \
 Epoch 1 Val Fidelity: 0.9123  Val Sparsity: 0.0731  Val Stability: 0.0321  Val Necessity: 0.1452
 ```
 `--plot-path` 옵션으로 저장되는 학습 곡선 그래프에도 Stability와 Necessity 추이가 함께 표시됩니다.
+
+구버전(단일 `GraphConv`) 기반 인코더로 학습한 explainer 체크포인트는
+`HeteroConv` 구조로 업데이트된 모델과 호환되지 않을 수 있습니다.
+이 경우 동일한 그래프 데이터로 `cli.explainer_train`을 다시 실행하여
+새로운 체크포인트를 생성하거나, 내부 구조를 변환하는 별도 스크립트를
+통해 재저장해야 합니다.

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -51,6 +51,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torch_geometric.data import HeteroData
+from torch_geometric.nn import HeteroConv, GraphConv
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
@@ -1597,7 +1598,21 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
 
     # Step 2: Pass through convolutional layers
     for conv in encoder.convs:
-        x_dict = conv(x_dict, graph.edge_index_dict)
+        if isinstance(conv, HeteroConv):
+            x_dict = conv(x_dict, graph.edge_index_dict)
+        elif isinstance(conv, GraphConv):
+            new_dict: dict[str, torch.Tensor] = {}
+            for (src, rel, dst) in graph.edge_types:
+                if src not in x_dict or dst not in x_dict:
+                    continue
+                edge_index = graph[(src, rel, dst)].edge_index
+                out = conv((x_dict[src], x_dict[dst]), edge_index)
+                new_dict[dst] = new_dict.get(dst, 0) + out
+            for nt in x_dict:
+                new_dict.setdefault(nt, x_dict[nt])
+            x_dict = new_dict
+        else:
+            x_dict = conv(x_dict, graph.edge_index_dict)
         x_dict = {k: encoder.drop(encoder.act(v)) for k, v in x_dict.items()}
 
     # Step 3: Determine the target embedding dimension from the encoder's architecture

--- a/tests/test_compute_node_embeddings_conv.py
+++ b/tests/test_compute_node_embeddings_conv.py
@@ -1,0 +1,69 @@
+import types
+import importlib
+import sys
+import torch
+from torch_geometric.data import HeteroData
+from torch_geometric.nn import GraphConv, HeteroConv
+
+# Ensure optional modules are available to avoid import errors during setup
+aug = importlib.import_module("src.augment")
+sys.modules.setdefault("augment", aug)
+for name, module in list(sys.modules.items()):
+    if name.startswith("src.augment"):
+        sys.modules.setdefault(name.replace("src.", "", 1), module)
+exp = importlib.import_module("src.explain")
+sys.modules.setdefault("explain", exp)
+for name, module in list(sys.modules.items()):
+    if name.startswith("src.explain"):
+        sys.modules.setdefault(name.replace("src.", "", 1), module)
+for mod_name in ["gensim", "gensim.downloader", "sentencepiece"]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+sys.modules.setdefault("gensim.models", types.ModuleType("gensim.models"))
+sys.modules["gensim.models"].Word2Vec = object
+
+et = importlib.import_module("src.cli.explainer_train")
+
+
+def _make_graph():
+    g = HeteroData()
+    g["a"].x = torch.zeros(2, 4)
+    g["b"].x = torch.zeros(2, 4)
+    g["a"].num_nodes = 2
+    g["b"].num_nodes = 2
+    g[("a", "r", "b")].edge_index = torch.tensor([[0, 1], [0, 1]])
+    return g
+
+
+def _make_encoder(conv):
+    enc = types.SimpleNamespace()
+    enc.input_proj = torch.nn.ModuleDict({
+        "a": torch.nn.Linear(4, 4),
+        "b": torch.nn.Linear(4, 4),
+    })
+    enc.attr_names = {"a": [], "b": []}
+    enc.meta_embed = None
+    enc.convs = torch.nn.ModuleList([conv])
+    enc.drop = torch.nn.Identity()
+    enc.act = torch.nn.Identity()
+    enc.out_proj = torch.nn.Linear(4, 2)
+    return enc
+
+
+def test_graphconv_embeddings():
+    g = _make_graph()
+    conv = GraphConv(4, 4)
+    enc = _make_encoder(conv)
+    out = et._compute_node_embeddings(g, enc)
+    assert set(out.keys()) == {"a", "b"}
+    assert out["b"].shape == (2, 4)
+
+
+def test_heteroconv_embeddings():
+    g = _make_graph()
+    conv = HeteroConv({("a", "r", "b"): GraphConv(4, 4)}, aggr="sum")
+    enc = _make_encoder(conv)
+    out = et._compute_node_embeddings(g, enc)
+    assert set(out.keys()) == {"b"}
+    assert out["b"].shape == (2, 4)
+


### PR DESCRIPTION
## Summary
- handle GraphConv layers when computing node embeddings
- document retraining or conversion requirement for old checkpoints
- add regression tests

## Testing
- `pytest tests/test_compute_node_embeddings_conv.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pefile')*

------
https://chatgpt.com/codex/tasks/task_e_6880e5b1d6f0832e912951f95350c67d