### PR TITLE
Improve node embedding conv handling

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import gc
 import math
+import inspect
 from pathlib import Path
 from contextlib import nullcontext
 from functools import partial
@@ -51,7 +52,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torch_geometric.data import HeteroData
-from torch_geometric.nn import HeteroConv, GraphConv
+from torch_geometric.nn import HeteroConv, GraphConv, MessagePassing
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
@@ -1600,7 +1601,7 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
     for conv in encoder.convs:
         if isinstance(conv, HeteroConv):
             x_dict = conv(x_dict, graph.edge_index_dict)
-        elif isinstance(conv, GraphConv):
+        elif isinstance(conv, MessagePassing):
             new_dict: dict[str, torch.Tensor] = {}
             for (src, rel, dst) in graph.edge_types:
                 if src not in x_dict or dst not in x_dict:
@@ -1612,7 +1613,15 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
                 new_dict.setdefault(nt, x_dict[nt])
             x_dict = new_dict
         else:
-            x_dict = conv(x_dict, graph.edge_index_dict)
+            sig = inspect.signature(conv.forward)
+            params = sig.parameters
+            if "edge_index" in params or "edge_index_dict" in params:
+                try:
+                    x_dict = conv(x_dict, graph.edge_index_dict)
+                except TypeError:
+                    x_dict = conv(x_dict, edge_index_dict=graph.edge_index_dict)
+            else:
+                x_dict = conv(x_dict)
         x_dict = {k: encoder.drop(encoder.act(v)) for k, v in x_dict.items()}
 
     # Step 3: Determine the target embedding dimension from the encoder's architecture


### PR DESCRIPTION
## Summary
- support `MessagePassing` conv modules in `_compute_node_embeddings`
- fallback to inspecting `edge_index` arguments for other custom convs

## Testing
- `pytest -q tests/test_compute_node_embeddings_conv.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6880f72225dc832ea9eb986fa4af391e