### PR TITLE
Fix CAPA rule temp files cleanup

### DIFF
--- a/src/evaluation/rule_evaluator.py
+++ b/src/evaluation/rule_evaluator.py
@@ -5,6 +5,7 @@ from typing import Sequence, Tuple
 import logging
 import json
 import subprocess
+import tempfile
 from pathlib import Path
 
 try:
@@ -52,6 +53,7 @@ class RuleEvaluator:
 
         try:
             rule_type = "capa" if rule_text.lstrip().startswith("rule:") else "yara"
+            rule_path = None
 
             if rule_type == "yara":
                 if yara is None:
@@ -65,14 +67,15 @@ class RuleEvaluator:
                         return False
 
             else:  # capa rule
-                with subprocess.NamedTemporaryFile("w", suffix=".yml", delete=False) as tmp:
+                with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as tmp:
                     tmp.write(rule_text)
                     tmp.flush()
+                    rule_path = tmp.name
 
                 def _match(path: Path) -> bool:
                     try:
                         proc = subprocess.run(
-                            ["capa", str(path), "-r", tmp.name, "--json"],
+                            ["capa", str(path), "-r", rule_path, "--json"],
                             capture_output=True,
                             text=True,
                             check=False,
@@ -142,3 +145,9 @@ class RuleEvaluator:
         except Exception as exc:  # pragma: no cover - unexpected evaluation errors
             log.warning("rule evaluation failed: %s", exc)
             return 0.0, 0.0, -1.0, (0, 0, 0, 0)
+        finally:
+            if rule_path is not None:
+                try:
+                    Path(rule_path).unlink(missing_ok=True)
+                except Exception:
+                    pass

--- a/tests/test_rule_evaluator.py
+++ b/tests/test_rule_evaluator.py
@@ -4,6 +4,7 @@ pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
 import torch
+import subprocess
 from torch_geometric.data import HeteroData
 from src.evaluation.rule_evaluator import RuleEvaluator
 
@@ -23,3 +24,29 @@ def test_evaluate_rule_failure_returns_negative(tmp_path):
     assert (f1_clean, f1_dummy) == (0.0, 0.0)
     assert certified_r < 0
     assert counts == (0, 0, 0, 0)
+
+
+def test_evaluate_rule_capa(monkeypatch):
+    evaluator = RuleEvaluator(clf=DummyClf())
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+
+    class DummyProc:
+        def __init__(self):
+            self.returncode = 0
+            self.stdout = "{}"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: DummyProc())
+
+    rule = """rule:
+  meta:
+    name: test
+  features:
+    - or:
+"""
+
+    f1_clean, f1_dummy, certified_r, counts = evaluator.evaluate_rule(rule, clean, dummy)
+
+    assert isinstance(f1_clean, float)
+    assert isinstance(f1_dummy, float)
+


### PR DESCRIPTION
## Summary
- import `tempfile` for NamedTemporaryFile
- use `tempfile.NamedTemporaryFile` when evaluating CAPA rules
- remove the temporary CAPA rule file after evaluation
- add CAPA evaluation test

## Testing
- `pytest tests/test_rule_evaluator.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6880fa315838832eb8ac3835143a42ac