### PR TITLE
Implement capa CLI match in CapaBuilder

### DIFF
--- a/src/rulegen/capa_builder.py
+++ b/src/rulegen/capa_builder.py
@@ -36,6 +36,9 @@ import random
 import re
 import string
 import uuid
+import json
+import subprocess
+import shutil
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
 
@@ -260,9 +263,88 @@ class CapaBuilder:
         self._loaded = text
 
     def match_file(self, sample_path: Path) -> bool:
-        """Placeholder matcher; real CAPA engine is optional."""
-        # Without capa engine we cannot perform matching. Always return False.
-        return False
+        """Return ``True`` if any loaded rule matches ``sample_path``."""
+
+        if not getattr(self, "_loaded", None):
+            return False
+
+        rule_text = self._loaded
+
+        # Try the python API first as it's faster than spawning a process.
+        try:  # pragma: no cover - optional dependency
+            import capa.main as capa_main  # type: ignore
+        except Exception:  # pragma: no cover - python API missing
+            capa_main = None
+
+        if capa_main is not None:
+            import io
+            import sys
+            import tempfile
+            rule_path = None
+            try:
+                with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as tmp:
+                    tmp.write(rule_text)
+                    tmp.flush()
+                    rule_path = tmp.name
+
+                buf = io.StringIO()
+                old_out = sys.stdout
+                sys.stdout = buf
+                rc = 0
+                try:
+                    capa_main.main([str(sample_path), "-r", rule_path, "--json"])
+                except SystemExit as e:  # pragma: no cover - capa exits normally
+                    rc = int(e.code) if isinstance(e.code, int) else 1
+                finally:
+                    sys.stdout = old_out
+
+                if rc != 0:
+                    return False
+
+                try:
+                    js = json.loads(buf.getvalue())
+                except Exception:
+                    return False
+                finally:
+                    if rule_path:
+                        Path(rule_path).unlink(missing_ok=True)
+
+                return bool(js.get("rules"))
+            finally:
+                if rule_path:
+                    Path(rule_path).unlink(missing_ok=True)
+
+        # Fallback to capa CLI
+        exe = shutil.which("capa")
+        if not exe:
+            return False
+
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as tmp:
+            tmp.write(rule_text)
+            tmp.flush()
+            rule_path = tmp.name
+
+        try:
+            proc = subprocess.run(
+                [exe, str(sample_path), "-r", rule_path, "--json"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            return False
+        finally:
+            Path(rule_path).unlink(missing_ok=True)
+
+        if proc.returncode != 0:
+            return False
+        try:
+            js = json.loads(proc.stdout)
+        except Exception:
+            return False
+        return bool(js.get("rules"))
 
     # ────────────────────────────── 내부 헬퍼 ───────────────────
     def _atoms_to_features_yaml(self, atoms: List[str]) -> List[str]:

--- a/tests/test_capa_builder_match.py
+++ b/tests/test_capa_builder_match.py
@@ -1,0 +1,38 @@
+import sys
+import subprocess
+import shutil
+from pathlib import Path
+
+from src.rulegen.capa_builder import CapaBuilder
+
+
+def test_match_file_cli(monkeypatch, tmp_path):
+    rule_file = tmp_path / "rule.yml"
+    rule_file.write_text(
+        """rule:\n  meta:\n    name: test\n  features:\n    - or:\n      - string: foo\n"""
+    )
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    builder = CapaBuilder()
+    builder.load(rule_file)
+
+    monkeypatch.setitem(sys.modules, "capa", None)
+    monkeypatch.setattr(shutil, "which", lambda name: name)
+
+    class DummyProc:
+        def __init__(self):
+            self.returncode = 0
+            self.stdout = '{"rules": ["test"]}'
+
+    called = {}
+
+    def fake_run(cmd, capture_output, text, check):
+        called["cmd"] = cmd
+        return DummyProc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert builder.match_file(sample)
+    assert called["cmd"][0] == "capa"
+    assert called["cmd"][1] == str(sample)


### PR DESCRIPTION
## Summary
- enhance CapaBuilder.match_file() with capa CLI and optional Python API
- add regression test verifying match_file works via subprocess

## Testing
- `pytest tests/test_capa_map_atom.py tests/test_capa_builder_match.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fc56ba0c832e97d58bd2e8d843b9