### PR TITLE
Fix CAPA rulegen default extension

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -1008,7 +1008,10 @@ def cmd_generate(args: argparse.Namespace) -> None:
         else:
             ts = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
             out_dir = Path("models") / "rulebank" / args.rule_type
-            out_path = out_dir / f"generated_{ts}.yar"
+            default_ext = ".yar"
+            if args.rule_type == "capa":
+                default_ext = ".yml"
+            out_path = out_dir / f"generated_{ts}{default_ext}"
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("w", encoding="utf-8") as fp:
             fp.write(rules_text)
@@ -1411,7 +1414,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     gen.add_argument(
         "--out",
-        help="Output rule file (.yar/.yml); defaults to models/rulebank/<type>/generated_<timestamp>.yar",
+        help="Output rule file (.yar/.yml); defaults to models/rulebank/<type>/generated_<timestamp>.yar (.yml for capa)",
     )
     gen.set_defaults(func=cmd_generate)
 

--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -28,7 +28,11 @@ from __future__ import annotations
 
 from typing import Union, Optional, List, Dict, Callable
 from pathlib import Path
-from torch.serialization import add_safe_globals
+try:  # torch<2.3 does not expose add_safe_globals
+    from torch.serialization import add_safe_globals
+except Exception:  # pragma: no cover - optional API
+    def add_safe_globals(*_args, **_kwargs):
+        pass
 import logging
 
 import torch

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -94,3 +94,60 @@ def test_generate_parser_accepts_target_graph(monkeypatch, tmp_path):
     )
     assert args.target_graph == str(tg)
     assert args.func == rulegen_cli.cmd_generate
+
+
+def test_generate_default_capa_extension(monkeypatch, tmp_path):
+    import importlib
+    import types
+    import argparse
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+
+    class DummyAgent:
+        def __init__(self, env, seed=None, use_hint=False):
+            pass
+
+        def load(self, ckpt):
+            pass
+
+        def sample_rules(self, n, temperature):
+            return [["token"]] * n
+
+    class DummyBuilder:
+        def build(self, rule):
+            return "rule"
+
+    def fake_lazy_imports():
+        rulegen_cli.PPORuleAgent = DummyAgent
+        rulegen_cli.YaraBuilder = DummyBuilder
+        rulegen_cli.CapaBuilder = DummyBuilder
+        rulegen_cli.rulegen = types.SimpleNamespace(make_env=lambda **kw: None)
+
+    monkeypatch.setattr(rulegen_cli, "_lazy_imports", fake_lazy_imports)
+    monkeypatch.chdir(tmp_path)
+
+    feat_fp = tmp_path / "feats.json"
+    feat_fp.write_text('[{"features": ["foo"]}]')
+
+    args = argparse.Namespace(
+        agent_checkpoint="agent.pt",
+        features=str(feat_fp),
+        n_rules=1,
+        temperature=1.0,
+        out=None,
+        rule_type="capa",
+        seed=42,
+        target_graph=None,
+        single_target_mode=False,
+        off_target_penalty=None,
+        off_target_penalty_start=None,
+        off_target_penalty_end=None,
+        off_target_steps=None,
+        no_tp_penalty=1.0,
+        reward_weights=None,
+    )
+
+    rulegen_cli.cmd_generate(args)
+
+    out_files = list((tmp_path / "models" / "rulebank" / "capa").glob("generated_*.yml"))
+    assert len(out_files) == 1


### PR DESCRIPTION
## Summary
- adjust default extension for CAPA rule generation to `.yml`
- clarify CLI help message on default extension
- add fallback when `torch.serialization.add_safe_globals` is missing
- add regression test for CAPA default extension

## Testing
- `pytest -k rulegen_cli -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*

------
https://chatgpt.com/codex/tasks/task_e_6880ffe8c2c0832e88b8e784edf57510