### PR TITLE
Improve wrapper conv handling

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1619,7 +1619,15 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
                 try:
                     x_dict = conv(x_dict, graph.edge_index_dict)
                 except TypeError:
-                    x_dict = conv(x_dict, edge_index_dict=graph.edge_index_dict)
+                    LOGGER.debug(
+                        "Wrapper layer detected; retrying with keyword argument"
+                    )
+                    try:
+                        x_dict = conv(
+                            x_dict, edge_index_dict=graph.edge_index_dict
+                        )
+                    except TypeError:
+                        x_dict = conv(x_dict)
             else:
                 x_dict = conv(x_dict)
         x_dict = {k: encoder.drop(encoder.act(v)) for k, v in x_dict.items()}


### PR DESCRIPTION
## Summary
- add fallback for wrapper conv layers in explainer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6881065b9ce0832e97b48247a1cdd6ec