### PR TITLE
Handle missing edge types in HeteroConv

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -1600,7 +1600,18 @@ def _compute_node_embeddings(graph: HeteroData, encoder) -> dict[str, torch.Tens
     # Step 2: Pass through convolutional layers
     for conv in encoder.convs:
         if isinstance(conv, HeteroConv):
-            x_dict = conv(x_dict, graph.edge_index_dict)
+            new_dict: dict[str, torch.Tensor] = {}
+            for (src, rel, dst), sub_conv in conv.convs.items():
+                if (src, rel, dst) not in graph.edge_index_dict:
+                    continue
+                if src not in x_dict or dst not in x_dict:
+                    continue
+                edge_index = graph[(src, rel, dst)].edge_index
+                out = sub_conv((x_dict[src], x_dict[dst]), edge_index)
+                new_dict[dst] = new_dict.get(dst, 0) + out
+            for nt in x_dict:
+                new_dict.setdefault(nt, x_dict[nt])
+            x_dict = new_dict
         elif isinstance(conv, MessagePassing):
             new_dict: dict[str, torch.Tensor] = {}
             for (src, rel, dst) in graph.edge_types:

--- a/tests/test_compute_node_embeddings_conv.py
+++ b/tests/test_compute_node_embeddings_conv.py
@@ -67,3 +67,16 @@ def test_heteroconv_embeddings():
     assert set(out.keys()) == {"b"}
     assert out["b"].shape == (2, 4)
 
+
+def test_heteroconv_missing_edge_type():
+    g = _make_graph()
+    conv = HeteroConv(
+        {("a", "r", "b"): GraphConv(4, 4), ("b", "s", "a"): GraphConv(4, 4)},
+        aggr="sum",
+    )
+    enc = _make_encoder(conv)
+    out = et._compute_node_embeddings(g, enc)
+    assert set(out.keys()) == {"a", "b"}
+    assert out["a"].shape == (2, 4)
+    assert out["b"].shape == (2, 4)
+


### PR DESCRIPTION
## Summary
- guard `_compute_node_embeddings` against missing edge types for `HeteroConv`
- test missing edge type branch in `_compute_node_embeddings`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688112be22e8832ea2378363e488e1cd