### PR TITLE
Fix device handling in PGExplainer

### DIFF
--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -131,7 +131,8 @@ class PGExplainer(nn.Module):
             self.edge_mlps[key] = nn.Sequential(*layers)
 
         self.register_buffer("tau", torch.tensor(tau_start))
-        self.to(device or "cpu")
+        self.device = torch.device(device or "cpu")
+        self.to(self.device)
 
     # ------------------------------------------------------------------ #
     def forward(


### PR DESCRIPTION
## Summary
- store the selected device in `PGExplainer`

## Testing
- `pytest -q` *(fails: pandas, pefile, transformers and other modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68811bc6472c832e8cfd4012e5325b73