### PR TITLE
Fix PGExplainer forward device handling

### DIFF
--- a/src/explain/pg_explainer.py
+++ b/src/explain/pg_explainer.py
@@ -168,7 +168,7 @@ class PGExplainer(nn.Module):
         if not x_dict:
             LOGGER.warning("x_dict is empty in PGExplainer.forward.")
             return torch.empty(
-                0, device=self.device
+                0, device=self.tau.device
             )  # Return empty tensor if no embeddings
 
         LOGGER.debug(


### PR DESCRIPTION
## Summary
- avoid AttributeError in `PGExplainer.forward`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68811bc6472c832e8cfd4012e5325b73