### PR TITLE
Fix saliency pre-processing in rule evaluator

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -12,6 +12,7 @@ from src.common.utils import get_logger
 
 import torch
 from torch_geometric.data import HeteroData
+from src.graphs.dataset.graph_dataset import GraphDataset
 
 from rulegen.feature_miner import FeatureMiner
 from rulegen.yara_builder import YaraBuilder
@@ -38,6 +39,21 @@ def _load_saliency(path: Path) -> Dict[str, torch.Tensor] | torch.Tensor:
     return sal
 
 
+def _ensure_fallback_features(
+    g: HeteroData, all_node_types: list[str], fallback_dim: int = 1
+) -> None:
+    """Attach ones features for node types missing ``x``."""
+    for nt in all_node_types:
+        if nt in g.node_types and not hasattr(g[nt], "x"):
+            if g[nt].num_nodes > 0:
+                LOGGER.info(
+                    "Node type '%s' has no features. Creating fallback features with dim=%d.",
+                    nt,
+                    fallback_dim,
+                )
+                g[nt].x = torch.ones((g[nt].num_nodes, fallback_dim))
+
+
 def _compute_saliency_with_explainer(
     graph: HeteroData,
     classifier_ckpt: Path,
@@ -51,7 +67,12 @@ def _compute_saliency_with_explainer(
     clf = RESGCLClassifier.load_pretrained(str(classifier_ckpt), map_location=device)
     clf.to(device).eval()
 
-    g = graph.to(device)
+    g = GraphDataset._ensure_num_nodes(graph)
+    g = GraphDataset._ensure_x(g)
+    g = GraphDataset._ensure_meta_ids(g, clf.encoder.attr_names)
+    all_node_types = list(clf.encoder.metadata[0])
+    _ensure_fallback_features(g, all_node_types, fallback_dim=1)
+    g = g.to(device)
 
     LOGGER.info(
         "Generating saliency via %s",

--- a/tests/test_explainer_rule_eval_saliency.py
+++ b/tests/test_explainer_rule_eval_saliency.py
@@ -12,9 +12,15 @@ import types
 import sys
 
 
+class DummyEncoder:
+    def __init__(self):
+        self.attr_names: dict[str, list[str]] = {}
+        self.metadata = (["n"], [])
+
+
 class DummyClassifier:
     def __init__(self):
-        self.encoder = object()
+        self.encoder = DummyEncoder()
 
     def to(self, device):
         return self


### PR DESCRIPTION
## Summary
- ensure rule evaluator builds fallback node features before computing saliency
- adjust saliency helper test for new encoder expectations

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py tests/test_explainer_rule_eval_saliency.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68812595d978832e9e4a3af4d8b408af