### PR TITLE
Add progress bar for batch explainer eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import logging
-from src.common.utils import get_logger
+from src.common.utils import get_logger, tqdm_wrap
 
 import torch
 from torch_geometric.data import HeteroData
@@ -303,7 +303,10 @@ def main(argv: list[str] | None = None) -> None:
         df = pd.read_csv(args.meta_csv)
         rows = df[df.get("label", 1) == 1]
         results: list[dict[str, Any]] = []
-        for _, row in rows.iterrows():
+        row_iter = tqdm_wrap(
+            rows.iterrows(), desc="graphs", total=len(rows), unit="graph"
+        )
+        for _, row in row_iter:
             sha = row["sha256"]
             filename = row.get("filename") or row.get("name") or f"{sha}.bin"
             gpath = Path(args.graph_dir) / f"{sha}.pt"


### PR DESCRIPTION
## Summary
- add optional tqdm progress bar to `explainer_rule_eval` when using `--graph-dir`

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q`
- `pytest tests/test_explainer_rule_eval_saliency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6881339e9b48832eaac8ba51f5971fd1