### PR TITLE
Implement soft necessity pruning

### DIFF
--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -160,53 +160,81 @@ def compute_necessity_loss(
     explainer: PGExplainer,
     model: RESGCLClassifier,
     full_score: torch.Tensor,
+    use_hard_prune: bool = False,
 ) -> torch.Tensor:
-    """Return necessity loss based on dropping salient nodes."""
+    """Return necessity loss based on dropping salient nodes.
+
+    When ``use_hard_prune`` is ``False`` (default) edges incident to the most
+    salient nodes are softly masked by setting their mask probability to ``0``.
+    If ``True`` the previous behaviour of physically removing those nodes is
+    used instead.
+    """
 
     saliency = explainer.get_node_saliency(graph, mask_prob)
     keep_idx: dict[str, torch.Tensor] = {}
+    drop_mask: dict[str, torch.Tensor] = {}
     for nt, score in saliency.items():
         if score.numel() == 0:
             continue
         k = max(1, int(score.numel() * 0.2))
         _, drop_idx = torch.topk(score, k)
-        mask = torch.ones(score.size(0), dtype=torch.bool, device=score.device)
-        mask[drop_idx] = False
-        keep_idx[nt] = mask.nonzero(as_tuple=False).view(-1)
+        keep = torch.ones(score.size(0), dtype=torch.bool, device=score.device)
+        keep[drop_idx] = False
+        keep_idx[nt] = keep.nonzero(as_tuple=False).view(-1)
+        dm = torch.zeros(score.size(0), dtype=torch.bool, device=score.device)
+        dm[drop_idx] = True
+        drop_mask[nt] = dm
 
-    selected = {}
-    for nt in graph.node_types:
-        device = getattr(graph[nt], "device", None)
-        if device is None:
-            for val in graph[nt].values():
-                if isinstance(val, torch.Tensor):
-                    device = val.device
-                    break
-        if device is None:
-            device = mask_prob.device
-        mask = torch.zeros(graph[nt].num_nodes, dtype=torch.float, device=device)
-        idx = keep_idx.get(nt)
-        if idx is not None and idx.numel() > 0:
-            mask[idx] = 1.0
-        selected[nt] = mask
+    if use_hard_prune:
+        selected = {}
+        for nt in graph.node_types:
+            device = getattr(graph[nt], "device", None)
+            if device is None:
+                for val in graph[nt].values():
+                    if isinstance(val, torch.Tensor):
+                        device = val.device
+                        break
+            if device is None:
+                device = mask_prob.device
+            mask = torch.zeros(graph[nt].num_nodes, dtype=torch.float, device=device)
+            idx = keep_idx.get(nt)
+            if idx is not None and idx.numel() > 0:
+                mask[idx] = 1.0
+            selected[nt] = mask
 
-    pruner = GraphPruner(selected, thresh=0.5, keep_edge_attrs="mask")
-    pruned = pruner.apply(graph)
+        pruner = GraphPruner(selected, thresh=0.5, keep_edge_attrs="mask")
+        pruned = pruner.apply(graph)
 
-    masks = []
-    ptr = 0
-    for et in iter_edge_types(graph, explainer.view):
-        num_e = graph[et].edge_index.size(1)
-        orig = mask_prob[ptr : ptr + num_e]
-        keep = pruned[et].edge_mask
-        if keep.numel() == 0:
-            masks.append(orig.new_empty(0))
-        else:
-            masks.append(orig[keep])
-        ptr += num_e
-        del pruned[et].edge_mask
-    pruned_mask = torch.cat(masks) if masks else mask_prob.new_empty(0)
-    logits = _soft_masked_score(pruned, 1 - pruned_mask, explainer.view, model)
+        masks = []
+        ptr = 0
+        for et in iter_edge_types(graph, explainer.view):
+            num_e = graph[et].edge_index.size(1)
+            orig = mask_prob[ptr : ptr + num_e]
+            keep = pruned[et].edge_mask
+            if keep.numel() == 0:
+                masks.append(orig.new_empty(0))
+            else:
+                masks.append(orig[keep])
+            ptr += num_e
+            del pruned[et].edge_mask
+        pruned_mask = torch.cat(masks) if masks else mask_prob.new_empty(0)
+        logits = _soft_masked_score(pruned, 1 - pruned_mask, explainer.view, model)
+    else:
+        pruned_mask = mask_prob.clone()
+        ptr = 0
+        for et in iter_edge_types(graph, explainer.view):
+            num_e = graph[et].edge_index.size(1)
+            mask_slice = pruned_mask[ptr : ptr + num_e]
+            src, dst = graph[et].edge_index
+            dm_src = drop_mask.get(et[0])
+            dm_dst = drop_mask.get(et[2])
+            if dm_src is not None:
+                mask_slice[dm_src[src]] = 0.0
+            if dm_dst is not None:
+                mask_slice[dm_dst[dst]] = 0.0
+            pruned_mask[ptr : ptr + num_e] = mask_slice
+            ptr += num_e
+        logits = _soft_masked_score(graph, pruned_mask, explainer.view, model)
     target = 1 - torch.sigmoid(full_score.detach())
     return F.binary_cross_entropy_with_logits(logits, target)
 
@@ -532,6 +560,11 @@ def build_parser() -> argparse.ArgumentParser:
     g.add_argument("--stability-start", type=int, default=0, help="Epoch to start applying stability loss")
     g.add_argument("--necessity-weight", type=float, default=0.0, help="Weight for necessity loss")
     g.add_argument("--necessity-start", type=int, default=0, help="Epoch to start applying necessity loss")
+    g.add_argument(
+        "--hard-necessity",
+        action="store_true",
+        help="Use hard node pruning when computing necessity loss",
+    )
     add_common(g)
     g.set_defaults(func=train_global)
 
@@ -1879,7 +1912,12 @@ def _evaluate_global(
                     g, explainer, mask_prob, True
                 )
                 nec_loss = compute_necessity_loss(
-                    g, mask_prob, explainer, model, full_score
+                    g,
+                    mask_prob,
+                    explainer,
+                    model,
+                    full_score,
+                    use_hard_prune=args.hard_necessity,
                 )
                 loss = explainer.loss(
                     full_score,
@@ -2221,7 +2259,12 @@ def train_global(args: argparse.Namespace) -> None:
                         )
                     if epoch >= args.necessity_start and args.necessity_weight > 0:
                         loss = loss + args.necessity_weight * compute_necessity_loss(
-                            g, mask_prob, explainer, model, full_score
+                            g,
+                            mask_prob,
+                            explainer,
+                            model,
+                            full_score,
+                            use_hard_prune=args.hard_necessity,
                         )
 
                 loss_item = loss.item()

--- a/tests/test_necessity_loss.py
+++ b/tests/test_necessity_loss.py
@@ -55,5 +55,10 @@ def test_compute_necessity_loss_runs():
     mask_prob = explainer(g)
     full_score = torch.tensor(0.0)
     loss = compute_necessity_loss(g, mask_prob, explainer, model, full_score)
+    loss_hard = compute_necessity_loss(
+        g, mask_prob, explainer, model, full_score, use_hard_prune=True
+    )
     assert isinstance(loss, torch.Tensor)
     assert loss.numel() == 1
+    assert isinstance(loss_hard, torch.Tensor)
+    assert loss_hard.numel() == 1


### PR DESCRIPTION
## Summary
- soften `compute_necessity_loss` by zeroing mask probabilities of salient nodes
- keep previous hard-pruning approach as an option via `--hard-necessity`
- adapt training and evaluation code to pass the new option
- update necessity loss test

## Testing
- `pytest tests/test_necessity_loss.py -q` *(fails: torch missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881afaf6f38832ea68c0459ac8951a7