### PR TITLE
Add necessity weight scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ python -m cli.explainer_train global \
        --soft-mask-epochs 5  # train with soft masks for the first N epochs
        --hard-mask-mode weight  # use straight-through weighted masking
        --stability-weight 0.1 --stability-start 10 \
-       --necessity-weight 0.05 --necessity-start 20
+       --necessity-weight 0.05 --necessity-start 20 \
+       --necessity-schedule  # weight increases from 1e-4 after start
 #
 # `gamma`는 마스크 확률의 엔트로피에 곱해지는 가중치로, 0보다 크게 설정하면
 # 탐색을 유도하는 항이 손실 함수에 추가됩니다. 기본값은 0.01이며 값이 너무

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -561,6 +561,35 @@ def build_parser() -> argparse.ArgumentParser:
     g.add_argument("--necessity-weight", type=float, default=0.0, help="Weight for necessity loss")
     g.add_argument("--necessity-start", type=int, default=0, help="Epoch to start applying necessity loss")
     g.add_argument(
+        "--necessity-schedule",
+        action="store_true",
+        help="Enable scheduling for necessity weight",
+    )
+    g.add_argument(
+        "--necessity-weight-start",
+        type=float,
+        default=1e-4,
+        help="Initial necessity weight when scheduling is enabled",
+    )
+    g.add_argument(
+        "--necessity-schedule-factor",
+        type=float,
+        default=1.5,
+        help="Multiplicative factor to increase necessity weight at each schedule step",
+    )
+    g.add_argument(
+        "--necessity-schedule-epochs",
+        type=int,
+        default=10,
+        help="Number of epochs between necessity weight increases",
+    )
+    g.add_argument(
+        "--necessity-weight-max",
+        type=float,
+        default=None,
+        help="Maximum value for necessity weight under the schedule. Defaults to --necessity-weight",
+    )
+    g.add_argument(
         "--hard-necessity",
         action="store_true",
         help="Use hard node pruning when computing necessity loss",
@@ -1965,6 +1994,14 @@ def _schedule_beta(current: float, args: argparse.Namespace, cap: float) -> floa
     return min(new_beta, cap)
 
 
+def _schedule_necessity_weight(
+    current: float, args: argparse.Namespace, cap: float
+) -> float:
+    """Return the next necessity weight value according to the schedule."""
+    new_weight = current * args.necessity_schedule_factor
+    return min(new_weight, cap)
+
+
 import matplotlib.pyplot as plt
 
 
@@ -2188,6 +2225,24 @@ def train_global(args: argparse.Namespace) -> None:
             f"target={beta_cap}"
         )
 
+    nec_cap = (
+        args.necessity_weight
+        if args.necessity_weight_max is None
+        else args.necessity_weight_max
+    )
+    current_necessity_weight = (
+        args.necessity_weight_start
+        if args.necessity_schedule
+        else args.necessity_weight
+    )
+    if args.necessity_schedule:
+        LOGGER.info(
+            f"Necessity weight scheduling enabled: start={args.necessity_weight_start}, "
+            f"factor={args.necessity_schedule_factor}, "
+            f"epochs_per_step={args.necessity_schedule_epochs}, "
+            f"target={nec_cap}"
+        )
+
     with logging_redirect_tqdm():
         for epoch in range(args.epochs):
             total_loss = 0.0
@@ -2257,8 +2312,8 @@ def train_global(args: argparse.Namespace) -> None:
                         loss = loss + args.stability_weight * compute_stability_loss(
                             g, explainer, mask_prob, use_hard_mask
                         )
-                    if epoch >= args.necessity_start and args.necessity_weight > 0:
-                        loss = loss + args.necessity_weight * compute_necessity_loss(
+                    if epoch >= args.necessity_start and current_necessity_weight > 0:
+                        loss = loss + current_necessity_weight * compute_necessity_loss(
                             g,
                             mask_prob,
                             explainer,
@@ -2295,7 +2350,13 @@ def train_global(args: argparse.Namespace) -> None:
                 if graph_count > 0:
                     avg_loss_so_far = total_loss / graph_count
                     pbar.set_description(
-                        f"Epoch {epoch + 1}/{args.epochs} (Loss: {avg_loss_so_far:.4f}, Beta: {current_beta:.4f})"
+                        "Epoch {}/{} (Loss: {:.4f}, Beta: {:.4f}, NecW: {:.4f})".format(
+                            epoch + 1,
+                            args.epochs,
+                            avg_loss_so_far,
+                            current_beta,
+                            current_necessity_weight,
+                        )
                     )
 
             if graph_count > 0:
@@ -2346,6 +2407,19 @@ def train_global(args: argparse.Namespace) -> None:
                 current_beta = _schedule_beta(current_beta, args, beta_cap)
                 LOGGER.info(
                     f"Beta scheduled update: new beta is {current_beta:.6f}"
+                )
+
+            if (
+                args.necessity_schedule
+                and (epoch + 1) >= args.necessity_start
+                and (epoch + 1 - args.necessity_start) % args.necessity_schedule_epochs == 0
+            ):
+                current_necessity_weight = _schedule_necessity_weight(
+                    current_necessity_weight, args, nec_cap
+                )
+                LOGGER.info(
+                    "Necessity weight scheduled update: "
+                    f"new weight is {current_necessity_weight:.6f}"
                 )
 
             # Decay tau at the end of the epoch

--- a/tests/test_explainer_train_global_cli.py
+++ b/tests/test_explainer_train_global_cli.py
@@ -51,6 +51,11 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
         captured["stability_start"] = args.stability_start
         captured["necessity_weight"] = args.necessity_weight
         captured["necessity_start"] = args.necessity_start
+        captured["necessity_schedule"] = args.necessity_schedule
+        captured["necessity_weight_start"] = args.necessity_weight_start
+        captured["necessity_schedule_factor"] = args.necessity_schedule_factor
+        captured["necessity_schedule_epochs"] = args.necessity_schedule_epochs
+        captured["necessity_weight_max"] = args.necessity_weight_max
 
     import torch.serialization
     monkeypatch.setattr(
@@ -91,3 +96,8 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
     assert captured["stability_start"] == 0
     assert captured["necessity_weight"] == 0.0
     assert captured["necessity_start"] == 0
+    assert captured["necessity_schedule"] is False
+    assert captured["necessity_weight_start"] == 1e-4
+    assert captured["necessity_schedule_factor"] == 1.5
+    assert captured["necessity_schedule_epochs"] == 10
+    assert captured["necessity_weight_max"] is None

--- a/tests/test_necessity_schedule.py
+++ b/tests/test_necessity_schedule.py
@@ -1,0 +1,29 @@
+import ast
+import pathlib
+import argparse
+import pytest
+
+src = pathlib.Path('src/cli/explainer_train.py').read_text()
+module = ast.parse(src)
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name == '_schedule_necessity_weight':
+        code = ast.get_source_segment(src, node)
+        break
+else:
+    raise AssertionError('_schedule_necessity_weight not found')
+namespace = {'argparse': argparse}
+exec(code, namespace)
+_schedule_necessity_weight = namespace['_schedule_necessity_weight']
+
+def test_schedule_necessity_reaches_target():
+    args = argparse.Namespace(
+        necessity_weight=0.05,
+        necessity_schedule=True,
+        necessity_schedule_factor=10.0,
+        necessity_schedule_epochs=1,
+    )
+    cap = args.necessity_weight
+    weight = 1e-4
+    for _ in range(3):
+        weight = _schedule_necessity_weight(weight, args, cap)
+    assert weight == pytest.approx(args.necessity_weight)


### PR DESCRIPTION
## Summary
- add command line options for necessity weight scheduling
- implement necessity weight schedule in `train_global`
- multiply necessity loss by current scheduled weight
- update README documentation and CLI test
- add unit test for scheduling logic

## Testing
- `pytest tests/test_beta_schedule.py tests/test_necessity_schedule.py tests/test_explainer_train_global_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b2498260832ea82c6e075343510f