### PR TITLE
Add necessity drop ratio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ python -m cli.explainer_train global \
        --stability-weight 0.1 --stability-start 10 \
        --necessity-weight 0.05 --necessity-start 20 \
        --necessity-schedule  # weight increases from 1e-4 after start
+       --necessity-drop-ratio 0.2 \
 #
 # `gamma`는 마스크 확률의 엔트로피에 곱해지는 가중치로, 0보다 크게 설정하면
 # 탐색을 유도하는 항이 손실 함수에 추가됩니다. 기본값은 0.01이며 값이 너무

--- a/src/cli/explainer_train.py
+++ b/src/cli/explainer_train.py
@@ -161,13 +161,16 @@ def compute_necessity_loss(
     model: RESGCLClassifier,
     full_score: torch.Tensor,
     use_hard_prune: bool = False,
+    *,
+    drop_ratio: float = 0.2,
 ) -> torch.Tensor:
     """Return necessity loss based on dropping salient nodes.
 
-    When ``use_hard_prune`` is ``False`` (default) edges incident to the most
-    salient nodes are softly masked by setting their mask probability to ``0``.
-    If ``True`` the previous behaviour of physically removing those nodes is
-    used instead.
+    ``drop_ratio`` controls the fraction of the highest-scoring nodes that are
+    dropped when computing the loss. When ``use_hard_prune`` is ``False``
+    (default) edges incident to the selected nodes are softly masked by setting
+    their mask probability to ``0``. If ``True`` the previous behaviour of
+    physically removing those nodes is used instead.
     """
 
     saliency = explainer.get_node_saliency(graph, mask_prob)
@@ -176,7 +179,7 @@ def compute_necessity_loss(
     for nt, score in saliency.items():
         if score.numel() == 0:
             continue
-        k = max(1, int(score.numel() * 0.2))
+        k = max(1, int(score.numel() * drop_ratio))
         _, drop_idx = torch.topk(score, k)
         keep = torch.ones(score.size(0), dtype=torch.bool, device=score.device)
         keep[drop_idx] = False
@@ -593,6 +596,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--hard-necessity",
         action="store_true",
         help="Use hard node pruning when computing necessity loss",
+    )
+    g.add_argument(
+        "--necessity-drop-ratio",
+        type=float,
+        default=0.2,
+        help="Fraction of nodes to drop when computing necessity loss",
     )
     add_common(g)
     g.set_defaults(func=train_global)
@@ -1947,6 +1956,7 @@ def _evaluate_global(
                     model,
                     full_score,
                     use_hard_prune=args.hard_necessity,
+                    drop_ratio=args.necessity_drop_ratio,
                 )
                 loss = explainer.loss(
                     full_score,
@@ -2320,6 +2330,7 @@ def train_global(args: argparse.Namespace) -> None:
                             model,
                             full_score,
                             use_hard_prune=args.hard_necessity,
+                            drop_ratio=args.necessity_drop_ratio,
                         )
 
                 loss_item = loss.item()

--- a/tests/test_explainer_train_global_cli.py
+++ b/tests/test_explainer_train_global_cli.py
@@ -56,6 +56,7 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
         captured["necessity_schedule_factor"] = args.necessity_schedule_factor
         captured["necessity_schedule_epochs"] = args.necessity_schedule_epochs
         captured["necessity_weight_max"] = args.necessity_weight_max
+        captured["necessity_drop_ratio"] = args.necessity_drop_ratio
 
     import torch.serialization
     monkeypatch.setattr(
@@ -101,3 +102,4 @@ def test_global_cli_invokes(tmp_path, monkeypatch):
     assert captured["necessity_schedule_factor"] == 1.5
     assert captured["necessity_schedule_epochs"] == 10
     assert captured["necessity_weight_max"] is None
+    assert captured["necessity_drop_ratio"] == 0.2

--- a/tests/test_necessity_loss.py
+++ b/tests/test_necessity_loss.py
@@ -54,9 +54,17 @@ def test_compute_necessity_loss_runs():
     explainer = PGExplainer(model, {"n": 1}, [("n", "r", "n")], view="r")
     mask_prob = explainer(g)
     full_score = torch.tensor(0.0)
-    loss = compute_necessity_loss(g, mask_prob, explainer, model, full_score)
+    loss = compute_necessity_loss(
+        g, mask_prob, explainer, model, full_score, drop_ratio=0.2
+    )
     loss_hard = compute_necessity_loss(
-        g, mask_prob, explainer, model, full_score, use_hard_prune=True
+        g,
+        mask_prob,
+        explainer,
+        model,
+        full_score,
+        use_hard_prune=True,
+        drop_ratio=0.2,
     )
     assert isinstance(loss, torch.Tensor)
     assert loss.numel() == 1


### PR DESCRIPTION
## Summary
- add `--necessity-drop-ratio` CLI argument to control how many nodes get dropped
- expose the new argument in README usage example
- allow `compute_necessity_loss` to accept `drop_ratio`
- propagate argument in training code
- update CLI and loss unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6881b4ceb278832ea3af304bb63524f6