### PR TITLE
Filter internal function names in FeatureMiner

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -343,6 +343,11 @@ class FeatureMiner:
 
         # 1) API / 함수명
         name = _get("name") or _get("api")
+        if isinstance(name, str):
+            n = name.lower()
+            if n.startswith(("sub_", "nullsub", "loc_")) or n in {"start", "_start"}:
+                name = None
+
         chain_label = None
         if isinstance(name, str) and self._API_RX.fullmatch(name):
             candidates.append(f"call:{name}")

--- a/tests/test_feature_miner_internal_names.py
+++ b/tests/test_feature_miner_internal_names.py
@@ -1,0 +1,18 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_miner_filters_internal_function_names():
+    g = HeteroData()
+    g["func"].x = torch.zeros(1, 1)
+    g["func"].name = ["sub_1000"]
+    sal = torch.tensor([1.0])
+
+    feats = FeatureMiner(top_k=1)(g, sal)
+    assert "call:sub_1000" not in feats


### PR DESCRIPTION
## Summary
- filter internal function names like `sub_1234` when extracting API candidates
- add unit test for filtered internal names

## Testing
- `pytest tests/test_feature_miner_internal_names.py -q` *(fails: ModuleNotFoundError: No module named 'torch', tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6881e98453e4832e9a71ec2e3661ffdd