### PR TITLE
Handle section names in loaders and feature miner

### DIFF
--- a/src/graphs/loaders/ast_loader.py
+++ b/src/graphs/loaders/ast_loader.py
@@ -152,7 +152,13 @@ class ASTLoader(GraphLoaderBase):
             except ValueError:  # 혹시 10진수 문자열/정수일 때
                 vsize = int(sec.get("virtual_size", 0))
                 rsize = int(sec.get("raw_size", 0))
-            nodes.append({"id": nid, "kind": "section", "feat": [vsize, rsize]})
+            name = sec.get("name", "").strip()
+            nodes.append({
+                "id": nid,
+                "kind": "section",
+                "name": name,
+                "feat": [vsize, rsize],
+            })
             edges.append([root, nid])
 
         # 3) 엔트리포인트

--- a/src/graphs/loaders/cfg_loader.py
+++ b/src/graphs/loaders/cfg_loader.py
@@ -135,10 +135,14 @@ class CFGLoader(GraphLoaderBase):
             vsize = _hex_to_int(sec.get("virtual_size", 0))
             rsize = _hex_to_int(sec.get("raw_size",    0))
             addr  = _hex_to_int(sec.get("virtual_address", "0x0"))
-            nodes.append({"id": sid,
-                          "addr": addr,
-                          "kind": "section",
-                          "feat": [vsize, rsize]})
+            name = sec.get("name", "").strip()
+            nodes.append({
+                "id": sid,
+                "addr": addr,
+                "kind": "section",
+                "name": name,
+                "feat": [vsize, rsize],
+            })
             edges.append({"src": root_id, "dst": sid, "type": _EDGE_KIND_CONTAINS})
             sec_nodes.append((sid, sec))
 

--- a/src/graphs/loaders/fcg_loader.py
+++ b/src/graphs/loaders/fcg_loader.py
@@ -153,6 +153,7 @@ class FCGLoader(GraphLoaderBase):
                 {
                     "id": idx,
                     "name": f"sec_{idx}_{name}",
+                    "section_name": name,
                     "addr": addr,
                     "feat": [vsize],
                 }

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -374,7 +374,15 @@ class FeatureMiner:
             if self._HEX_RX.search(hx):
                 candidates.append(f"byte[{len(byte_arr)}]:{hx}")
 
-        # 5) 기타 Heuristic
+        # 5) section 이름
+        if ntype == "section":
+            sec = _get("name") or _get("section_name")
+            if isinstance(sec, str):
+                s = sec.strip("\x00 ").strip()
+                if s and s not in {".text", ".data", ".rdata"}:
+                    candidates.append(f'"{s}" ascii nocase')
+
+        # 6) 기타 Heuristic
         #    예) ntype == 'syscall' 등
         syscall = _get("syscall")
         if syscall is None and ntype == "syscall":
@@ -382,7 +390,7 @@ class FeatureMiner:
         if isinstance(syscall, str):
             candidates.append(f"syscall:{syscall}")
 
-        # 6) 파일 경로
+        # 7) 파일 경로
         path_val = _get("path")
         if path_val is None and ntype == "file":
             path_val = _get("name")
@@ -395,7 +403,7 @@ class FeatureMiner:
                     if seg:
                         candidates.append(f"path:{seg}")
 
-        # 7) 레지스트리 경로
+        # 8) 레지스트리 경로
         reg_val = _get("reg")
         if reg_val is None and ntype == "registry":
             reg_val = _get("name")
@@ -408,7 +416,7 @@ class FeatureMiner:
                     if seg:
                         candidates.append(f"reg:{seg}")
 
-        # 8) URL
+        # 9) URL
         url_val = _get("url")
         if isinstance(url_val, str):
             u = self._STRING_FILTER.sub("", url_val)

--- a/tests/test_ast_loader.py
+++ b/tests/test_ast_loader.py
@@ -32,3 +32,16 @@ def test_parse_missing_kind_assigns_unknown(tmp_path, caplog):
     assert any("node missing 'kind'" in rec.message for rec in caplog.records)
     assert "unknown" in data.kind_str
 
+
+def test_convert_pejson_section_name():
+    sample = {
+        "pe_headers": {
+            "sections": [
+                {"name": ".foo", "virtual_size": "0x10", "raw_size": "0x10"}
+            ]
+        }
+    }
+    ast = ASTLoader._convert_pejson_to_ast(sample)
+    sec_nodes = [n for n in ast["nodes"] if n["kind"] == "section"]
+    assert sec_nodes and sec_nodes[0].get("name") == ".foo"
+

--- a/tests/test_cfg_loader.py
+++ b/tests/test_cfg_loader.py
@@ -55,3 +55,17 @@ def test_parse_preserves_kind_and_text():
     assert hasattr(data, "kind_str")
     assert hasattr(data, "text")
     assert "main" in data.text
+
+
+def test_convert_pejson_to_cfg_section_name():
+    sample = {
+        "pe_headers": {
+            "sections": [
+                {"name": ".x", "virtual_address": "0x1000", "virtual_size": "0x10", "raw_size": "0x10"}
+            ]
+        }
+    }
+
+    cfg = CFGLoader._convert_pejson_to_cfg(sample)
+    secs = [n for n in cfg["nodes"] if n["kind"] == "section"]
+    assert secs and secs[0].get("name") == ".x"

--- a/tests/test_fcg_loader.py
+++ b/tests/test_fcg_loader.py
@@ -25,7 +25,7 @@ def test_convert_pejson_to_fcg():
     assert set(["functions", "calls", "entry_id"]).issubset(fcg)
 
     num_sections = sample["pe_headers"]["number_of_sections"]
-    section_funcs = [f for f in fcg["functions"] if f["id"] != 0]
+    section_funcs = [f for f in fcg["functions"] if f["id"] != 0 and f.get("kind") != "token"]
     assert len(section_funcs) == num_sections
 
     for idx in range(1, num_sections + 1):
@@ -51,6 +51,22 @@ def test_convert_pejson_to_fcg_adds_tokens():
         edge = next(e for e in fcg["calls"] if e["dst"] == t["id"])
         assert edge["type"] == _EDGE_KIND_CONTAINS
         assert edge["src"] not in token_ids
+
+
+def test_convert_pejson_to_fcg_section_name():
+    sample = {
+        "pe_headers": {
+            "entry_point": "0x1000",
+            "sections": [
+                {"name": ".sec", "virtual_address": "0x1000", "virtual_size": "0x100"}
+            ],
+        },
+        "get_current_function": {"size": "0x20"},
+    }
+
+    fcg = FCGLoader._convert_pejson_to_fcg(sample)
+    sec_func = next(f for f in fcg["functions"] if f["id"] == 1)
+    assert sec_func.get("section_name") == ".sec"
 
 
 def test_parse_preserves_kind_and_text():

--- a/tests/test_feature_miner_additional_fields.py
+++ b/tests/test_feature_miner_additional_fields.py
@@ -36,3 +36,12 @@ def test_miner_extracts_url_tokens():
     feats = FeatureMiner(top_k=1)(g, sal)
     assert "url:malicious.com" in feats
     assert "url:evil" in feats
+
+
+def test_miner_extracts_section_name():
+    g = HeteroData()
+    g["section"].x = torch.zeros(1, 1)
+    g["section"].name = [".foo"]
+    sal = torch.tensor([0.9])
+    feats = FeatureMiner(top_k=1)(g, sal)
+    assert '".foo" ascii nocase' in feats


### PR DESCRIPTION
## Summary
- preserve section names when converting PE JSON in `ast_loader` and `cfg_loader`
- add `section_name` metadata for synthetic functions in `fcg_loader`
- mine section names in `FeatureMiner`
- extend loader and miner tests for section name handling

## Testing
- `pytest tests/test_ast_loader.py tests/test_cfg_loader.py tests/test_fcg_loader.py tests/test_feature_miner_additional_fields.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881eafc6a50832ebf920ab4f32ba0e4