### PR TITLE
Limit FeatureMiner selection to top_k nodes

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -197,7 +197,12 @@ class FeatureMiner:
         if n_nodes > k:
             topk_idx = torch.topk(flat_sal, k).indices
             mask[topk_idx] = True
-        return mask.nonzero(as_tuple=False).squeeze(1)
+
+        selected = mask.nonzero(as_tuple=False).squeeze(1)
+        if selected.numel() > k:
+            topk_idx = torch.topk(flat_sal[selected], k).indices
+            selected = selected[topk_idx]
+        return selected
 
     def _map_global_to_local(
         self,

--- a/tests/test_feature_miner_select_nodes.py
+++ b/tests/test_feature_miner_select_nodes.py
@@ -1,0 +1,14 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_select_nodes_limits_to_top_k():
+    sal = torch.arange(10.0, 0.0, -1.0)
+    miner = FeatureMiner(top_k=5, min_saliency=0.0)
+    idx = miner._select_nodes(sal)
+    assert len(idx) <= 5
+    assert set(idx.tolist()) == set(range(5))


### PR DESCRIPTION
## Summary
- ensure FeatureMiner `_select_nodes` never returns more than top_k nodes
- add regression test for selection size constraint

## Testing
- `pytest -q tests/test_feature_miner_select_nodes.py`

------
https://chatgpt.com/codex/tasks/task_e_6881fe71db40832ebfe33a52f8211e09