### PR TITLE
Add candidate filtering for uppercase and hex tokens

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -64,6 +64,9 @@ class FeatureMiner:
     _API_RX = re.compile(r"[A-Za-z0-9_#!?@\[\]\-\.+]{3,}")
     _STRING_FILTER = re.compile(r"[\x00-\x1F]")  # control chars
     _HEX_RX = re.compile(r"[0-9A-Fa-f]{2}")
+    _UPPER_RX = re.compile(r"^[A-Z0-9_]+$")
+    _LABEL_RX = re.compile(r"^(?:sub|loc|nullsub|unk)_[0-9A-Fa-f]+$")
+    _LONG_HEX_RX = re.compile(r"^[0-9A-Fa-f]{20,}$")
 
     def __init__(
         self,
@@ -341,6 +344,8 @@ class FeatureMiner:
                         continue
                 # plain python object
                 try:
+                    if isinstance(x, str):
+                        return x
                     return x[local_idx] if hasattr(x, "__getitem__") else x
                 except Exception:
                     continue
@@ -489,8 +494,27 @@ class FeatureMiner:
         """
         cnt = Counter(feats)
         ranked = sorted(cnt.items(), key=lambda kv: (-kv[1], kv[0]))
+        filtered: List[str] = []
+        for feat, _ in ranked:
+            token = feat
+            if token.startswith(
+                ("call:", "chain:", "import:", "syscall:", "path:", "reg:", "url:")
+            ):
+                token = token.split(":", 1)[1]
+            if token.startswith('"'):
+                m = re.match(r'"([^"\n]+)', token)
+                if m:
+                    token = m.group(1)
+            token = token.strip()
+            if self._UPPER_RX.fullmatch(token):
+                continue
+            if self._LABEL_RX.fullmatch(token):
+                continue
+            if self._LONG_HEX_RX.fullmatch(token):
+                continue
+            filtered.append(feat)
         # 타입 편중 완화를 위해 같은 prefix 그룹별 한도를 둘 수도 있음 (TODO)
-        return [feat for feat, _ in ranked]
+        return filtered
 
     def _filter_by_saliency_stats(
         self, feats: Sequence[str], stats: Dict[str, Tuple[float, float]]

--- a/tests/test_feature_miner_token_filter.py
+++ b/tests/test_feature_miner_token_filter.py
@@ -1,0 +1,21 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_normalize_and_rank_filters_tokens():
+    miner = FeatureMiner(top_k=1)
+    feats = [
+        "FOO",
+        "call:sub_1234",
+        "\"0123456789ABCDEF0123456789ABCDEF\" wide ascii nocase",
+        "call:CreateFileW",
+    ]
+    out = miner._normalize_and_rank(feats)
+    assert len(out) < len(feats)
+    assert "call:CreateFileW" in out
+    assert "FOO" not in out
+    assert "call:sub_1234" not in out
+    assert "\"0123456789ABCDEF0123456789ABCDEF\" wide ascii nocase" not in out


### PR DESCRIPTION
## Summary
- filter feature miner output to remove all-uppercase tokens, internal labels, or long hex strings
- fix metadata retrieval for nested strings
- test that filtered list is shorter after normalization

## Testing
- `pytest tests/test_feature_miner_token_filter.py -q`
- `pytest tests/test_feature_miner_* -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ff4535ec832e96797e1f8299876e