### PR TITLE
Update YaraBuilder condition logic

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -164,10 +164,8 @@ class YaraBuilder:
 
         # chain 처리 – "chain:A→B" 를 분리해 call prefix 보정
         processed: List[str] = []
-        chain_found = False
         for feat in unique_feats:
             if feat.startswith("chain:") and "→" in feat:
-                chain_found = True
                 rest = feat[len("chain:") :]
                 partA, partB = rest.split("→", 1)
                 if not partA.startswith("call:"):
@@ -193,10 +191,7 @@ class YaraBuilder:
             strings_section_lines.append(f"    $s{idx} = {yara_str}")
 
         # 4) condition
-        if chain_found:
-            cond_line = "    all of them"
-            _LOG.debug("chain detected; forcing all-of-them condition")
-        elif self.condition_type == "any":
+        if self.condition_type == "any":
             cond_line = "    any of them"
         elif self.condition_type == "all":
             cond_line = "    all of them"
@@ -332,11 +327,16 @@ def _cli():
     """
     parser = argparse.ArgumentParser(description="YARA Builder CLI")
     parser.add_argument("tokens", nargs="+", help="space‑separated token list")
-    parser.add_argument("--cond", choices=["any", "all", "percentage"], default="any")
-    parser.add_argument("--pct", type=int, default=70, help="percentage value")
+    parser.add_argument(
+        "--condition-type",
+        choices=["any", "all", "percentage"],
+        default="any",
+        help="Condition aggregation strategy",
+    )
+    parser.add_argument("--percentage", type=int, default=70, help="percentage value")
     args = parser.parse_args()
 
-    builder = YaraBuilder(condition_type=args.cond, percentage=args.pct)
+    builder = YaraBuilder(condition_type=args.condition_type, percentage=args.percentage)
     rule_text = builder.build(args.tokens)
     print(rule_text)
     ok, err = builder.validate(rule_text)

--- a/tests/test_chain_builders.py
+++ b/tests/test_chain_builders.py
@@ -1,13 +1,32 @@
-from src.rulegen.yara_builder import tokens_to_yara
+import pytest
+
+from src.rulegen.yara_builder import tokens_to_yara, YaraBuilder
 from src.rulegen.capa_builder import tokens_to_capa
 
 def test_chain_tokens_to_yara():
     rule = tokens_to_yara(["chain:CreateFileW\u2192ReadFile"])
     assert "$s0" in rule
     assert "$s1" in rule
-    assert "all of them" in rule
+    assert "any of them" in rule
+    ok, err = YaraBuilder().validate(rule)
+    assert ok, err
 
 
 def test_chain_tokens_to_capa():
     rule = tokens_to_capa(["chain:CreateFileW\u2192ReadFile"])
     assert "sequence:" in rule
+
+@pytest.mark.parametrize(
+    "cond,expected",
+    [
+        ("any", "any of them"),
+        ("all", "all of them"),
+        ("percentage", "70% of them"),
+    ],
+)
+def test_chain_tokens_condition_types(cond, expected):
+    builder = YaraBuilder(condition_type=cond)
+    rule = builder.build(["chain:CreateFileW\u2192ReadFile"])
+    assert expected in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- respect `--condition-type` for YaraBuilder
- update CLI to use `--condition-type`/`--percentage`
- remove special chain token condition handling
- extend chain token tests for all condition modes

## Testing
- `pytest tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_quotes.py tests/test_chain_builders.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6882018f56d8832e93aeb00d9d06fc22