### PR TITLE
Add sample YARA rule output option

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -195,6 +195,7 @@ def evaluate_single(
     if LOGGER.isEnabledFor(logging.DEBUG):
         LOGGER.debug("Mined %d features", len(features))
 
+    LOGGER.info("Building YARA rule with %d features", len(features))
     builder = YaraBuilder(condition_type=condition_type, percentage=percentage)
     rule_text = builder.build(features)
     builder.validate(rule_text)
@@ -229,6 +230,7 @@ def evaluate_single(
         "mask_sparsity": mask_sparsity,
         "coverage": coverage,
     }
+    result["rule_text"] = rule_text
 
     if clean_dir is not None and clean_dir.is_dir():
         fp = False
@@ -285,6 +287,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--clean-sample", type=Path, help="Optional clean sample for FP check")
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")
+    p.add_argument("--sample-rules-out", type=Path, help="Path to write example rules")
     p.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
     return p
 
@@ -339,6 +342,12 @@ def main(argv: list[str] | None = None) -> None:
             fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
             LOGGER.info("average detection=%.3f, FP ratio=%.3f", det_rate, fp_ratio)
 
+            rule_texts = [r.get("rule_text") for r in results if r.get("rule_text")]
+            if args.sample_rules_out and rule_texts:
+                import random
+
+                selected = random.sample(rule_texts, min(5, len(rule_texts)))
+                args.sample_rules_out.write_text("\n\n".join(selected), encoding="utf-8")
         else:
             LOGGER.warning("No samples evaluated")
 
@@ -366,6 +375,9 @@ def main(argv: list[str] | None = None) -> None:
         if args.out:
             args.out.write_text(text, encoding="utf-8")
         print(text)
+
+        if args.sample_rules_out:
+            args.sample_rules_out.write_text(result.get("rule_text", ""), encoding="utf-8")
 
 
 __all__ = ["main"]

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -45,3 +45,38 @@ def test_cli_runs_and_writes_json(tmp_path, caplog):
     assert "detected" in data
     assert any("Building YARA rule" in rec.message for rec in caplog.records)
 
+
+def test_cli_sample_rules_out(tmp_path):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    rule_out = tmp_path / "rule.txt"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--sample-rules-out",
+        str(rule_out),
+    ])
+
+    assert rule_out.exists()
+    text = rule_out.read_text()
+    assert text.strip().startswith("rule ")
+


### PR DESCRIPTION
## Summary
- support saving example rules from explainer CLI
- expose rule text in `evaluate_single`
- log rule generation and handle new `--sample-rules-out` argument
- add tests for the new behaviour

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_runs_and_writes_json -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_sample_rules_out -q`


------
https://chatgpt.com/codex/tasks/task_e_68820b6b93f8832e990862e66d832863