### PR TITLE
Strip prefixes in YARA builder

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -103,6 +103,7 @@ class YaraBuilder:
         condition_type: str = "any",  # "any" | "all" | "percentage"
         percentage: int = 70,  # condition_type=="percentage" 일 때
         tokenizer: Optional[PreTrainedTokenizer] = None,
+        strip_prefix: bool = True,
     ) -> None:
         self.rule_name_prefix = rule_name_prefix
         self.condition_type = condition_type
@@ -110,6 +111,7 @@ class YaraBuilder:
         if self.condition_type not in {"any", "all", "percentage"}:
             raise ValueError("condition_type must be any|all|percentage")
         self.tokenizer = tokenizer
+        self.strip_prefix = strip_prefix
 
     def _detokenize(self, tokens: Sequence[str]) -> str:
         """
@@ -277,12 +279,21 @@ class YaraBuilder:
                 seen.add(f)
         return uniq
 
-    @staticmethod
-    def _to_yara_string(feat: str) -> str:
+    def _to_yara_string(self, feat: str) -> str:
         """
         • feat 자체가 정규식/16진 패턴 등이면 그대로
         • 아니면 → `"<feat>" nocase ascii`
         """
+        if self.strip_prefix:
+            lowered = feat.lower()
+            for prefix in ("call:", "syscall:", "import:"):
+                if lowered.startswith(prefix):
+                    feat = feat.split(":", 1)[1]
+                    lowered = feat.lower()
+                    break
+            if "!" in feat:
+                feat = feat.split("!", 1)[1]
+
         if feat.startswith("/") and feat.endswith("/"):
             return feat
         if feat.startswith("{") and feat.endswith("}"):

--- a/tests/test_yara_builder_prefix_strip.py
+++ b/tests/test_yara_builder_prefix_strip.py
@@ -1,0 +1,14 @@
+import pytest
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_prefix_and_module_removed_by_default():
+    builder = YaraBuilder()
+    rule = builder.build(["call:kernel32!CreateFileW", "import:WS2_32.dll"])
+    assert 'call:' not in rule
+    assert 'import:' not in rule
+    assert 'kernel32!' not in rule
+    assert '"CreateFileW" nocase ascii' in rule
+    assert '"WS2_32.dll" nocase ascii' in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- strip `call:`/`import:` prefixes and module names when building YARA strings
- allow disabling the behaviour via `strip_prefix` option
- add regression test for prefix removal

## Testing
- `pytest tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_quotes.py tests/test_yara_builder_prefix_strip.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68820f836848832ebfef2dd5de49a97a