### PR TITLE
Add json-match option for YARA evaluator

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -175,6 +175,7 @@ def evaluate_single(
     clean_dir: Path | None = None,
     clean_sample: Path | None = None,
     sample_json: Path | None = None,
+    json_match: bool = False,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -200,20 +201,32 @@ def evaluate_single(
     rule_text = builder.build(features)
     builder.validate(rule_text)
 
-    import yara
+    if json_match:
+        jpath = sample_json if sample_json is not None else sample_path.with_suffix(".json")
+        if not jpath.is_file():
+            LOGGER.warning("json_match enabled but JSON %s not found", jpath)
+            detected = False
+        else:
+            detected = verify_features(jpath, features)
+        coverage = 0.0
+        LOGGER.info("Skipping YARA match; using JSON verification only")
+        compiled = None
+        matches = []
+    else:
+        import yara
 
-    compiled = yara.compile(source=rule_text)
-    matches = compiled.match(str(sample_path))
-    detected = bool(matches)
+        compiled = yara.compile(source=rule_text)
+        matches = compiled.match(str(sample_path))
+        detected = bool(matches)
 
-    coverage = 0.0
-    if detected:
-        total = sum(len(s[2]) for s in matches[0].strings)
-        try:
-            size = sample_path.stat().st_size
-            coverage = float(total) / float(size) if size > 0 else 0.0
-        except Exception:
-            coverage = 0.0
+        coverage = 0.0
+        if detected:
+            total = sum(len(s[2]) for s in matches[0].strings)
+            try:
+                size = sample_path.stat().st_size
+                coverage = float(total) / float(size) if size > 0 else 0.0
+            except Exception:
+                coverage = 0.0
 
     if isinstance(saliency, dict):
         flat = torch.cat(list(saliency.values()))
@@ -232,7 +245,7 @@ def evaluate_single(
     }
     result["rule_text"] = rule_text
 
-    if clean_dir is not None and clean_dir.is_dir():
+    if clean_dir is not None and clean_dir.is_dir() and compiled is not None:
         fp = False
         for fp_path in clean_dir.iterdir():
             if not fp_path.is_file():
@@ -244,11 +257,13 @@ def evaluate_single(
             except Exception:
                 continue
         result["false_positive"] = fp
-    elif clean_sample is not None:
+    elif clean_sample is not None and compiled is not None:
         try:
             result["false_positive"] = bool(compiled.match(str(clean_sample)))
         except Exception:
             result["false_positive"] = False
+    elif clean_dir is not None or clean_sample is not None:
+        result["false_positive"] = False
 
     if sample_json is not None and sample_json.is_file():
         result["feature_verified"] = verify_features(sample_json, features)
@@ -288,6 +303,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")
     p.add_argument("--sample-rules-out", type=Path, help="Path to write example rules")
+    p.add_argument(
+        "--json-match",
+        action="store_true",
+        help="Verify features in sample JSON instead of YARA match",
+    )
     p.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
     return p
 
@@ -330,6 +350,7 @@ def main(argv: list[str] | None = None) -> None:
                 clean_dir=args.clean_dir,
                 clean_sample=None,
                 sample_json=jpath,
+                json_match=args.json_match,
             )
             res["sha256"] = sha
             results.append(res)
@@ -369,6 +390,7 @@ def main(argv: list[str] | None = None) -> None:
             clean_dir=args.clean_dir,
             clean_sample=args.clean_sample,
             sample_json=(args.sample_dir / f"{args.sample.stem}.json" if args.sample_dir else None),
+            json_match=args.json_match,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -80,3 +80,51 @@ def test_cli_sample_rules_out(tmp_path):
     text = rule_out.read_text()
     assert text.strip().startswith("rule ")
 
+
+def test_cli_json_match_detects(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    out = tmp_path / "res.json"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--json-match",
+        "--out",
+        str(out),
+    ])
+
+    data = json.loads(out.read_text())
+    assert data["detected"] is True
+    assert data["coverage"] == 0.0
+


### PR DESCRIPTION
## Summary
- support `--json-match` for `explainer_rule_eval` to verify features using JSON files instead of YARA
- document this option in CLI parser
- skip YARA matching when `--json-match` is set and log it
- handle coverage and false-positive checks accordingly
- add unit test verifying JSON match detection

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68820f5e3cb8832e82b22301cbcbef64