### PR TITLE
Add token filters for addresses and sections

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -67,6 +67,8 @@ class FeatureMiner:
     _UPPER_RX = re.compile(r"^[A-Z0-9_]+$")
     _LABEL_RX = re.compile(r"^(?:sub|loc|nullsub|unk)_[0-9A-Fa-f]+$")
     _LONG_HEX_RX = re.compile(r"^[0-9A-Fa-f]{20,}$")
+    _ADDR_RX = re.compile(r"^(?:0x)?[0-9A-Fa-f]{4,}$")
+    _SEC_RX = re.compile(r"^\.[A-Za-z0-9$.]{1,8}$")
 
     def __init__(
         self,
@@ -511,6 +513,10 @@ class FeatureMiner:
             if self._LABEL_RX.fullmatch(token):
                 continue
             if self._LONG_HEX_RX.fullmatch(token):
+                continue
+            if self._ADDR_RX.fullmatch(token):
+                continue
+            if self._SEC_RX.fullmatch(token):
                 continue
             filtered.append(feat)
         # 타입 편중 완화를 위해 같은 prefix 그룹별 한도를 둘 수도 있음 (TODO)

--- a/tests/test_feature_miner_token_filter.py
+++ b/tests/test_feature_miner_token_filter.py
@@ -10,6 +10,8 @@ def test_normalize_and_rank_filters_tokens():
     feats = [
         "FOO",
         "call:sub_1234",
+        "call:0x401000",
+        '".rsrc" ascii nocase',
         "\"0123456789ABCDEF0123456789ABCDEF\" wide ascii nocase",
         "call:CreateFileW",
     ]
@@ -18,4 +20,6 @@ def test_normalize_and_rank_filters_tokens():
     assert "call:CreateFileW" in out
     assert "FOO" not in out
     assert "call:sub_1234" not in out
+    assert '".rsrc" ascii nocase' not in out
+    assert "call:0x401000" not in out
     assert "\"0123456789ABCDEF0123456789ABCDEF\" wide ascii nocase" not in out


### PR DESCRIPTION
## Summary
- filter memory address-like and section name tokens in `FeatureMiner`
- test that address and section tokens are removed by `_normalize_and_rank`

## Testing
- `pytest -q tests/test_feature_miner_token_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_68822210e39c832e880e5c16c26b2b36