### PR TITLE
Add count condition to YaraBuilder

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -100,16 +100,18 @@ class YaraBuilder:
         self,
         *,
         rule_name_prefix: str = "auto_rule",
-        condition_type: str = "any",  # "any" | "all" | "percentage"
+        condition_type: str = "any",  # "any" | "all" | "percentage" | "count"
         percentage: int = 70,  # condition_type=="percentage" 일 때
+        min_count: int | None = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
         strip_prefix: bool = True,
     ) -> None:
         self.rule_name_prefix = rule_name_prefix
         self.condition_type = condition_type
         self.percentage = percentage
-        if self.condition_type not in {"any", "all", "percentage"}:
-            raise ValueError("condition_type must be any|all|percentage")
+        self.min_count = min_count
+        if self.condition_type not in {"any", "all", "percentage", "count"}:
+            raise ValueError("condition_type must be any|all|percentage|count")
         self.tokenizer = tokenizer
         self.strip_prefix = strip_prefix
 
@@ -197,8 +199,10 @@ class YaraBuilder:
             cond_line = "    any of them"
         elif self.condition_type == "all":
             cond_line = "    all of them"
-        else:
+        elif self.condition_type == "percentage":
             cond_line = f"    {self.percentage}% of them"
+        else:  # "count"
+            cond_line = f"    {self.min_count} of them"
 
         # 5) join
         rule_lines = [
@@ -340,14 +344,19 @@ def _cli():
     parser.add_argument("tokens", nargs="+", help="space‑separated token list")
     parser.add_argument(
         "--condition-type",
-        choices=["any", "all", "percentage"],
+        choices=["any", "all", "percentage", "count"],
         default="any",
         help="Condition aggregation strategy",
     )
     parser.add_argument("--percentage", type=int, default=70, help="percentage value")
+    parser.add_argument("--min-count", type=int, default=None, help="minimum count value")
     args = parser.parse_args()
 
-    builder = YaraBuilder(condition_type=args.condition_type, percentage=args.percentage)
+    builder = YaraBuilder(
+        condition_type=args.condition_type,
+        percentage=args.percentage,
+        min_count=args.min_count,
+    )
     rule_text = builder.build(args.tokens)
     print(rule_text)
     ok, err = builder.validate(rule_text)

--- a/tests/test_yara_builder_count.py
+++ b/tests/test_yara_builder_count.py
@@ -1,0 +1,10 @@
+import pytest
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_count_condition():
+    builder = YaraBuilder(condition_type="count", min_count=2)
+    rule = builder.build(["featA", "featB", "featC"])
+    assert "2 of them" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- extend YaraBuilder with optional `min_count` and new `count` condition type
- output min-count clause when `condition_type` is `count`
- expose `--min-count` in `_cli()`
- test new mode in `tests/test_yara_builder_count.py`

## Testing
- `pytest tests/test_yara_builder_prefix_strip.py tests/test_yara_builder_quotes.py tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_count.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68822335c884832e9060f4ba1b9f5955