### PR TITLE
Add FeatureMiner CLI options

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -4,6 +4,7 @@
 
 - **경로/레지스트리/URL 기반 특징도 추출한다.**
 - CLI: `python -m cli.rulegen_cli feature-mine` 으로 후보 특성을 수집할 수 있습니다.
+- `--dynamic-k`, `--top-k-percent`, `--keep-per-type` 옵션으로 후보 선별 방식을 세밀하게 조정할 수 있습니다.
 - PPO 학습용 데이터셋은 `python -m cli.rulegen_cli build-dataset` 또는
   ``rulegen.build_dataset.build_dataset`` 함수로 생성합니다.
   함수 호출 시 ``binary_dir`` 인자를 지정하면 그래프의 ``file_path``가 해당 경로를
@@ -14,10 +15,19 @@ from rulegen import FeatureMiner
 from torch_geometric.data import HeteroData
 
 # data: HeteroData, saliency: Tensor
-miner = FeatureMiner(top_k=40)
+miner = FeatureMiner(
+    top_k=40,
+    top_k_percent=0.05,
+    dynamic_k=True,
+    keep_per_type=20,
+)
 candidates = miner(data, saliency)
 print(candidates[:5])
 ```
+
+`top_k_percent` 비율을 지정하면 전체 노드 수에 따라 `k`가 자동 계산됩니다.
+`dynamic_k=True` 로 설정하면 saliency 분포를 이용해 `k`가 조정됩니다.
+`keep_per_type` 는 노드 타입별 최대 후보 수를 제한합니다.
 
 환경 초기화 시 보상 가중치를 조정할 수 있습니다.
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -169,7 +169,10 @@ def evaluate_single(
     saliency_path: Path | None,
     device: torch.device,
     top_k: int,
-    min_saliency: float,
+    top_k_percent: float | None = None,
+    dynamic_k: bool = False,
+    min_saliency: float = 1e-3,
+    keep_per_type: int = 20,
     condition_type: str,
     percentage: int,
     clean_dir: Path | None = None,
@@ -191,7 +194,13 @@ def evaluate_single(
     else:
         saliency = _compute_saliency_with_explainer(graph, classifier_ckpt, explainer_ckpt, device)
 
-    miner = FeatureMiner(top_k=top_k, min_saliency=min_saliency)
+    miner = FeatureMiner(
+        top_k=top_k,
+        top_k_percent=top_k_percent,
+        dynamic_k=dynamic_k,
+        min_saliency=min_saliency,
+        keep_per_type=keep_per_type,
+    )
     features = miner.mine(graph, saliency)
     if LOGGER.isEnabledFor(logging.DEBUG):
         LOGGER.debug("Mined %d features", len(features))
@@ -291,6 +300,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--classifier", type=Path, required=True, help="Classifier checkpoint")
     p.add_argument("--device", type=str, default="cpu")
     p.add_argument("--top-k", type=int, default=40)
+    p.add_argument("--top-k-percent", type=float, default=None)
+    p.add_argument("--dynamic-k", action="store_true")
+    p.add_argument("--keep-per-type", type=int, default=20)
     p.add_argument("--min-saliency", type=float, default=1e-3)
     p.add_argument(
         "--condition-type",
@@ -344,7 +356,10 @@ def main(argv: list[str] | None = None) -> None:
                 saliency_path=None,
                 device=device,
                 top_k=args.top_k,
+                top_k_percent=args.top_k_percent,
+                dynamic_k=args.dynamic_k,
                 min_saliency=args.min_saliency,
+                keep_per_type=args.keep_per_type,
                 condition_type=args.condition_type,
                 percentage=args.percentage,
                 clean_dir=args.clean_dir,
@@ -384,7 +399,10 @@ def main(argv: list[str] | None = None) -> None:
             saliency_path=args.saliency,
             device=device,
             top_k=args.top_k,
+            top_k_percent=args.top_k_percent,
+            dynamic_k=args.dynamic_k,
             min_saliency=args.min_saliency,
+            keep_per_type=args.keep_per_type,
             condition_type=args.condition_type,
             percentage=args.percentage,
             clean_dir=args.clean_dir,


### PR DESCRIPTION
## Summary
- expose `--dynamic-k`, `--top-k-percent` and `--keep-per-type` in `explainer_rule_eval` CLI
- forward new arguments to `FeatureMiner`
- document advanced feature-mining options

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_runs_and_writes_json -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6882240eca1c832ebc9df4eff837d332