### PR TITLE
Fix sample rules output

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -314,7 +314,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--clean-sample", type=Path, help="Optional clean sample for FP check")
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")
-    p.add_argument("--sample-rules-out", type=Path, help="Path to write example rules")
+    p.add_argument(
+        "--sample-rules-out",
+        type=Path,
+        help="Directory to write example rules",
+    )
     p.add_argument(
         "--json-match",
         action="store_true",
@@ -378,12 +382,19 @@ def main(argv: list[str] | None = None) -> None:
             fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
             LOGGER.info("average detection=%.3f, FP ratio=%.3f", det_rate, fp_ratio)
 
-            rule_texts = [r.get("rule_text") for r in results if r.get("rule_text")]
+            rule_texts = [
+                (r.get("sha256"), r.get("rule_text"))
+                for r in results
+                if r.get("rule_text")
+            ]
             if args.sample_rules_out and rule_texts:
                 import random
 
+                args.sample_rules_out.mkdir(parents=True, exist_ok=True)
                 selected = random.sample(rule_texts, min(5, len(rule_texts)))
-                args.sample_rules_out.write_text("\n\n".join(selected), encoding="utf-8")
+                for i, (sha, text) in enumerate(selected, start=1):
+                    fname = f"{sha}.yar" if sha else f"rule_{i}.yar"
+                    (args.sample_rules_out / fname).write_text(text, encoding="utf-8")
         else:
             LOGGER.warning("No samples evaluated")
 
@@ -417,7 +428,9 @@ def main(argv: list[str] | None = None) -> None:
         print(text)
 
         if args.sample_rules_out:
-            args.sample_rules_out.write_text(result.get("rule_text", ""), encoding="utf-8")
+            args.sample_rules_out.mkdir(parents=True, exist_ok=True)
+            rule_path = args.sample_rules_out / f"{args.sample.stem}.yar"
+            rule_path.write_text(result.get("rule_text", ""), encoding="utf-8")
 
 
 __all__ = ["main"]

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -62,7 +62,7 @@ def test_cli_sample_rules_out(tmp_path):
     sample.write_bytes(b"dummy")
 
     mod = importlib.import_module("src.cli.explainer_rule_eval")
-    rule_out = tmp_path / "rule.txt"
+    rule_out = tmp_path / "rules"
     mod.main([
         "--graph",
         str(gpath),
@@ -76,8 +76,10 @@ def test_cli_sample_rules_out(tmp_path):
         str(rule_out),
     ])
 
-    assert rule_out.exists()
-    text = rule_out.read_text()
+    assert rule_out.is_dir()
+    files = list(rule_out.glob("*.yar"))
+    assert len(files) == 1
+    text = files[0].read_text()
     assert text.strip().startswith("rule ")
 
 


### PR DESCRIPTION
## Summary
- update `--sample-rules-out` CLI option to accept a directory
- write sample rule files into that directory
- adjust tests for new behaviour

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_sample_rules_out -q`

------
https://chatgpt.com/codex/tasks/task_e_688226e5c848832e9d5dbc0c7f17de97