### PR TITLE
Change YARA rule build logs to debug

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -205,7 +205,7 @@ def evaluate_single(
     if LOGGER.isEnabledFor(logging.DEBUG):
         LOGGER.debug("Mined %d features", len(features))
 
-    LOGGER.info("Building YARA rule with %d features", len(features))
+    LOGGER.debug("Building YARA rule with %d features", len(features))
     builder = YaraBuilder(condition_type=condition_type, percentage=percentage)
     rule_text = builder.build(features)
     builder.validate(rule_text)
@@ -218,7 +218,7 @@ def evaluate_single(
         else:
             detected = verify_features(jpath, features)
         coverage = 0.0
-        LOGGER.info("Skipping YARA match; using JSON verification only")
+        LOGGER.debug("Skipping YARA match; using JSON verification only")
         compiled = None
         matches = []
     else:

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -27,7 +27,7 @@ def test_cli_runs_and_writes_json(tmp_path, caplog):
 
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     out = tmp_path / "res.json"
-    caplog.set_level("INFO")
+    caplog.set_level("DEBUG")
     mod.main([
         "--graph",
         str(gpath),


### PR DESCRIPTION
## Summary
- adjust log level for YARA rule generation in `explainer_rule_eval`
- update CLI test to capture debug logs

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -vv` *(fails: collected 0 items / 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68822c720b08832eb5ee6aeeffeba5ab