### PR TITLE
Handle missing graphs in rule eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -342,6 +342,7 @@ def main(argv: list[str] | None = None) -> None:
         df = pd.read_csv(args.meta_csv)
         rows = df[df.get("label", 1) == 1]
         results: list[dict[str, Any]] = []
+        skipped = 0
         row_iter = tqdm_wrap(
             rows.iterrows(), desc="graphs", total=len(rows), unit="graph"
         )
@@ -352,30 +353,38 @@ def main(argv: list[str] | None = None) -> None:
             spath = Path(args.sample_dir or args.graph_dir) / filename
             jpath = Path(args.sample_dir or args.graph_dir) / f"{sha}.json"
 
-            res = evaluate_single(
-                gpath,
-                spath,
-                classifier_ckpt=args.classifier,
-                explainer_ckpt=args.explainer,
-                saliency_path=None,
-                device=device,
-                top_k=args.top_k,
-                top_k_percent=args.top_k_percent,
-                dynamic_k=args.dynamic_k,
-                min_saliency=args.min_saliency,
-                keep_per_type=args.keep_per_type,
-                condition_type=args.condition_type,
-                percentage=args.percentage,
-                clean_dir=args.clean_dir,
-                clean_sample=None,
-                sample_json=jpath,
-                json_match=args.json_match,
-            )
+            try:
+                res = evaluate_single(
+                    gpath,
+                    spath,
+                    classifier_ckpt=args.classifier,
+                    explainer_ckpt=args.explainer,
+                    saliency_path=None,
+                    device=device,
+                    top_k=args.top_k,
+                    top_k_percent=args.top_k_percent,
+                    dynamic_k=args.dynamic_k,
+                    min_saliency=args.min_saliency,
+                    keep_per_type=args.keep_per_type,
+                    condition_type=args.condition_type,
+                    percentage=args.percentage,
+                    clean_dir=args.clean_dir,
+                    clean_sample=None,
+                    sample_json=jpath,
+                    json_match=args.json_match,
+                )
+            except FileNotFoundError as exc:
+                skipped += 1
+                LOGGER.warning("Skipping %s: %s", sha, exc)
+                continue
+
             res["sha256"] = sha
             results.append(res)
 
         if args.out_csv:
             pd.DataFrame(results).to_csv(args.out_csv, index=False)
+
+        LOGGER.info("Skipped %d graphs due to missing files", skipped)
 
         if results:
             det_rate = sum(r.get("detected", False) for r in results) / len(results)


### PR DESCRIPTION
## Summary
- handle missing graph files in `explainer_rule_eval.py`
- report how many graphs were skipped

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68822e44c464832e86f7721883477eca