### PR TITLE
Add detected rule storage feature

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -381,6 +381,12 @@ def main(argv: list[str] | None = None) -> None:
             res["sha256"] = sha
             results.append(res)
 
+            if args.sample_rules_out and res.get("detected"):
+                rule_dir = args.sample_rules_out / "rule"
+                rule_dir.mkdir(parents=True, exist_ok=True)
+                fname = f"{sha}.yar"
+                (rule_dir / fname).write_text(res.get("rule_text", ""), encoding="utf-8")
+
         if args.out_csv:
             pd.DataFrame(results).to_csv(args.out_csv, index=False)
 
@@ -440,6 +446,13 @@ def main(argv: list[str] | None = None) -> None:
             args.sample_rules_out.mkdir(parents=True, exist_ok=True)
             rule_path = args.sample_rules_out / f"{args.sample.stem}.yar"
             rule_path.write_text(result.get("rule_text", ""), encoding="utf-8")
+
+            if result.get("detected"):
+                rule_dir = args.sample_rules_out / "rule"
+                rule_dir.mkdir(parents=True, exist_ok=True)
+                (rule_dir / f"{args.sample.stem}.yar").write_text(
+                    result.get("rule_text", ""), encoding="utf-8"
+                )
 
 
 __all__ = ["main"]

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -27,7 +27,7 @@ def test_cli_runs_and_writes_json(tmp_path, caplog):
 
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     out = tmp_path / "res.json"
-    caplog.set_level("DEBUG")
+    caplog.set_level("DEBUG", logger=mod.LOGGER.name)
     mod.main([
         "--graph",
         str(gpath),
@@ -81,6 +81,54 @@ def test_cli_sample_rules_out(tmp_path):
     assert len(files) == 1
     text = files[0].read_text()
     assert text.strip().startswith("rule ")
+
+
+def test_cli_sample_rules_out_detected(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    rule_out = tmp_path / "rules"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--json-match",
+        "--sample-rules-out",
+        str(rule_out),
+    ])
+
+    det_dir = rule_out / "rule"
+    assert det_dir.is_dir()
+    assert (det_dir / f"{sample.stem}.yar").is_file()
 
 
 def test_cli_json_match_detects(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- save detected rules under `<out>/rule` directory when using `--sample-rules-out`
- adjust CLI unit tests

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68823de7a884832ebd0802193c34a378