### PR TITLE
Update percentage-based YARA conditions

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -41,6 +41,7 @@ import logging
 import random
 import re
 import string
+import math
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
 
@@ -200,7 +201,8 @@ class YaraBuilder:
         elif self.condition_type == "all":
             cond_line = "    all of them"
         elif self.condition_type == "percentage":
-            cond_line = f"    {self.percentage}% of them"
+            thresh = max(1, math.ceil(len(unique_feats) * self.percentage / 100.0))
+            cond_line = f"    {thresh} of them"
         else:  # "count"
             cond_line = f"    {self.min_count} of them"
 

--- a/tests/test_chain_builders.py
+++ b/tests/test_chain_builders.py
@@ -21,7 +21,7 @@ def test_chain_tokens_to_capa():
     [
         ("any", "any of them"),
         ("all", "all of them"),
-        ("percentage", "70% of them"),
+        ("percentage", "2 of them"),
     ],
 )
 def test_chain_tokens_condition_types(cond, expected):

--- a/tests/test_yara_builder_percentage.py
+++ b/tests/test_yara_builder_percentage.py
@@ -1,0 +1,10 @@
+import pytest
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_percentage_condition_min_one():
+    builder = YaraBuilder(condition_type="percentage", percentage=10)
+    rule = builder.build(["featA", "featB", "featC"])
+    assert "1 of them" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- support integer thresholds for percentage conditions in YaraBuilder
- ensure at least one match for percentage conditions
- update tests for new behaviour and add regression test

## Testing
- `pytest tests/test_chain_builders.py tests/test_yara_builder_count.py tests/test_yara_builder_prefix_strip.py tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_quotes.py tests/test_yara_builder_percentage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882460f73b0832e89a3c205b1adfc6b