### PR TITLE
Add combo YARA condition mode

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -785,7 +785,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         hint_features: list[str] | None = None,
     ) -> dict:
         builder = (
-            YaraBuilder(condition_type=args.condition_type)
+            YaraBuilder(
+                condition_type=args.condition_type,
+                group_percentage=args.group_percentage,
+                group_min_count=args.group_min_count,
+            )
             if getattr(env, "rule_type", "yara") == "yara"
             else CapaBuilder()
         )
@@ -898,7 +902,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
         # NOTE: 학습에 사용된 설정 파일과 생성된 예시 룰을
         #       동일한 디렉터리 아래에 보관하면 관리가 용이하다.
 
-        builder = YaraBuilder(condition_type=args.condition_type)
+        builder = YaraBuilder(
+            condition_type=args.condition_type,
+            group_percentage=args.group_percentage,
+            group_min_count=args.group_min_count,
+        )
         sample_tokens = agent.sample_rules(n=1)[0]
         sample_rule = builder.build(sample_tokens)
         out_dir = Path("results")
@@ -1215,10 +1223,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     pt.add_argument(
         "--condition-type",
-        choices=["any", "all", "percentage"],
+        choices=["any", "all", "percentage", "combo"],
         default="any",
-        help="Condition aggregation strategy ('any', 'all', 'percentage'), defaults to 'any'",
+        help="Condition aggregation strategy ('any', 'all', 'percentage', 'combo'), defaults to 'any'",
     )
+    pt.add_argument("--group-percentage", type=int, help="combo mode: percentage of each group")
+    pt.add_argument("--group-min-count", type=int, help="combo mode: minimum matches per group")
     pt.add_argument("--epochs", type=int, default=30, help="Training epochs")
     pt.add_argument(
         "--eval-interval",

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -101,9 +101,11 @@ class YaraBuilder:
         self,
         *,
         rule_name_prefix: str = "auto_rule",
-        condition_type: str = "any",  # "any" | "all" | "percentage" | "count"
+        condition_type: str = "any",  # "any" | "all" | "percentage" | "count" | "combo"
         percentage: int = 70,  # condition_type=="percentage" 일 때
         min_count: int | None = None,
+        group_percentage: int | None = None,
+        group_min_count: int | None = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
         strip_prefix: bool = True,
     ) -> None:
@@ -111,10 +113,14 @@ class YaraBuilder:
         self.condition_type = condition_type
         self.percentage = percentage
         self.min_count = min_count
-        if self.condition_type not in {"any", "all", "percentage", "count"}:
-            raise ValueError("condition_type must be any|all|percentage|count")
+        if self.condition_type not in {"any", "all", "percentage", "count", "combo"}:
+            raise ValueError("condition_type must be any|all|percentage|count|combo")
+        if self.condition_type == "combo" and group_percentage is not None and group_min_count is not None:
+            raise ValueError("Specify only one of group_percentage or group_min_count")
         self.tokenizer = tokenizer
         self.strip_prefix = strip_prefix
+        self.group_percentage = group_percentage
+        self.group_min_count = group_min_count
 
     def _detokenize(self, tokens: Sequence[str]) -> str:
         """
@@ -191,9 +197,23 @@ class YaraBuilder:
 
         # 3) strings section
         strings_section_lines = []
-        for idx, feat in enumerate(unique_feats):
-            yara_str = self._to_yara_string(feat)
-            strings_section_lines.append(f"    $s{idx} = {yara_str}")
+        groups: dict[str, list[str]] = {}
+        if self.condition_type == "combo":
+            prefix_map = {"call:": "c", "import:": "i"}
+            for feat in unique_feats:
+                tag = "o"
+                for p, t in prefix_map.items():
+                    if feat.startswith(p):
+                        tag = t
+                        break
+                idx = len(groups.setdefault(tag, []))
+                yara_str = self._to_yara_string(feat)
+                strings_section_lines.append(f"    ${tag}{idx} = {yara_str}")
+                groups[tag].append(feat)
+        else:
+            for idx, feat in enumerate(unique_feats):
+                yara_str = self._to_yara_string(feat)
+                strings_section_lines.append(f"    $s{idx} = {yara_str}")
 
         # 4) condition
         if self.condition_type == "any":
@@ -203,8 +223,21 @@ class YaraBuilder:
         elif self.condition_type == "percentage":
             thresh = max(1, math.ceil(len(unique_feats) * self.percentage / 100.0))
             cond_line = f"    {thresh} of them"
-        else:  # "count"
+        elif self.condition_type == "count":
             cond_line = f"    {self.min_count} of them"
+        else:  # combo
+            parts = []
+            for tag, feats_list in groups.items():
+                if not feats_list:
+                    continue
+                if self.group_min_count is not None:
+                    parts.append(f"{self.group_min_count} of (${tag}*)")
+                elif self.group_percentage is not None:
+                    n = max(1, math.ceil(len(feats_list) * self.group_percentage / 100.0))
+                    parts.append(f"{n} of (${tag}*)")
+                else:
+                    parts.append(f"any of (${tag}*)")
+            cond_line = "    " + " and ".join(parts)
 
         # 5) join
         rule_lines = [
@@ -346,18 +379,22 @@ def _cli():
     parser.add_argument("tokens", nargs="+", help="space‑separated token list")
     parser.add_argument(
         "--condition-type",
-        choices=["any", "all", "percentage", "count"],
+        choices=["any", "all", "percentage", "count", "combo"],
         default="any",
         help="Condition aggregation strategy",
     )
     parser.add_argument("--percentage", type=int, default=70, help="percentage value")
     parser.add_argument("--min-count", type=int, default=None, help="minimum count value")
+    parser.add_argument("--group-percentage", type=int, help="combo mode: group percentage")
+    parser.add_argument("--group-min-count", type=int, help="combo mode: group min count")
     args = parser.parse_args()
 
     builder = YaraBuilder(
         condition_type=args.condition_type,
         percentage=args.percentage,
         min_count=args.min_count,
+        group_percentage=args.group_percentage,
+        group_min_count=args.group_min_count,
     )
     rule_text = builder.build(args.tokens)
     print(rule_text)

--- a/tests/test_rulegen_cli.py
+++ b/tests/test_rulegen_cli.py
@@ -151,3 +151,26 @@ def test_generate_default_capa_extension(monkeypatch, tmp_path):
 
     out_files = list((tmp_path / "models" / "rulebank" / "capa").glob("generated_*.yml"))
     assert len(out_files) == 1
+
+
+def test_parser_accepts_combo_options(monkeypatch):
+    import importlib
+
+    rulegen_cli = importlib.import_module("src.cli.rulegen_cli")
+    parser = rulegen_cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ppo-train",
+            "--train-features",
+            "feats.json",
+            "--dataset-dir",
+            "d",
+            "--condition-type",
+            "combo",
+            "--group-min-count",
+            "2",
+        ]
+    )
+    assert args.condition_type == "combo"
+    assert args.group_min_count == 2
+    assert args.func == rulegen_cli.cmd_ppo_train

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -1,0 +1,19 @@
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_combo_basic():
+    builder = YaraBuilder(condition_type="combo")
+    rule = builder.build(["call:CreateFileW", "import:WS2_32.dll"])
+    assert "any of ($c*)" in rule
+    assert "any of ($i*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err
+
+
+def test_combo_group_min_count():
+    builder = YaraBuilder(condition_type="combo", group_min_count=2)
+    rule = builder.build(["call:A", "call:B", "import:X", "import:Y"])
+    assert "2 of ($c*)" in rule
+    assert "2 of ($i*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- extend `YaraBuilder` with new `combo` condition type that groups features by prefix
- support per‑group thresholds using `group_percentage` or `group_min_count`
- expose new parameters in `rulegen_cli`
- update Yara builder CLI for combo mode
- test combo behaviour and CLI parsing

## Testing
- `pytest -q tests/test_yara_builder_combo.py`
- `pytest -q tests/test_yara_builder_percentage.py tests/test_yara_builder_count.py tests/test_yara_builder_prefix_strip.py tests/test_yara_builder_quotes.py tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_combo.py`
- `pytest -q tests/test_rulegen_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_688247ceb4f0832e8e23571b8f749c66