### PR TITLE
Improve FP check for explainer rule evaluator

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import logging
 from src.common.utils import get_logger, tqdm_wrap
@@ -177,6 +177,7 @@ def evaluate_single(
     percentage: int,
     clean_dir: Path | None = None,
     clean_sample: Path | None = None,
+    clean_paths: Sequence[Path] | None = None,
     sample_json: Path | None = None,
     json_match: bool = False,
 ) -> Dict[str, Any]:
@@ -271,7 +272,17 @@ def evaluate_single(
             result["false_positive"] = bool(compiled.match(str(clean_sample)))
         except Exception:
             result["false_positive"] = False
-    elif clean_dir is not None or clean_sample is not None:
+    elif clean_paths is not None and compiled is not None:
+        fp = False
+        for p in clean_paths:
+            try:
+                if compiled.match(str(p)):
+                    fp = True
+                    break
+            except Exception:
+                continue
+        result["false_positive"] = fp
+    elif clean_dir is not None or clean_sample is not None or clean_paths is not None:
         result["false_positive"] = False
 
     if sample_json is not None and sample_json.is_file():
@@ -341,6 +352,12 @@ def main(argv: list[str] | None = None) -> None:
 
         df = pd.read_csv(args.meta_csv)
         rows = df[df.get("label", 1) == 1]
+        benign_paths: list[Path] = []
+        benign_rows = df[df.get("label", 1) == 0]
+        for _, b_row in benign_rows.iterrows():
+            bsha = b_row["sha256"]
+            bname = b_row.get("filename") or b_row.get("name") or f"{bsha}.bin"
+            benign_paths.append(Path(args.sample_dir or args.graph_dir) / bname)
         results: list[dict[str, Any]] = []
         skipped = 0
         row_iter = tqdm_wrap(
@@ -370,6 +387,7 @@ def main(argv: list[str] | None = None) -> None:
                     percentage=args.percentage,
                     clean_dir=args.clean_dir,
                     clean_sample=None,
+                    clean_paths=(benign_paths if args.clean_dir is None and args.clean_sample is None else None),
                     sample_json=jpath,
                     json_match=args.json_match,
                 )
@@ -433,6 +451,7 @@ def main(argv: list[str] | None = None) -> None:
             percentage=args.percentage,
             clean_dir=args.clean_dir,
             clean_sample=args.clean_sample,
+            clean_paths=None,
             sample_json=(args.sample_dir / f"{args.sample.stem}.json" if args.sample_dir else None),
             json_match=args.json_match,
         )

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -178,3 +178,57 @@ def test_cli_json_match_detects(tmp_path, monkeypatch):
     assert data["detected"] is True
     assert data["coverage"] == 0.0
 
+
+def test_batch_fp_ratio_from_benign(tmp_path, monkeypatch, caplog):
+    import pandas as pd
+
+    csv = tmp_path / "meta.csv"
+    pd.DataFrame(
+        {
+            "sha256": ["a", "b"],
+            "label": [1, 0],
+            "filename": ["a.bin", "b.bin"],
+        }
+    ).to_csv(csv, index=False)
+
+    gdir = tmp_path / "graphs"
+    gdir.mkdir()
+    (gdir / "a.pt").write_text("stub")
+
+    sdir = tmp_path / "samples"
+    sdir.mkdir()
+    (sdir / "a.bin").write_text("mal")
+    (sdir / "b.bin").write_text("ben")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    calls = []
+
+    def fake_eval(*args, **kwargs):
+        calls.append(list(kwargs.get("clean_paths", []) or []))
+        return {
+            "detected": True,
+            "rule_length": 0,
+            "avg_importance": 0.0,
+            "mask_sparsity": 0.0,
+            "coverage": 0.0,
+            "false_positive": True,
+        }
+
+    monkeypatch.setattr(mod, "evaluate_single", fake_eval)
+
+    caplog.set_level("INFO", logger=mod.LOGGER.name)
+    mod.main([
+        "--graph-dir",
+        str(gdir),
+        "--sample-dir",
+        str(sdir),
+        "--meta-csv",
+        str(csv),
+        "--classifier",
+        str(sdir / "a.bin"),
+    ])
+
+    assert calls == [[sdir / "b.bin"]]
+    assert any("FP ratio=1.000" in rec.message for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- support benign sample list for FP detection in `evaluate_single`
- feed benign paths from metadata in batch evaluation
- test FP ratio calculation for benign samples

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_batch_fp_ratio_from_benign -q`
- `pytest -q` *(fails: missing heavy dependencies like matplotlib, sentencepiece)*

------
https://chatgpt.com/codex/tasks/task_e_688249ac9900832e9ee837e84da7c29a