### PR TITLE
Improve JSON FP checks in explainer evaluator

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -255,35 +255,51 @@ def evaluate_single(
     }
     result["rule_text"] = rule_text
 
-    if clean_dir is not None and clean_dir.is_dir() and compiled is not None:
-        fp = False
-        for fp_path in clean_dir.iterdir():
-            if not fp_path.is_file():
-                continue
-            try:
-                if compiled.match(str(fp_path)):
-                    fp = True
-                    break
-            except Exception:
-                continue
-        result["false_positive"] = fp
-    elif clean_sample is not None and compiled is not None:
-        try:
-            result["false_positive"] = bool(compiled.match(str(clean_sample)))
-        except Exception:
+    if json_match:
+        def _check_json(p: Path) -> bool:
+            j = p.with_suffix(".json")
+            return j.is_file() and verify_features(j, features)
+
+        if clean_dir is not None and clean_dir.is_dir():
+            fp = any(_check_json(p) for p in clean_dir.iterdir() if p.is_file())
+            result["false_positive"] = fp
+        elif clean_sample is not None:
+            result["false_positive"] = _check_json(clean_sample)
+        elif clean_paths is not None:
+            fp = any(_check_json(p) for p in clean_paths)
+            result["false_positive"] = fp
+        elif clean_dir is not None or clean_sample is not None or clean_paths is not None:
             result["false_positive"] = False
-    elif clean_paths is not None and compiled is not None:
-        fp = False
-        for p in clean_paths:
+    else:
+        if clean_dir is not None and clean_dir.is_dir() and compiled is not None:
+            fp = False
+            for fp_path in clean_dir.iterdir():
+                if not fp_path.is_file():
+                    continue
+                try:
+                    if compiled.match(str(fp_path)):
+                        fp = True
+                        break
+                except Exception:
+                    continue
+            result["false_positive"] = fp
+        elif clean_sample is not None and compiled is not None:
             try:
-                if compiled.match(str(p)):
-                    fp = True
-                    break
+                result["false_positive"] = bool(compiled.match(str(clean_sample)))
             except Exception:
-                continue
-        result["false_positive"] = fp
-    elif clean_dir is not None or clean_sample is not None or clean_paths is not None:
-        result["false_positive"] = False
+                result["false_positive"] = False
+        elif clean_paths is not None and compiled is not None:
+            fp = False
+            for p in clean_paths:
+                try:
+                    if compiled.match(str(p)):
+                        fp = True
+                        break
+                except Exception:
+                    continue
+            result["false_positive"] = fp
+        elif clean_dir is not None or clean_sample is not None or clean_paths is not None:
+            result["false_positive"] = False
 
     if sample_json is not None and sample_json.is_file():
         result["feature_verified"] = verify_features(sample_json, features)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -232,3 +232,110 @@ def test_batch_fp_ratio_from_benign(tmp_path, monkeypatch, caplog):
     assert calls == [[sdir / "b.bin"]]
     assert any("FP ratio=1.000" in rec.message for rec in caplog.records)
 
+
+def test_evaluate_single_json_match_fp_with_clean_sample(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+    clean_json = tmp_path / "clean.json"
+    clean_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+    )
+
+    assert res["false_positive"] is True
+
+
+def test_evaluate_single_json_match_fp_with_clean_dir(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    cldir = tmp_path / "cleandir"
+    cldir.mkdir()
+    clean = cldir / "clean.bin"
+    clean.write_bytes(b"dummy")
+    (cldir / "clean.json").write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        clean_dir=cldir,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+    )
+
+    assert res["false_positive"] is True
+


### PR DESCRIPTION
## Summary
- ensure `evaluate_single` checks clean sample JSONs when `--json-match` is used
- support this behaviour for `--clean-dir` and `--clean-sample`
- test FP detection for JSON matching with clean sample and clean dir

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_json_match_fp_with_clean_sample -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_json_match_fp_with_clean_dir -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68824bfd78c0832ea659bc3fc7194d50