### PR TITLE
Support combo/count in explainer rule CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,20 @@ obs, _ = env.reset()  # `reset()` 호출 시 다른 힌트를 전달할 수도 �
 # The YARA builder keeps at least one real feature even when token
 # extraction fails. Short hint tokens such as `pe` are accepted
 # without padding.
+
+```bash
+# explainer output evaluation with combo condition
+python -m src.cli.explainer_rule_eval \
+    --graph graph.pt --sample sample.bin \
+    --saliency sal.pt --classifier models/gnn/res_gcl.pt \
+    --condition-type combo --group-min-count 2
+
+# count condition example
+python -m src.cli.explainer_rule_eval \
+    --graph graph.pt --sample sample.bin \
+    --saliency sal.pt --classifier models/gnn/res_gcl.pt \
+    --condition-type count --min-count 3
+```
 # XAI selector 학습
 # 분류기가 HeteroData 그래프를 입력으로 받아도 동일하게 사용할 수 있습니다.
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -175,6 +175,9 @@ def evaluate_single(
     keep_per_type: int = 20,
     condition_type: str,
     percentage: int,
+    min_count: int | None = None,
+    group_percentage: int | None = None,
+    group_min_count: int | None = None,
     clean_dir: Path | None = None,
     clean_sample: Path | None = None,
     clean_paths: Sequence[Path] | None = None,
@@ -207,7 +210,13 @@ def evaluate_single(
         LOGGER.debug("Mined %d features", len(features))
 
     LOGGER.debug("Building YARA rule with %d features", len(features))
-    builder = YaraBuilder(condition_type=condition_type, percentage=percentage)
+    builder = YaraBuilder(
+        condition_type=condition_type,
+        percentage=percentage,
+        min_count=min_count,
+        group_percentage=group_percentage,
+        group_min_count=group_min_count,
+    )
     rule_text = builder.build(features)
     builder.validate(rule_text)
 
@@ -333,11 +342,32 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--min-saliency", type=float, default=1e-3)
     p.add_argument(
         "--condition-type",
-        choices=["any", "all", "percentage"],
+        choices=["any", "all", "percentage", "count", "combo"],
         default="any",
         help="YARA condition type",
     )
-    p.add_argument("--percentage", type=int, default=70, help="Percentage value if using percentage condition")
+    p.add_argument(
+        "--percentage",
+        type=int,
+        default=70,
+        help="Percentage value if using percentage condition",
+    )
+    p.add_argument(
+        "--min-count",
+        type=int,
+        default=None,
+        help="Minimum match count if using count condition",
+    )
+    p.add_argument(
+        "--group-percentage",
+        type=int,
+        help="combo mode: percentage of each group",
+    )
+    p.add_argument(
+        "--group-min-count",
+        type=int,
+        help="combo mode: minimum matches per group",
+    )
     p.add_argument("--clean-sample", type=Path, help="Optional clean sample for FP check")
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")
@@ -401,6 +431,9 @@ def main(argv: list[str] | None = None) -> None:
                     keep_per_type=args.keep_per_type,
                     condition_type=args.condition_type,
                     percentage=args.percentage,
+                    min_count=args.min_count,
+                    group_percentage=args.group_percentage,
+                    group_min_count=args.group_min_count,
                     clean_dir=args.clean_dir,
                     clean_sample=None,
                     clean_paths=(benign_paths if args.clean_dir is None and args.clean_sample is None else None),
@@ -465,6 +498,9 @@ def main(argv: list[str] | None = None) -> None:
             keep_per_type=args.keep_per_type,
             condition_type=args.condition_type,
             percentage=args.percentage,
+            min_count=args.min_count,
+            group_percentage=args.group_percentage,
+            group_min_count=args.group_min_count,
             clean_dir=args.clean_dir,
             clean_sample=args.clean_sample,
             clean_paths=None,

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -46,6 +46,82 @@ def test_cli_runs_and_writes_json(tmp_path, caplog):
     assert any("Building YARA rule" in rec.message for rec in caplog.records)
 
 
+def test_cli_condition_type_count(tmp_path):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    out = tmp_path / "res.json"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--condition-type",
+        "count",
+        "--min-count",
+        "1",
+        "--out",
+        str(out),
+    ])
+
+    data = json.loads(out.read_text())
+    assert "detected" in data
+
+
+def test_cli_condition_type_combo(tmp_path):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    out = tmp_path / "res.json"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--condition-type",
+        "combo",
+        "--group-min-count",
+        "1",
+        "--out",
+        str(out),
+    ])
+
+    data = json.loads(out.read_text())
+    assert "detected" in data
+
+
 def test_cli_sample_rules_out(tmp_path):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)
@@ -276,6 +352,9 @@ def test_evaluate_single_json_match_fp_with_clean_sample(tmp_path, monkeypatch):
         top_k=1,
         condition_type="any",
         percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
         clean_dir=None,
         clean_sample=clean,
         clean_paths=None,
@@ -330,6 +409,9 @@ def test_evaluate_single_json_match_fp_with_clean_dir(tmp_path, monkeypatch):
         top_k=1,
         condition_type="any",
         percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
         clean_dir=cldir,
         clean_sample=None,
         clean_paths=None,


### PR DESCRIPTION
## Summary
- extend `explainer_rule_eval` to accept combo and count rule types
- add CLI arguments for `--min-count`, `--group-percentage`, and `--group-min-count`
- pass new parameters to `YaraBuilder`
- document usage examples with the new options
- test CLI with combo and count conditions

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py tests/test_yara_builder_combo.py tests/test_yara_builder_count.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68824e3fefc4832ebe0a4ccbc65d6aa1