### PR TITLE
Add benign freq filtering to FeatureMiner

### DIFF
--- a/scripts/compute_feature_freqs.py
+++ b/scripts/compute_feature_freqs.py
@@ -1,0 +1,51 @@
+import argparse
+import json
+from pathlib import Path
+from collections import Counter
+
+
+def read_items(path: Path) -> list[dict]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, list):
+            return obj
+    except json.JSONDecodeError:
+        pass
+    items = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        items.append(json.loads(line))
+    return items
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description="Compute feature frequency statistics")
+    p.add_argument("features", nargs="+", type=Path, help="JSON files from feature-mine")
+    p.add_argument("--output", type=Path, required=True, help="Output JSON path")
+    args = p.parse_args(argv)
+
+    benign = Counter()
+    malicious = Counter()
+    for fp in args.features:
+        for item in read_items(fp):
+            feats = item.get("features") or []
+            label = item.get("label", 1)
+            if label == 0:
+                benign.update(feats)
+            else:
+                malicious.update(feats)
+
+    result = {
+        "benign": dict(benign),
+        "malicious": dict(malicious),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"[OK] saved -> {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -173,6 +173,8 @@ def evaluate_single(
     dynamic_k: bool = False,
     min_saliency: float = 1e-3,
     keep_per_type: int = 20,
+    benign_freqs: dict[str, int] | None = None,
+    freq_threshold: float | int = 0,
     condition_type: str,
     percentage: int,
     clean_dir: Path | None = None,
@@ -201,6 +203,8 @@ def evaluate_single(
         dynamic_k=dynamic_k,
         min_saliency=min_saliency,
         keep_per_type=keep_per_type,
+        benign_freqs=benign_freqs,
+        freq_threshold=freq_threshold,
     )
     features = miner.mine(graph, saliency)
     if LOGGER.isEnabledFor(logging.DEBUG):
@@ -331,6 +335,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dynamic-k", action="store_true")
     p.add_argument("--keep-per-type", type=int, default=20)
     p.add_argument("--min-saliency", type=float, default=1e-3)
+    p.add_argument("--benign-freqs", type=Path, help="JSON with benign feature frequencies")
+    p.add_argument("--freq-threshold", type=float, default=0.0, help="Frequency threshold for filtering")
     p.add_argument(
         "--condition-type",
         choices=["any", "all", "percentage"],
@@ -360,6 +366,10 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.verbose:
         LOGGER.setLevel(logging.DEBUG)
+
+    benign_freqs = None
+    if args.benign_freqs and args.benign_freqs.is_file():
+        benign_freqs = json.loads(args.benign_freqs.read_text(encoding="utf-8"))
 
     device = torch.device(args.device)
 
@@ -399,6 +409,8 @@ def main(argv: list[str] | None = None) -> None:
                     dynamic_k=args.dynamic_k,
                     min_saliency=args.min_saliency,
                     keep_per_type=args.keep_per_type,
+                    benign_freqs=benign_freqs,
+                    freq_threshold=args.freq_threshold,
                     condition_type=args.condition_type,
                     percentage=args.percentage,
                     clean_dir=args.clean_dir,
@@ -463,6 +475,8 @@ def main(argv: list[str] | None = None) -> None:
             dynamic_k=args.dynamic_k,
             min_saliency=args.min_saliency,
             keep_per_type=args.keep_per_type,
+            benign_freqs=benign_freqs,
+            freq_threshold=args.freq_threshold,
             condition_type=args.condition_type,
             percentage=args.percentage,
             clean_dir=args.clean_dir,

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -185,7 +185,10 @@ def generate_explainer_hints(
         except Exception as exc:  # pragma: no cover - simple I/O errors
             raise RuntimeError(f"failed to load explainer: {exc}")
 
-    miner = FeatureMiner()
+    benign_freqs = None
+    if args.benign_freqs and Path(args.benign_freqs).is_file():
+        benign_freqs = json.loads(Path(args.benign_freqs).read_text(encoding="utf-8"))
+    miner = FeatureMiner(benign_freqs=benign_freqs, freq_threshold=args.freq_threshold)
     hints: list[str] = []
 
     for g in graphs:
@@ -1161,6 +1164,8 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Classifier checkpoint used during explainer training",
     )
+    fm.add_argument("--benign-freqs", type=Path, help="JSON with benign feature frequencies")
+    fm.add_argument("--freq-threshold", type=float, default=0.0, help="Frequency threshold for filtering")
     fm.set_defaults(func=cmd_feature_mine)
 
     # ------------------- build-dataset ------------------- #

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -78,6 +78,8 @@ class FeatureMiner:
         dynamic_k: bool = False,
         min_saliency: float = 1e-3,
         keep_per_type: int = 20,
+        benign_freqs: dict[str, int] | None = None,
+        freq_threshold: float | int = 0,
     ) -> None:
         """
         Args
@@ -93,6 +95,8 @@ class FeatureMiner:
         self.dynamic_k = dynamic_k
         self.min_saliency = min_saliency
         self.keep_per_type = keep_per_type
+        self.benign_freqs = benign_freqs
+        self.freq_threshold = freq_threshold
 
     # ──────────────────────────────────────────────── public ―─
 
@@ -136,6 +140,7 @@ class FeatureMiner:
 
         # 3) 정규화 & dedup 정렬
         cleaned = self._normalize_and_rank(raw_features)
+        cleaned = self._filter_by_benign_freq(cleaned)
         if sal_stats is not None:
             cleaned = self._filter_by_saliency_stats(cleaned, sal_stats)
         _LOG.debug("FeatureMiner: mined %d distinct candidates", len(cleaned))
@@ -535,6 +540,19 @@ class FeatureMiner:
             mal_score, ben_score = val
             if mal_score > self.min_saliency and mal_score > ben_score:
                 filtered.append(f)
+        return filtered
+
+    def _filter_by_benign_freq(self, feats: Sequence[str]) -> List[str]:
+        """정상 샘플에서 자주 등장하는 토큰을 제거한다."""
+        if not self.benign_freqs:
+            return list(feats)
+        threshold = float(self.freq_threshold)
+        filtered: List[str] = []
+        for f in feats:
+            freq = self.benign_freqs.get(f)
+            if freq is not None and freq >= threshold:
+                continue
+            filtered.append(f)
         return filtered
 
     # ──────────────────────────────────────────────────────────

--- a/tests/test_feature_miner_benign_freq.py
+++ b/tests/test_feature_miner_benign_freq.py
@@ -1,0 +1,18 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+import torch
+from torch_geometric.data import HeteroData
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_benign_freq_filter_removes_common_token():
+    g = HeteroData()
+    g["func"].x = torch.zeros(1, 1)
+    g["func"].name = ["CreateFileW"]
+    sal = torch.tensor([1.0])
+    miner = FeatureMiner(top_k=1, benign_freqs={"call:CreateFileW": 10}, freq_threshold=5)
+    feats = miner(g, sal)
+    assert "call:CreateFileW" not in feats


### PR DESCRIPTION
## Summary
- allow FeatureMiner to remove common tokens based on benign frequency
- compute frequency stats via `scripts/compute_feature_freqs.py`
- pass benign frequency options via rulegen CLI and explainer rule evaluation
- test that benign frequency filter drops common tokens

## Testing
- `pytest tests/test_feature_miner_benign_freq.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: pandas, sklearn, transformers, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68824e21ad58832eb27d2411120c1446