### PR TITLE
Enforce per-type node limits in FeatureMiner

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -125,6 +125,32 @@ class FeatureMiner:
 
         # 1) saliency 상위 노드 선택
         selected_indices = self._select_nodes(flat_sal)
+
+        # 타입별 상한 적용을 위해 선택 노드를 그룹화한다.
+        if self.keep_per_type > 0:
+            grouped: Dict[str, torch.Tensor] = {}
+            for ntype, (start, end) in node_offsets.items():
+                mask = (selected_indices >= start) & (selected_indices < end)
+                idxs = selected_indices[mask]
+                if idxs.numel() == 0:
+                    continue
+                sal_slice = flat_sal[idxs]
+                order = torch.argsort(sal_slice, descending=True)
+                idxs = idxs[order]
+                if idxs.numel() > self.keep_per_type:
+                    _LOG.debug(
+                        "FeatureMiner: trimmed %d nodes of type '%s'",
+                        idxs.numel() - self.keep_per_type,
+                        ntype,
+                    )
+                    idxs = idxs[: self.keep_per_type]
+                grouped[ntype] = idxs
+            if grouped:
+                selected_indices = torch.cat(list(grouped.values()))
+                sal_vals = flat_sal[selected_indices]
+                order = torch.argsort(sal_vals, descending=True)
+                selected_indices = selected_indices[order]
+
         selected_set = set(selected_indices.tolist())
 
         # 2) 노드별 메타 추출

--- a/tests/test_feature_miner_select_nodes.py
+++ b/tests/test_feature_miner_select_nodes.py
@@ -12,3 +12,24 @@ def test_select_nodes_limits_to_top_k():
     idx = miner._select_nodes(sal)
     assert len(idx) <= 5
     assert set(idx.tolist()) == set(range(5))
+
+
+def test_mine_limits_nodes_per_type():
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["func"].x = torch.zeros(3, 1)
+    g["func"].name = ["func0", "func1", "func2"]
+    g["str"].x = torch.zeros(3, 1)
+    g["str"].value = ["data0", "data1", "data2"]
+
+    sal = torch.tensor([0.9, 0.8, 0.7, 0.6, 0.5, 0.4])
+    miner = FeatureMiner(top_k=6, min_saliency=0.0, keep_per_type=2)
+    feats = miner(g, sal)
+
+    func_feats = [f for f in feats if f.startswith("call:")]
+    str_feats = [f for f in feats if "wide ascii" in f]
+    assert len(func_feats) == 2
+    assert len(str_feats) == 2
+    assert "call:func2" not in func_feats
+    assert '"s2" wide ascii nocase' not in str_feats


### PR DESCRIPTION
## Summary
- cap selected nodes per type in `FeatureMiner.mine`
- log trimming actions through `_LOG.debug`
- ensure overall ordering by saliency after trimming
- add regression test for per-type limit in `test_feature_miner_select_nodes`

## Testing
- `pytest -q tests/test_feature_miner_select_nodes.py`

------
https://chatgpt.com/codex/tasks/task_e_68826070487c832e9c4e731b62ab5c27