### PR TITLE
Update rule eval defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,11 +282,16 @@ obs, _ = env.reset()  # `reset()` 호출 시 다른 힌트를 전달할 수도 �
 # without padding.
 
 ```bash
-# explainer output evaluation with combo condition
+# explainer output evaluation (combo mode by default)
+python -m src.cli.explainer_rule_eval \
+    --graph graph.pt --sample sample.bin \
+    --saliency sal.pt --classifier models/gnn/res_gcl.pt
+
+# require at least two matches per group
 python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt \
-    --condition-type combo --group-min-count 2
+    --group-min-count 2
 
 # count condition example
 python -m src.cli.explainer_rule_eval \

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -174,3 +174,17 @@ python -m cli.rulegen_cli ppo-train \
     --use-shaping
 ```
 
+### Rule evaluation CLI
+
+`src.cli.explainer_rule_eval`는 그래프와 샘플을 입력으로 중요 노드를 기반한
+YARA 룰을 생성해 탐지 여부를 확인합니다. 기본 `--condition-type`은 `combo`
+이며 각 그룹의 50% 이상이 매치되어야 합니다.
+
+```bash
+python -m src.cli.explainer_rule_eval \
+    --graph graph.pt --sample sample.bin \
+    --saliency sal.pt --classifier models/gnn/res_gcl.pt
+```
+
+`--group-min-count` 나 `--group-percentage`로 조건을 조정할 수 있습니다.
+

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -349,7 +349,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--condition-type",
         choices=["any", "all", "percentage", "count", "combo"],
-        default="any",
+        default="combo",
         help="YARA condition type",
     )
     p.add_argument(
@@ -367,6 +367,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--group-percentage",
         type=int,
+        default=50,
         help="combo mode: percentage of each group",
     )
     p.add_argument(


### PR DESCRIPTION
## Summary
- default `--condition-type` to combo in explainer_rule_eval CLI
- set `--group-percentage` default to 50
- document rule evaluation defaults in README and quick start guide

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_runs_and_writes_json -q` *(fails: ModuleNotFoundError: No module named 'yara')*

------
https://chatgpt.com/codex/tasks/task_e_688269594b00832e80705d4263eaafb4