### PR TITLE
Fix benign freq graph lookup

### DIFF
--- a/scripts/compute_benign_freqs.py
+++ b/scripts/compute_benign_freqs.py
@@ -7,7 +7,7 @@ from collections import Counter
 import torch
 from torch_geometric.data import Data, HeteroData
 
-from src.graphs.dataset.graph_dataset import GraphDataset
+from src.graphs.dataset.graph_dataset import GraphDataset, _guess_graph_path
 from rulegen.feature_miner import FeatureMiner
 
 
@@ -51,7 +51,7 @@ def main(argv: list[str] | None = None) -> None:
                 alt = row.get("filename") or row.get("name")
                 path = None
                 if sha:
-                    cand = GraphDataset._guess_graph_path(graph_dir, sha)
+                    cand = _guess_graph_path(graph_dir, sha)
                     if cand.is_file():
                         path = cand
                 if path is None and alt:


### PR DESCRIPTION
## Summary
- update benign freq calculator to import and use `_guess_graph_path`

## Testing
- `pytest -k benign_freq -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68826eaef068832ead43ebe129d8b564