### PR TITLE
Add live progress metrics in rule eval batch loop

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -461,7 +461,15 @@ def main(argv: list[str] | None = None) -> None:
             res["sha256"] = sha
             results.append(res)
 
+            det_rate = sum(r.get("detected", False) for r in results) / len(results)
+            fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
+            row_iter.set_postfix(avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}")
+
+            if args.out_csv:
+                pd.DataFrame(results).to_csv(args.out_csv, index=False)
+
             if args.sample_rules_out and res.get("detected"):
+                # 탐지된 경우 규칙을 바로 저장하여 누락을 방지합니다.
                 rule_dir = args.sample_rules_out / "rule"
                 rule_dir.mkdir(parents=True, exist_ok=True)
                 fname = f"{sha}.yar"


### PR DESCRIPTION
## Summary
- update rule evaluation CLI to display live detection and FP metrics during batch runs
- save CSV incrementally when specified
- clarify rule saving comment for detected cases

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_runs_and_writes_json -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6882737ffd2c832e93414761bed1b9bb