### PR TITLE
Update default freq_threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ when an out-of-range index is found.
 python -m cli.rulegen_cli feature-mine \
        --graph-dir data/splits/ \
        --labels data/meta.csv \
-       --embed-dir data/embeds \
-       --classifier-ckpt models/gnn/res_gcl.pt \
-       --out features.json
+        --embed-dir data/embeds \
+        --classifier-ckpt models/gnn/res_gcl.pt \
+        --freq-threshold 10 \
+        --out features.json
 # 경로/레지스트리/URL 기반 문자열도 함께 추출됩니다.
 
 # 데이터셋 변환 예시

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -33,6 +33,7 @@ miner = FeatureMiner(
     top_k_percent=0.05,
     dynamic_k=True,
     keep_per_type=20,
+    freq_threshold=10,
 )
 candidates = miner(data, saliency)
 print(candidates[:5])

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -174,7 +174,7 @@ def evaluate_single(
     min_saliency: float = 1e-3,
     keep_per_type: int = 20,
     benign_freqs: dict[str, int] | None = None,
-    freq_threshold: float | int = 0,
+    freq_threshold: float | int = 10,
     condition_type: str,
     percentage: int,
     min_count: int | None = None,
@@ -345,7 +345,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--keep-per-type", type=int, default=20)
     p.add_argument("--min-saliency", type=float, default=1e-3)
     p.add_argument("--benign-freqs", type=Path, help="JSON with benign feature frequencies")
-    p.add_argument("--freq-threshold", type=float, default=0.0, help="Frequency threshold for filtering")
+    p.add_argument(
+        "--freq-threshold",
+        type=float,
+        default=10.0,
+        help="Frequency threshold for filtering",
+    )
     p.add_argument(
         "--condition-type",
         choices=["any", "all", "percentage", "count", "combo"],

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -356,7 +356,7 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
             )
             raise SystemExit(1)
 
-    miner = FeatureMiner()
+    miner = FeatureMiner(freq_threshold=args.freq_threshold)
 
     all_features: List[dict] = []
     num_features_per_graph: List[int] = []
@@ -1165,7 +1165,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Classifier checkpoint used during explainer training",
     )
     fm.add_argument("--benign-freqs", type=Path, help="JSON with benign feature frequencies")
-    fm.add_argument("--freq-threshold", type=float, default=0.0, help="Frequency threshold for filtering")
+    fm.add_argument(
+        "--freq-threshold",
+        type=float,
+        default=10.0,
+        help="Frequency threshold for filtering",
+    )
     fm.set_defaults(func=cmd_feature_mine)
 
     # ------------------- build-dataset ------------------- #


### PR DESCRIPTION
## Summary
- bump FeatureMiner freq_threshold defaults to 10 in CLI
- document new freq_threshold default in quick start
- update README usage example with `--freq-threshold 10`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68827e659dc8832e8486235cbfe059dd