### PR TITLE
Enhance combo YARA builder

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -192,7 +192,8 @@ python -m cli.rulegen_cli ppo-train \
 
 `src.cli.explainer_rule_eval`는 그래프와 샘플을 입력으로 중요 노드를 기반한
 YARA 룰을 생성해 탐지 여부를 확인합니다. 기본 `--condition-type`은 `combo`
-이며 각 그룹의 50% 이상이 매치되어야 합니다.
+이며 각 그룹의 50% 이상이 매치되어야 합니다. 단, 그룹이 하나이거나 특징이
+2개 이하일 때는 자동으로 `any` 조건으로 전환됩니다.
 
 ```bash
 python -m src.cli.explainer_rule_eval \
@@ -200,5 +201,7 @@ python -m src.cli.explainer_rule_eval \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt
 ```
 
-`--group-min-count` 나 `--group-percentage`로 조건을 조정할 수 있습니다.
+`--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
+`--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로
+낮춰집니다.
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -180,6 +180,7 @@ def evaluate_single(
     min_count: int | None = None,
     group_percentage: int | None = None,
     group_min_count: int | None = None,
+    adjust_group_percentage: bool = False,
     clean_dir: Path | None = None,
     clean_sample: Path | None = None,
     clean_paths: Sequence[Path] | None = None,
@@ -220,6 +221,7 @@ def evaluate_single(
         min_count=min_count,
         group_percentage=group_percentage,
         group_min_count=group_min_count,
+        adjust_group_percentage=adjust_group_percentage,
     )
     rule_text = builder.build(features)
     builder.validate(rule_text)
@@ -373,12 +375,20 @@ def build_parser() -> argparse.ArgumentParser:
         "--group-percentage",
         type=int,
         default=50,
-        help="combo mode: percentage of each group",
+        help=(
+            "combo mode: percentage of each group; if only one group or two "
+            "features are present the condition falls back to 'any'."
+        ),
     )
     p.add_argument(
         "--group-min-count",
         type=int,
         help="combo mode: minimum matches per group",
+    )
+    p.add_argument(
+        "--adjust-group-percentage",
+        action="store_true",
+        help="lower group percentage automatically for many features",
     )
     p.add_argument("--clean-sample", type=Path, help="Optional clean sample for FP check")
     p.add_argument("--out", type=Path, help="Save JSON result path")
@@ -452,6 +462,7 @@ def main(argv: list[str] | None = None) -> None:
                     min_count=args.min_count,
                     group_percentage=args.group_percentage,
                     group_min_count=args.group_min_count,
+                    adjust_group_percentage=args.adjust_group_percentage,
                     clean_dir=args.clean_dir,
                     clean_sample=None,
                     clean_paths=(benign_paths if args.clean_dir is None and args.clean_sample is None else None),
@@ -529,6 +540,7 @@ def main(argv: list[str] | None = None) -> None:
             min_count=args.min_count,
             group_percentage=args.group_percentage,
             group_min_count=args.group_min_count,
+            adjust_group_percentage=args.adjust_group_percentage,
             clean_dir=args.clean_dir,
             clean_sample=args.clean_sample,
             clean_paths=None,

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -106,6 +106,7 @@ class YaraBuilder:
         min_count: int | None = None,
         group_percentage: int | None = None,
         group_min_count: int | None = None,
+        adjust_group_percentage: bool = False,
         tokenizer: Optional[PreTrainedTokenizer] = None,
         strip_prefix: bool = True,
     ) -> None:
@@ -121,6 +122,17 @@ class YaraBuilder:
         self.strip_prefix = strip_prefix
         self.group_percentage = group_percentage
         self.group_min_count = group_min_count
+        self.adjust_group_percentage = adjust_group_percentage
+
+    def _scaled_group_percentage(self, n_feats: int) -> int:
+        """Return adjusted group percentage based on feature count."""
+        if not self.adjust_group_percentage or self.group_percentage is None:
+            return self.group_percentage or 0
+        if n_feats <= 0:
+            return self.group_percentage
+        scaled = int(round(self.group_percentage / math.sqrt(n_feats)))
+        scaled = max(1, min(self.group_percentage, scaled))
+        return scaled
 
     def _detokenize(self, tokens: Sequence[str]) -> str:
         """
@@ -226,18 +238,29 @@ class YaraBuilder:
         elif self.condition_type == "count":
             cond_line = f"    {self.min_count} of them"
         else:  # combo
-            parts = []
-            for tag, feats_list in groups.items():
-                if not feats_list:
-                    continue
-                if self.group_min_count is not None:
-                    parts.append(f"{self.group_min_count} of (${tag}*)")
-                elif self.group_percentage is not None:
-                    n = max(1, math.ceil(len(feats_list) * self.group_percentage / 100.0))
-                    parts.append(f"{n} of (${tag}*)")
-                else:
-                    parts.append(f"any of (${tag}*)")
-            cond_line = "    " + " and ".join(parts)
+            group_count = sum(1 for v in groups.values() if v)
+            feat_count = len(unique_feats)
+            if (
+                self.group_percentage is not None
+                and (group_count <= 1 or feat_count <= 2)
+            ):
+                cond_line = "    any of them"
+            else:
+                parts = []
+                for tag, feats_list in groups.items():
+                    if not feats_list:
+                        continue
+                    if self.group_min_count is not None:
+                        parts.append(f"{self.group_min_count} of (${tag}*)")
+                    elif self.group_percentage is not None:
+                        pct = self.group_percentage
+                        if self.adjust_group_percentage:
+                            pct = self._scaled_group_percentage(len(feats_list))
+                        n = max(1, math.ceil(len(feats_list) * pct / 100.0))
+                        parts.append(f"{n} of (${tag}*)")
+                    else:
+                        parts.append(f"any of (${tag}*)")
+                cond_line = "    " + " and ".join(parts)
 
         # 5) join
         rule_lines = [
@@ -387,6 +410,11 @@ def _cli():
     parser.add_argument("--min-count", type=int, default=None, help="minimum count value")
     parser.add_argument("--group-percentage", type=int, help="combo mode: group percentage")
     parser.add_argument("--group-min-count", type=int, help="combo mode: group min count")
+    parser.add_argument(
+        "--adjust-group-percentage",
+        action="store_true",
+        help="lower group percentage automatically for many features",
+    )
     args = parser.parse_args()
 
     builder = YaraBuilder(
@@ -395,6 +423,7 @@ def _cli():
         min_count=args.min_count,
         group_percentage=args.group_percentage,
         group_min_count=args.group_min_count,
+        adjust_group_percentage=args.adjust_group_percentage,
     )
     rule_text = builder.build(args.tokens)
     print(rule_text)

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -17,3 +17,25 @@ def test_combo_group_min_count():
     assert "2 of ($i*)" in rule
     ok, err = builder.validate(rule)
     assert ok, err
+
+
+def test_combo_percentage_falls_back_any():
+    builder = YaraBuilder(condition_type="combo", group_percentage=50)
+    rule = builder.build(["call:A", "call:B"])
+    assert "any of them" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err
+
+
+def test_combo_adjust_group_percentage():
+    feats = [f"call:A{i}" for i in range(5)] + [f"import:I{i}" for i in range(5)]
+    builder = YaraBuilder(
+        condition_type="combo",
+        group_percentage=50,
+        adjust_group_percentage=True,
+    )
+    rule = builder.build(feats)
+    assert "2 of ($c*)" in rule
+    assert "2 of ($i*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- adapt YaraBuilder combo mode
  - fallback to `any` if only one group or <=2 features
  - optional adaptive group percentage
- expose new behaviour via explainer CLI
- document updated CLI options
- extend tests for combo conditions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.contrast')*

------
https://chatgpt.com/codex/tasks/task_e_688281358164832eb1bd85e715f1c6ad