### PR TITLE
Filter rule features by sample JSON

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -211,15 +211,23 @@ def evaluate_single(
         freq_threshold=freq_threshold,
     )
     features = miner.mine(graph, saliency)
+    if sample_json is not None and sample_json.is_file():
+        filtered = [f for f in features if verify_features(sample_json, [f])]
+        if not filtered and features:
+            filtered = [features[0]]
+        features = filtered
     if LOGGER.isEnabledFor(logging.DEBUG):
         LOGGER.debug("Mined %d features", len(features))
 
     LOGGER.debug("Building YARA rule with %d features", len(features))
+    group_pct = group_percentage
+    if condition_type == "combo" and group_min_count is not None:
+        group_pct = None
     builder = YaraBuilder(
         condition_type=condition_type,
         percentage=percentage,
         min_count=min_count,
-        group_percentage=group_percentage,
+        group_percentage=group_pct,
         group_min_count=group_min_count,
         adjust_group_percentage=adjust_group_percentage,
     )

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -421,3 +421,108 @@ def test_evaluate_single_json_match_fp_with_clean_dir(tmp_path, monkeypatch):
 
     assert res["false_positive"] is True
 
+
+def test_evaluate_single_json_feature_filter(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:bar", "call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+    )
+
+    assert res["rule_length"] == 1
+    assert "foo" in res["rule_text"]
+    assert "bar" not in res["rule_text"]
+
+
+def test_evaluate_single_json_feature_filter_fallback(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["other"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+    )
+
+    assert res["rule_length"] == 1
+    assert "foo" in res["rule_text"]
+


### PR DESCRIPTION
## Summary
- filter features mined for a sample by verifying they exist in the JSON report
- when filtering removes all features, keep one feature based on saliency order
- avoid YARA builder argument conflict when using combo mode with `--group-min-count`
- test JSON-based feature filtering and fallback logic

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688286715a58832eb1ec09bf06da91a0