### PR TITLE
Add saliency top percent filter

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -170,6 +170,7 @@ def evaluate_single(
     device: torch.device,
     top_k: int,
     top_k_percent: float | None = None,
+    saliency_top_percent: float | None = None,
     dynamic_k: bool = False,
     min_saliency: float = 1e-3,
     keep_per_type: int = 20,
@@ -204,6 +205,7 @@ def evaluate_single(
     miner = FeatureMiner(
         top_k=top_k,
         top_k_percent=top_k_percent,
+        saliency_top_percent=saliency_top_percent,
         dynamic_k=dynamic_k,
         min_saliency=min_saliency,
         keep_per_type=keep_per_type,
@@ -351,6 +353,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--device", type=str, default="cpu")
     p.add_argument("--top-k", type=int, default=40)
     p.add_argument("--top-k-percent", type=float, default=None)
+    p.add_argument("--saliency-top-percent", type=float, default=None, help="Limit nodes by cumulative saliency percentage")
     p.add_argument("--dynamic-k", action="store_true")
     p.add_argument("--keep-per-type", type=int, default=20)
     p.add_argument("--min-saliency", type=float, default=1e-3)
@@ -460,6 +463,7 @@ def main(argv: list[str] | None = None) -> None:
                     device=device,
                     top_k=args.top_k,
                     top_k_percent=args.top_k_percent,
+                    saliency_top_percent=args.saliency_top_percent,
                     dynamic_k=args.dynamic_k,
                     min_saliency=args.min_saliency,
                     keep_per_type=args.keep_per_type,
@@ -538,6 +542,7 @@ def main(argv: list[str] | None = None) -> None:
             device=device,
             top_k=args.top_k,
             top_k_percent=args.top_k_percent,
+            saliency_top_percent=args.saliency_top_percent,
             dynamic_k=args.dynamic_k,
             min_saliency=args.min_saliency,
             keep_per_type=args.keep_per_type,

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -164,6 +164,7 @@ def generate_explainer_hints(
     classifier_ckpt: str,
     device: str,
     explainer_ckpt: str | None = None,
+    saliency_top_percent: float | None = None,
 ) -> list[str]:
     """Generate rule hints using gradients or a pretrained explainer."""
 
@@ -188,7 +189,11 @@ def generate_explainer_hints(
     benign_freqs = None
     if args.benign_freqs and Path(args.benign_freqs).is_file():
         benign_freqs = json.loads(Path(args.benign_freqs).read_text(encoding="utf-8"))
-    miner = FeatureMiner(benign_freqs=benign_freqs, freq_threshold=args.freq_threshold)
+    miner = FeatureMiner(
+        benign_freqs=benign_freqs,
+        freq_threshold=args.freq_threshold,
+        saliency_top_percent=saliency_top_percent,
+    )
     hints: list[str] = []
 
     for g in graphs:
@@ -356,7 +361,10 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
             )
             raise SystemExit(1)
 
-    miner = FeatureMiner(freq_threshold=args.freq_threshold)
+    miner = FeatureMiner(
+        freq_threshold=args.freq_threshold,
+        saliency_top_percent=args.saliency_top_percent,
+    )
 
     all_features: List[dict] = []
     num_features_per_graph: List[int] = []
@@ -566,6 +574,7 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
                 args.classifier_checkpoint,
                 args.classifier_device,
                 args.explainer_checkpoint,
+                saliency_top_percent=args.saliency_top_percent,
             )
         except Exception as exc:
             logger.error("Failed to generate explainer hints: %s", exc)
@@ -1170,6 +1179,12 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=10.0,
         help="Frequency threshold for filtering",
+    )
+    fm.add_argument(
+        "--saliency-top-percent",
+        type=float,
+        default=None,
+        help="Limit nodes by cumulative saliency percentage",
     )
     fm.set_defaults(func=cmd_feature_mine)
 

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -75,6 +75,7 @@ class FeatureMiner:
         *,
         top_k: int = 50,
         top_k_percent: float | None = None,
+        saliency_top_percent: float | None = None,
         dynamic_k: bool = False,
         min_saliency: float = 1e-3,
         keep_per_type: int = 20,
@@ -89,9 +90,11 @@ class FeatureMiner:
         dynamic_k     : 노드 saliency 분포(평균+표준편차)에 따라 k를 자동 조정한다.
         min_saliency  : 절대 saliency 임계값 (둘 중 하나라도 통과하면 선택).
         keep_per_type : 노드 타입마다 너무 편중되지 않도록 선정 상한.
+        saliency_top_percent : 누적 saliency 기준 추가 필터 (0~1 사이).
         """
         self.top_k = top_k
         self.top_k_percent = top_k_percent
+        self.saliency_top_percent = saliency_top_percent
         self.dynamic_k = dynamic_k
         self.min_saliency = min_saliency
         self.keep_per_type = keep_per_type
@@ -238,6 +241,26 @@ class FeatureMiner:
         if selected.numel() > k:
             topk_idx = torch.topk(flat_sal[selected], k).indices
             selected = selected[topk_idx]
+
+        if (
+            self.saliency_top_percent is not None
+            and selected.numel() > 0
+            and self.saliency_top_percent > 0
+        ):
+            order = torch.argsort(flat_sal[selected], descending=True)
+            sal_slice = flat_sal[selected][order]
+            cum = torch.cumsum(sal_slice, dim=0)
+            total = float(cum[-1])
+            if total > 0:
+                ratio = cum / total
+                idx = torch.searchsorted(
+                    ratio, float(self.saliency_top_percent), right=False
+                ).item()
+                keep_len = min(int(idx) + 1, selected.numel())
+                selected = selected[order][:keep_len]
+            else:
+                selected = selected[order[:1]]
+
         return selected
 
     def _map_global_to_local(

--- a/tests/test_feature_miner_select_nodes.py
+++ b/tests/test_feature_miner_select_nodes.py
@@ -33,3 +33,10 @@ def test_mine_limits_nodes_per_type():
     assert len(str_feats) == 2
     assert "call:func2" not in func_feats
     assert '"s2" wide ascii nocase' not in str_feats
+
+
+def test_select_nodes_saliency_top_percent():
+    sal = torch.tensor([10.0, 9.0, 8.0, 7.0, 6.0])
+    miner = FeatureMiner(top_k=5, min_saliency=0.0, saliency_top_percent=0.5)
+    idx = miner._select_nodes(sal)
+    assert set(idx.tolist()) == {0, 1, 2}


### PR DESCRIPTION
## Summary
- extend `FeatureMiner` with `saliency_top_percent` for cumulative saliency filtering
- expose the option via `--saliency-top-percent` in CLI tools
- filter by this option when selecting nodes
- unit test for new saliency top percent behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.contrast')*

------
https://chatgpt.com/codex/tasks/task_e_68828a0671cc832ea8b1ad9b4a6ede8e