### PR TITLE
Ensure benign freq filter keeps one token

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -602,6 +602,10 @@ class FeatureMiner:
             if freq is not None and freq >= threshold:
                 continue
             filtered.append(f)
+        if not filtered and feats:
+            # 모든 토큰이 필터링된 경우 최소 1개는 남기도록 한다.
+            first = feats[0]
+            filtered.append(first)
         return filtered
 
     # ──────────────────────────────────────────────────────────

--- a/tests/test_feature_miner_benign_freq.py
+++ b/tests/test_feature_miner_benign_freq.py
@@ -15,4 +15,20 @@ def test_benign_freq_filter_removes_common_token():
     sal = torch.tensor([1.0])
     miner = FeatureMiner(top_k=1, benign_freqs={"call:CreateFileW": 10}, freq_threshold=5)
     feats = miner(g, sal)
-    assert "call:CreateFileW" not in feats
+    assert feats == ["call:CreateFileW"]
+
+
+def test_benign_freq_filter_keeps_one_token_when_all_removed():
+    g = HeteroData()
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["CreateFileA", "CreateFileW"]
+
+    sal = torch.tensor([1.0, 0.9])
+    miner = FeatureMiner(
+        top_k=2,
+        benign_freqs={"call:CreateFileA": 10, "call:CreateFileW": 10},
+        freq_threshold=5,
+    )
+    feats = miner(g, sal)
+
+    assert feats == ["call:CreateFileA"]


### PR DESCRIPTION
## Summary
- keep the first feature if benign frequency filtering removes all
- add regression test checking that at least one token is returned
- adjust existing benign frequency filter test expectations

## Testing
- `pytest -q tests/test_feature_miner_benign_freq.py`

------
https://chatgpt.com/codex/tasks/task_e_6882ef8b6258832ea2152186626072bb