### PR TITLE
Enhance JSON feature verification

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any, Dict, Sequence
+import math
 
 import logging
 from src.common.utils import get_logger, tqdm_wrap
@@ -140,8 +141,16 @@ def _extract_tokens(feature: str) -> list[str]:
     return tokens
 
 
-def verify_features(json_path: Path, features: list[str]) -> bool:
-    """Return True if any feature token is found in sample JSON."""
+def verify_features(
+    json_path: Path,
+    features: list[str],
+    *,
+    condition_type: str = "any",
+    group_percentage: int | None = None,
+    group_min_count: int | None = None,
+    adjust_group_percentage: bool = False,
+) -> bool:
+    """Return True if ``features`` satisfy the condition in sample JSON."""
     try:
         js = json.loads(json_path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
@@ -153,11 +162,64 @@ def verify_features(json_path: Path, features: list[str]) -> bool:
         text_fields.extend(js.get(key, []))
 
     joined = "\n".join(text_fields).lower()
-    for feat in features:
+
+    def _feat_present(feat: str) -> bool:
         for tok in _extract_tokens(feat):
             if tok.lower() in joined:
                 return True
-    return False
+        return False
+
+    matched = [f for f in features if _feat_present(f)]
+
+    if condition_type != "combo":
+        if condition_type == "all":
+            return len(matched) == len(features)
+        if condition_type == "percentage" and group_percentage is not None:
+            thresh = max(1, math.ceil(len(features) * group_percentage / 100.0))
+            return len(matched) >= thresh
+        if condition_type == "count" and group_min_count is not None:
+            return len(matched) >= group_min_count
+        return bool(matched)
+
+    # combo mode
+    prefix_map = {"call:": "c", "import:": "i"}
+    groups: dict[str, list[str]] = {}
+    matched_groups: dict[str, int] = {}
+    for feat in features:
+        tag = "o"
+        for p, t in prefix_map.items():
+            if feat.startswith(p):
+                tag = t
+                break
+        groups.setdefault(tag, []).append(feat)
+        if feat in matched:
+            matched_groups[tag] = matched_groups.get(tag, 0) + 1
+
+    group_count = sum(1 for v in groups.values() if v)
+    feat_count = sum(len(v) for v in groups.values())
+
+    if group_percentage is not None and (group_count <= 1 or feat_count <= 2):
+        return bool(matched)
+
+    for tag, feats_list in groups.items():
+        if not feats_list:
+            continue
+        mcount = matched_groups.get(tag, 0)
+        if group_min_count is not None:
+            if mcount < group_min_count:
+                return False
+        elif group_percentage is not None:
+            pct = group_percentage
+            if adjust_group_percentage:
+                scaled = int(round(pct / math.sqrt(len(feats_list))))
+                pct = max(1, min(pct, scaled))
+            req = max(1, math.ceil(len(feats_list) * pct / 100.0))
+            if mcount < req:
+                return False
+        else:
+            if mcount == 0:
+                return False
+    return True
 
 
 def evaluate_single(
@@ -213,8 +275,22 @@ def evaluate_single(
         freq_threshold=freq_threshold,
     )
     features = miner.mine(graph, saliency)
+    group_pct = group_percentage
+    if condition_type == "combo" and group_min_count is not None:
+        group_pct = None
     if sample_json is not None and sample_json.is_file():
-        filtered = [f for f in features if verify_features(sample_json, [f])]
+        filtered = [
+            f
+            for f in features
+            if verify_features(
+                sample_json,
+                [f],
+                condition_type=condition_type,
+                group_percentage=group_pct,
+                group_min_count=group_min_count,
+                adjust_group_percentage=adjust_group_percentage,
+            )
+        ]
         if not filtered and features:
             filtered = [features[0]]
         features = filtered
@@ -222,9 +298,6 @@ def evaluate_single(
         LOGGER.debug("Mined %d features", len(features))
 
     LOGGER.debug("Building YARA rule with %d features", len(features))
-    group_pct = group_percentage
-    if condition_type == "combo" and group_min_count is not None:
-        group_pct = None
     builder = YaraBuilder(
         condition_type=condition_type,
         percentage=percentage,
@@ -242,7 +315,14 @@ def evaluate_single(
             LOGGER.warning("json_match enabled but JSON %s not found", jpath)
             detected = False
         else:
-            detected = verify_features(jpath, features)
+            detected = verify_features(
+                jpath,
+                features,
+                condition_type=condition_type,
+                group_percentage=group_pct,
+                group_min_count=group_min_count,
+                adjust_group_percentage=adjust_group_percentage,
+            )
         coverage = 0.0
         LOGGER.debug("Skipping YARA match; using JSON verification only")
         compiled = None
@@ -283,7 +363,14 @@ def evaluate_single(
     if json_match:
         def _check_json(p: Path) -> bool:
             j = p.with_suffix(".json")
-            return j.is_file() and verify_features(j, features)
+            return j.is_file() and verify_features(
+                j,
+                features,
+                condition_type=condition_type,
+                group_percentage=group_pct,
+                group_min_count=group_min_count,
+                adjust_group_percentage=adjust_group_percentage,
+            )
 
         if clean_dir is not None and clean_dir.is_dir():
             fp = any(_check_json(p) for p in clean_dir.iterdir() if p.is_file())
@@ -327,7 +414,14 @@ def evaluate_single(
             result["false_positive"] = False
 
     if sample_json is not None and sample_json.is_file():
-        result["feature_verified"] = verify_features(sample_json, features)
+        result["feature_verified"] = verify_features(
+            sample_json,
+            features,
+            condition_type=condition_type,
+            group_percentage=group_pct,
+            group_min_count=group_min_count,
+            adjust_group_percentage=adjust_group_percentage,
+        )
 
     return result
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -526,3 +526,90 @@ def test_evaluate_single_json_feature_filter_fallback(tmp_path, monkeypatch):
     assert res["rule_length"] == 1
     assert "foo" in res["rule_text"]
 
+
+def test_verify_features_combo_percentage(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["foo"]}))
+    feats = ["call:foo", "call:bar", "import:baz"]
+
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_percentage=50,
+        )
+        is False
+    )
+
+    js.write_text(json.dumps({"c_code": ["foo", "baz"]}))
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_percentage=50,
+        )
+        is True
+    )
+
+
+def test_verify_features_combo_min_count(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["foo"]}))
+    feats = ["call:foo", "call:bar", "import:baz", "import:qux"]
+
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_min_count=2,
+        )
+        is False
+    )
+
+    js.write_text(json.dumps({"c_code": ["foo", "bar", "baz", "qux"]}))
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_min_count=2,
+        )
+        is True
+    )
+
+
+def test_verify_features_combo_adjust_pct(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["foo", "qux"]}))
+    feats = ["call:foo", "call:bar", "call:baz", "import:qux"]
+
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_percentage=50,
+        )
+        is False
+    )
+
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_percentage=50,
+            adjust_group_percentage=True,
+        )
+        is True
+    )
+


### PR DESCRIPTION
## Summary
- extend `verify_features` for YARA combo rule logic
- pass verification parameters from `evaluate_single`
- test combo feature verification

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_verify_features_combo_percentage tests/test_explainer_rule_eval_cli.py::test_verify_features_combo_min_count tests/test_explainer_rule_eval_cli.py::test_verify_features_combo_adjust_pct -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f6bd9468832eb4711a5c3a9ab5aa