### PR TITLE
Extend evaluate_single for multiple rule generation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -25,6 +25,7 @@ LOGGER = get_logger(__name__)
 # Helper utilities
 # ---------------------------------------------------------------------------
 
+
 def _load_saliency(path: Path) -> Dict[str, torch.Tensor] | torch.Tensor:
     """Load saliency tensor from ``.pt`` or JSON."""
     if path.suffix == ".pt":
@@ -244,6 +245,8 @@ def evaluate_single(
     group_percentage: int | None = None,
     group_min_count: int | None = None,
     adjust_group_percentage: bool = False,
+    num_rules: int = 1,
+    chunk_size: int | None = None,
     clean_dir: Path | None = None,
     clean_sample: Path | None = None,
     clean_paths: Sequence[Path] | None = None,
@@ -262,7 +265,9 @@ def evaluate_single(
         LOGGER.info("Loading saliency from %s", saliency_path)
         saliency = _load_saliency(saliency_path)
     else:
-        saliency = _compute_saliency_with_explainer(graph, classifier_ckpt, explainer_ckpt, device)
+        saliency = _compute_saliency_with_explainer(
+            graph, classifier_ckpt, explainer_ckpt, device
+        )
 
     miner = FeatureMiner(
         top_k=top_k,
@@ -298,125 +303,167 @@ def evaluate_single(
         LOGGER.debug("Mined %d features", len(features))
 
     LOGGER.debug("Building YARA rule with %d features", len(features))
-    builder = YaraBuilder(
-        condition_type=condition_type,
-        percentage=percentage,
-        min_count=min_count,
-        group_percentage=group_pct,
-        group_min_count=group_min_count,
-        adjust_group_percentage=adjust_group_percentage,
-    )
-    rule_text = builder.build(features)
-    builder.validate(rule_text)
 
-    if json_match:
-        jpath = sample_json if sample_json is not None else sample_path.with_suffix(".json")
-        if not jpath.is_file():
-            LOGGER.warning("json_match enabled but JSON %s not found", jpath)
-            detected = False
-        else:
-            detected = verify_features(
-                jpath,
-                features,
-                condition_type=condition_type,
-                group_percentage=group_pct,
-                group_min_count=group_min_count,
-                adjust_group_percentage=adjust_group_percentage,
+    if chunk_size is None or chunk_size <= 0:
+        chunk_size = max(1, math.ceil(len(features) / max(1, num_rules)))
+
+    groups: list[list[str]] = []
+    start = 0
+    for _ in range(max(1, num_rules)):
+        if start >= len(features):
+            break
+        groups.append(features[start : start + chunk_size])
+        start += chunk_size
+
+    rule_texts: list[str] = []
+    detections: list[bool] = []
+    coverages: list[float] = []
+    false_positives: list[bool] = []
+
+    def _eval_group(feats: list[str]) -> tuple[bool, float, bool, str]:
+        builder = YaraBuilder(
+            condition_type=condition_type,
+            percentage=percentage,
+            min_count=min_count,
+            group_percentage=group_pct,
+            group_min_count=group_min_count,
+            adjust_group_percentage=adjust_group_percentage,
+        )
+        rule_text = builder.build(feats)
+        builder.validate(rule_text)
+
+        if json_match:
+            jpath = (
+                sample_json
+                if sample_json is not None
+                else sample_path.with_suffix(".json")
             )
-        coverage = 0.0
-        LOGGER.debug("Skipping YARA match; using JSON verification only")
-        compiled = None
-        matches = []
-    else:
-        import yara
+            if not jpath.is_file():
+                LOGGER.warning("json_match enabled but JSON %s not found", jpath)
+                detected = False
+            else:
+                detected = verify_features(
+                    jpath,
+                    feats,
+                    condition_type=condition_type,
+                    group_percentage=group_pct,
+                    group_min_count=group_min_count,
+                    adjust_group_percentage=adjust_group_percentage,
+                )
+            coverage = 0.0
+            LOGGER.debug("Skipping YARA match; using JSON verification only")
+            compiled = None
+        else:
+            import yara
 
-        compiled = yara.compile(source=rule_text)
-        matches = compiled.match(str(sample_path))
-        detected = bool(matches)
+            compiled = yara.compile(source=rule_text)
+            matches = compiled.match(str(sample_path))
+            detected = bool(matches)
 
-        coverage = 0.0
-        if detected:
-            total = sum(len(s[2]) for s in matches[0].strings)
-            try:
-                size = sample_path.stat().st_size
-                coverage = float(total) / float(size) if size > 0 else 0.0
-            except Exception:
-                coverage = 0.0
+            coverage = 0.0
+            if detected:
+                total = sum(len(s[2]) for s in matches[0].strings)
+                try:
+                    size = sample_path.stat().st_size
+                    coverage = float(total) / float(size) if size > 0 else 0.0
+                except Exception:
+                    coverage = 0.0
+
+        fp = False
+        if json_match:
+
+            def _check_json(p: Path) -> bool:
+                j = p.with_suffix(".json")
+                return j.is_file() and verify_features(
+                    j,
+                    feats,
+                    condition_type=condition_type,
+                    group_percentage=group_pct,
+                    group_min_count=group_min_count,
+                    adjust_group_percentage=adjust_group_percentage,
+                )
+
+            if clean_dir is not None and clean_dir.is_dir():
+                fp = any(_check_json(p) for p in clean_dir.iterdir() if p.is_file())
+            elif clean_sample is not None:
+                fp = _check_json(clean_sample)
+            elif clean_paths is not None:
+                fp = any(_check_json(p) for p in clean_paths)
+            elif (
+                clean_dir is not None
+                or clean_sample is not None
+                or clean_paths is not None
+            ):
+                fp = False
+        else:
+            if clean_dir is not None and clean_dir.is_dir() and compiled is not None:
+                for fp_path in clean_dir.iterdir():
+                    if not fp_path.is_file():
+                        continue
+                    try:
+                        if compiled.match(str(fp_path)):
+                            fp = True
+                            break
+                    except Exception:
+                        continue
+            elif clean_sample is not None and compiled is not None:
+                try:
+                    fp = bool(compiled.match(str(clean_sample)))
+                except Exception:
+                    fp = False
+            elif clean_paths is not None and compiled is not None:
+                for p in clean_paths:
+                    try:
+                        if compiled.match(str(p)):
+                            fp = True
+                            break
+                    except Exception:
+                        continue
+            elif (
+                clean_dir is not None
+                or clean_sample is not None
+                or clean_paths is not None
+            ):
+                fp = False
+
+        return detected, coverage, fp, rule_text
+
+    for grp in groups:
+        det, cov, fp, rt = _eval_group(grp)
+        detections.append(det)
+        coverages.append(cov)
+        false_positives.append(fp)
+        rule_texts.append(rt)
 
     if isinstance(saliency, dict):
         flat = torch.cat(list(saliency.values()))
     else:
         flat = saliency
-    num_selected = min(len(features), flat.numel())
-    avg_importance = float(flat.topk(num_selected).values.mean().item()) if num_selected > 0 else 0.0
-    mask_sparsity = float(1.0 - num_selected / flat.numel()) if flat.numel() > 0 else 0.0
+    first_feats = groups[0] if groups else []
+    num_selected = min(len(first_feats), flat.numel())
+    avg_importance = (
+        float(flat.topk(num_selected).values.mean().item()) if num_selected > 0 else 0.0
+    )
+    mask_sparsity = (
+        float(1.0 - num_selected / flat.numel()) if flat.numel() > 0 else 0.0
+    )
 
     result: Dict[str, Any] = {
-        "detected": detected,
-        "rule_length": len(features),
+        "detected": detections[0] if detections else False,
+        "rule_length": len(first_feats),
         "avg_importance": avg_importance,
         "mask_sparsity": mask_sparsity,
-        "coverage": coverage,
+        "coverage": coverages[0] if coverages else 0.0,
+        "rule_text": rule_texts[0] if rule_texts else "",
+        "false_positive": false_positives[0] if false_positives else False,
     }
-    result["rule_text"] = rule_text
+    result["rule_texts"] = rule_texts
+    result["false_positives"] = false_positives
 
-    if json_match:
-        def _check_json(p: Path) -> bool:
-            j = p.with_suffix(".json")
-            return j.is_file() and verify_features(
-                j,
-                features,
-                condition_type=condition_type,
-                group_percentage=group_pct,
-                group_min_count=group_min_count,
-                adjust_group_percentage=adjust_group_percentage,
-            )
-
-        if clean_dir is not None and clean_dir.is_dir():
-            fp = any(_check_json(p) for p in clean_dir.iterdir() if p.is_file())
-            result["false_positive"] = fp
-        elif clean_sample is not None:
-            result["false_positive"] = _check_json(clean_sample)
-        elif clean_paths is not None:
-            fp = any(_check_json(p) for p in clean_paths)
-            result["false_positive"] = fp
-        elif clean_dir is not None or clean_sample is not None or clean_paths is not None:
-            result["false_positive"] = False
-    else:
-        if clean_dir is not None and clean_dir.is_dir() and compiled is not None:
-            fp = False
-            for fp_path in clean_dir.iterdir():
-                if not fp_path.is_file():
-                    continue
-                try:
-                    if compiled.match(str(fp_path)):
-                        fp = True
-                        break
-                except Exception:
-                    continue
-            result["false_positive"] = fp
-        elif clean_sample is not None and compiled is not None:
-            try:
-                result["false_positive"] = bool(compiled.match(str(clean_sample)))
-            except Exception:
-                result["false_positive"] = False
-        elif clean_paths is not None and compiled is not None:
-            fp = False
-            for p in clean_paths:
-                try:
-                    if compiled.match(str(p)):
-                        fp = True
-                        break
-                except Exception:
-                    continue
-            result["false_positive"] = fp
-        elif clean_dir is not None or clean_sample is not None or clean_paths is not None:
-            result["false_positive"] = False
-
-    if sample_json is not None and sample_json.is_file():
+    if sample_json is not None and sample_json.is_file() and first_feats:
         result["feature_verified"] = verify_features(
             sample_json,
-            features,
+            first_feats,
             condition_type=condition_type,
             group_percentage=group_pct,
             group_min_count=group_min_count,
@@ -430,6 +477,7 @@ def evaluate_single(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Evaluate explainer output by generating a YARA rule",
@@ -438,20 +486,35 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--graph", type=Path, help="HeteroData graph")
     p.add_argument("--sample", type=Path, help="Binary to scan")
     p.add_argument("--graph-dir", type=Path, help="Directory of graphs for batch mode")
-    p.add_argument("--sample-dir", type=Path, help="Directory containing binaries/JSONs")
+    p.add_argument(
+        "--sample-dir", type=Path, help="Directory containing binaries/JSONs"
+    )
     p.add_argument("--meta-csv", type=Path, help="CSV with sha256,label,filename")
-    p.add_argument("--clean-dir", type=Path, help="Directory of clean binaries for FP check")
-    p.add_argument("--saliency", type=Path, help="Precomputed node saliency (.pt or json)")
+    p.add_argument(
+        "--clean-dir", type=Path, help="Directory of clean binaries for FP check"
+    )
+    p.add_argument(
+        "--saliency", type=Path, help="Precomputed node saliency (.pt or json)"
+    )
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
-    p.add_argument("--classifier", type=Path, required=True, help="Classifier checkpoint")
+    p.add_argument(
+        "--classifier", type=Path, required=True, help="Classifier checkpoint"
+    )
     p.add_argument("--device", type=str, default="cpu")
     p.add_argument("--top-k", type=int, default=40)
     p.add_argument("--top-k-percent", type=float, default=None)
-    p.add_argument("--saliency-top-percent", type=float, default=None, help="Limit nodes by cumulative saliency percentage")
+    p.add_argument(
+        "--saliency-top-percent",
+        type=float,
+        default=None,
+        help="Limit nodes by cumulative saliency percentage",
+    )
     p.add_argument("--dynamic-k", action="store_true")
     p.add_argument("--keep-per-type", type=int, default=20)
     p.add_argument("--min-saliency", type=float, default=1e-3)
-    p.add_argument("--benign-freqs", type=Path, help="JSON with benign feature frequencies")
+    p.add_argument(
+        "--benign-freqs", type=Path, help="JSON with benign feature frequencies"
+    )
     p.add_argument(
         "--freq-threshold",
         type=float,
@@ -495,7 +558,18 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="lower group percentage automatically for many features",
     )
-    p.add_argument("--clean-sample", type=Path, help="Optional clean sample for FP check")
+    p.add_argument(
+        "--num-rules", type=int, default=1, help="Number of rules to generate"
+    )
+    p.add_argument(
+        "--chunk-size",
+        type=int,
+        default=None,
+        help="Number of features per rule chunk",
+    )
+    p.add_argument(
+        "--clean-sample", type=Path, help="Optional clean sample for FP check"
+    )
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")
     p.add_argument(
@@ -569,9 +643,15 @@ def main(argv: list[str] | None = None) -> None:
                     group_percentage=args.group_percentage,
                     group_min_count=args.group_min_count,
                     adjust_group_percentage=args.adjust_group_percentage,
+                    num_rules=args.num_rules,
+                    chunk_size=args.chunk_size,
                     clean_dir=args.clean_dir,
                     clean_sample=None,
-                    clean_paths=(benign_paths if args.clean_dir is None and args.clean_sample is None else None),
+                    clean_paths=(
+                        benign_paths
+                        if args.clean_dir is None and args.clean_sample is None
+                        else None
+                    ),
                     sample_json=jpath,
                     json_match=args.json_match,
                 )
@@ -595,7 +675,9 @@ def main(argv: list[str] | None = None) -> None:
                 rule_dir = args.sample_rules_out / "rule"
                 rule_dir.mkdir(parents=True, exist_ok=True)
                 fname = f"{sha}.yar"
-                (rule_dir / fname).write_text(res.get("rule_text", ""), encoding="utf-8")
+                (rule_dir / fname).write_text(
+                    res.get("rule_text", ""), encoding="utf-8"
+                )
 
         if args.out_csv:
             pd.DataFrame(results).to_csv(args.out_csv, index=False)
@@ -648,10 +730,16 @@ def main(argv: list[str] | None = None) -> None:
             group_percentage=args.group_percentage,
             group_min_count=args.group_min_count,
             adjust_group_percentage=args.adjust_group_percentage,
+            num_rules=args.num_rules,
+            chunk_size=args.chunk_size,
             clean_dir=args.clean_dir,
             clean_sample=args.clean_sample,
             clean_paths=None,
-            sample_json=(args.sample_dir / f"{args.sample.stem}.json" if args.sample_dir else None),
+            sample_json=(
+                args.sample_dir / f"{args.sample.stem}.json"
+                if args.sample_dir
+                else None
+            ),
             json_match=args.json_match,
         )
 


### PR DESCRIPTION
## Summary
- expand `evaluate_single` to support generating multiple rules sequentially
- store all rule texts and false positive results
- expose `--num-rules` and `--chunk-size` CLI options

## Testing
- `black src/cli/explainer_rule_eval.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68830b2742d0832e980a7fcce47392f5