### PR TITLE
Add rule evaluation logging and iterative pipeline

### DIFF
--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -882,6 +882,10 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             n_eval_rules,
             hint_features=val_hint_feats if val_hint_feats else None,
         )
+        if args.eval_log:
+            with Path(args.eval_log).open("a", encoding="utf-8") as fp:
+                for entry in env.get_rule_eval_history():
+                    fp.write(json.dumps(entry) + "\n")
         val_history.append(
             (step + seg, metrics["f1_clean"], metrics["f1_dummy"], metrics["reward"])
         )
@@ -905,6 +909,11 @@ def cmd_ppo_train(args: argparse.Namespace) -> None:
             logger.info("Checkpoint saved → %s", step_path)
 
     _plot_history()
+
+    if args.eval_log:
+        with Path(args.eval_log).open("a", encoding="utf-8") as fp:
+            for entry in env.get_rule_eval_history():
+                fp.write(json.dumps(entry) + "\n")
 
     if args.checkpoint:
         Path(args.checkpoint).parent.mkdir(parents=True, exist_ok=True)
@@ -1106,6 +1115,71 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
         writer.writerow(row)
 
 
+def _extract_fp_updates(log_path: Path, threshold: float = 0.5) -> dict[str, int]:
+    """Collect tokens from rules with high false positive rate."""
+
+    if not log_path.is_file():
+        return {}
+    from rulegen.rl_env import RuleGenEnv
+
+    counts: dict[str, int] = {}
+    for line in log_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        if float(entry.get("fp_rate", 0.0)) < threshold:
+            continue
+        for tok in RuleGenEnv._rule_tokenize(entry.get("rule", "")):
+            counts[tok] = counts.get(tok, 0) + 1
+    return counts
+
+
+def cmd_pipeline(args: argparse.Namespace) -> None:
+    """Run feature mining and PPO training iteratively updating benign freqs."""
+
+    work = Path(args.work_dir)
+    work.mkdir(parents=True, exist_ok=True)
+    freq_path = Path(args.benign_freqs)
+
+    for i in range(args.iterations):
+        feat_path = work / f"features_{i}.json"
+        fm_args = argparse.Namespace(
+            graph_dir=args.graph_dir,
+            labels=args.labels,
+            embed_dir=None,
+            out=str(feat_path),
+            selector_checkpoint=None,
+            classifier_ckpt=None,
+            benign_freqs=str(freq_path) if freq_path.exists() else None,
+            freq_threshold=args.freq_threshold,
+            saliency_top_percent=None,
+        )
+        cmd_feature_mine(fm_args)
+
+        log_file = work / f"eval_{i}.jsonl"
+        train_args = argparse.Namespace(
+            train_features=str(feat_path),
+            val_features=None,
+            dataset_dir=args.dataset_dir,
+            config=args.config,
+            epochs=args.epochs,
+            checkpoint=str(work / f"agent_{i}.pt"),
+            cpu=args.cpu,
+            eval_log=str(log_file),
+        )
+        cmd_ppo_train(train_args)
+
+        updates = _extract_fp_updates(log_file, args.fp_threshold)
+        if updates:
+            if freq_path.is_file():
+                data = json.loads(freq_path.read_text())
+            else:
+                data = {}
+            for k, v in updates.items():
+                data[k] = data.get(k, 0) + v
+            freq_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
 def cmd_build_dataset(args: argparse.Namespace) -> None:
     """Convert labeled graphs into PPO dataset format."""
     from rulegen.build_dataset import build_dataset
@@ -1279,6 +1353,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     pt.add_argument("--checkpoint", help="Output checkpoint path (.pt)")
     pt.add_argument("--plot-path", type=Path, help="Save training curve PNG")
+    pt.add_argument(
+        "--eval-log",
+        type=Path,
+        help="Path to JSONL file for rule evaluation logs",
+    )
     pt.add_argument(
         "--reward-weights",
         type=_parse_reward_weights,
@@ -1475,6 +1554,24 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ev.set_defaults(func=cmd_evaluate)
 
+    # ------------------- pipeline ------------------- #
+    pipe = sub.add_parser(
+        "pipeline",
+        help="Iteratively run feature-mine and ppo-train with benign freq updates",
+    )
+    pipe.add_argument("--graph-dir", required=True)
+    pipe.add_argument("--labels")
+    pipe.add_argument("--dataset-dir", required=True)
+    pipe.add_argument("--work-dir", type=Path, required=True)
+    pipe.add_argument("--iterations", type=int, default=2)
+    pipe.add_argument("--freq-threshold", type=float, default=10.0)
+    pipe.add_argument("--benign-freqs", type=Path, required=True)
+    pipe.add_argument("--fp-threshold", type=float, default=0.5)
+    pipe.add_argument("--epochs", type=int, default=1)
+    pipe.add_argument("--cpu", action="store_true")
+    pipe.add_argument("--config")
+    pipe.set_defaults(func=cmd_pipeline)
+
     return parser
 
 
@@ -1497,6 +1594,7 @@ def main(argv: List[str] | None = None) -> None:
         "ppo-train": "train.log",
         "generate": "generate.log",
         "evaluate": "evaluate.log",
+        "pipeline": "pipeline.log",
     }
     log_path = run_dir / name_map.get(args.command, "run.log")
     _setup_logger(args.verbose, log_file=str(log_path))

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -101,6 +101,20 @@ class FeatureMiner:
         self.benign_freqs = benign_freqs
         self.freq_threshold = freq_threshold
 
+    # ────────────────────────────────────────── benign freq updates ―
+    def update_benign_freqs(self, updates: Dict[str, int]) -> None:
+        """Update :attr:`benign_freqs` with additional counts."""
+
+        if self.benign_freqs is None:
+            self.benign_freqs = {}
+        for k, v in updates.items():
+            self.benign_freqs[k] = self.benign_freqs.get(k, 0) + int(v)
+
+    def set_freq_threshold(self, thresh: float) -> None:
+        """Update :attr:`freq_threshold` value."""
+
+        self.freq_threshold = float(thresh)
+
     # ──────────────────────────────────────────────── public ―─
 
     def __call__(

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -38,7 +38,7 @@ import json
 import logging
 import random
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 try:
     from transformers import PreTrainedTokenizer  # type: ignore
@@ -272,6 +272,13 @@ class RuleGenEnv(gym.Env):
 
         self.running_stats = RunningStats()
 
+        # rule evaluation logging
+        self.rule_eval_history: List[dict] = []
+        self.rule_eval_callback: Optional[
+            Callable[[str, dict], None]
+        ] = None
+        self._max_history = 1000
+
         self.core_tokens = set(core_tokens or [])
         self.use_shaping = use_shaping
         self.use_lookahead = bool(use_lookahead)
@@ -457,6 +464,21 @@ class RuleGenEnv(gym.Env):
         for k, v in kwargs.items():
             if k in self.reward_weights:
                 self.reward_weights[k] = float(v)
+
+    # ───────────────────────────────────────────── rule eval logging ―
+    def set_rule_eval_callback(
+        self, callback: Callable[[str, dict], None] | None
+    ) -> None:
+        """Register a callback invoked after each rule evaluation."""
+
+        self.rule_eval_callback = callback
+
+    def get_rule_eval_history(self) -> List[dict]:
+        """Return and clear recorded rule evaluation history."""
+
+        hist = list(self.rule_eval_history)
+        self.rule_eval_history.clear()
+        return hist
 
     # ─────────────────────────────────────────────────── gym API —
     def reset(
@@ -1082,6 +1104,16 @@ class RuleGenEnv(gym.Env):
                 self._phi_last = phi
         if update_stats:
             self.running_stats.update(float(reward))
+        log_entry = {"rule": rule_text}
+        log_entry.update(metrics)
+        self.rule_eval_history.append(log_entry)
+        if len(self.rule_eval_history) > self._max_history:
+            self.rule_eval_history.pop(0)
+        if self.rule_eval_callback:
+            try:
+                self.rule_eval_callback(rule_text, metrics)
+            except Exception:  # pragma: no cover - logging errors shouldn't crash
+                _LOG.exception("rule_eval_callback failed")
         return reward, metrics, shaping
 
     # rule string tokenizer (공용)

--- a/tests/test_rule_eval_logging.py
+++ b/tests/test_rule_eval_logging.py
@@ -1,0 +1,26 @@
+import json
+import types
+import pytest
+from torch_geometric.data import HeteroData
+from src.rulegen.rl_env import RuleGenEnv
+
+@pytest.fixture
+def env(tmp_path):
+    clean = [HeteroData()]
+    dummy = [HeteroData()]
+    vocab = {"A":0, "<PAD>":1, "<END>":2}
+    torch = pytest.importorskip('torch')
+    torch.save(clean, tmp_path/'clean.pt')
+    torch.save(dummy, tmp_path/'dummy.pt')
+    (tmp_path/'vocab.json').write_text(json.dumps(vocab))
+    e = RuleGenEnv(rule_type='yara', vocab_file=tmp_path/'vocab.json', dataset_dir=tmp_path, max_len=4, classifier_checkpoint=tmp_path/'clf.pt', device='cpu')
+    return e
+
+def test_callback_and_history(env, monkeypatch):
+    logs = []
+    env.set_rule_eval_callback(lambda r,m: logs.append((r,m)))
+    monkeypatch.setattr(env.evaluator, 'evaluate_rule', lambda *a,**k: (0.1,0.2,2.0,(1,1,0,0)))
+    env._compute_reward('A', update_stats=True)
+    hist = env.get_rule_eval_history()
+    assert len(hist) == 1
+    assert logs and logs[0][0] == 'A'


### PR DESCRIPTION
## Summary
- track per-rule evaluation metrics inside `RuleGenEnv`
- expose callback and history APIs to fetch evaluation results
- allow `FeatureMiner` benign frequency updates
- log evaluation results in `ppo-train` and add iterative `pipeline` command
- add regression test for new logging API

## Testing
- `pytest -q` *(fails: torch and other dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68830b196608832eb3dbc982108cd26b