### PR TITLE
Add Yara rule combination feature

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -568,6 +568,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of features per rule chunk",
     )
     p.add_argument(
+        "--combine-mode",
+        choices=["or", "and"],
+        default="or",
+        help="Combine multiple rules with logical OR/AND when saving",
+    )
+    p.add_argument(
         "--clean-sample", type=Path, help="Optional clean sample for FP check"
     )
     p.add_argument("--out", type=Path, help="Save JSON result path")
@@ -675,9 +681,11 @@ def main(argv: list[str] | None = None) -> None:
                 rule_dir = args.sample_rules_out / "rule"
                 rule_dir.mkdir(parents=True, exist_ok=True)
                 fname = f"{sha}.yar"
-                (rule_dir / fname).write_text(
-                    res.get("rule_text", ""), encoding="utf-8"
+                rule_txt = YaraBuilder().combine_rules(
+                    res.get("rule_texts", [res.get("rule_text", "")]),
+                    mode=args.combine_mode,
                 )
+                (rule_dir / fname).write_text(rule_txt, encoding="utf-8")
 
         if args.out_csv:
             pd.DataFrame(results).to_csv(args.out_csv, index=False)
@@ -690,18 +698,19 @@ def main(argv: list[str] | None = None) -> None:
             LOGGER.info("average detection=%.3f, FP ratio=%.3f", det_rate, fp_ratio)
 
             rule_texts = [
-                (r.get("sha256"), r.get("rule_text"))
+                (r.get("sha256"), r.get("rule_texts", [r.get("rule_text", "")]))
                 for r in results
-                if r.get("rule_text")
+                if r.get("rule_texts") or r.get("rule_text")
             ]
             if args.sample_rules_out and rule_texts:
                 import random
 
                 args.sample_rules_out.mkdir(parents=True, exist_ok=True)
                 selected = random.sample(rule_texts, min(5, len(rule_texts)))
-                for i, (sha, text) in enumerate(selected, start=1):
+                for i, (sha, texts) in enumerate(selected, start=1):
                     fname = f"{sha}.yar" if sha else f"rule_{i}.yar"
-                    (args.sample_rules_out / fname).write_text(text, encoding="utf-8")
+                    combined = YaraBuilder().combine_rules(texts, mode=args.combine_mode)
+                    (args.sample_rules_out / fname).write_text(combined, encoding="utf-8")
         else:
             LOGGER.warning("No samples evaluated")
 
@@ -751,13 +760,17 @@ def main(argv: list[str] | None = None) -> None:
         if args.sample_rules_out:
             args.sample_rules_out.mkdir(parents=True, exist_ok=True)
             rule_path = args.sample_rules_out / f"{args.sample.stem}.yar"
-            rule_path.write_text(result.get("rule_text", ""), encoding="utf-8")
+            rule_txt = YaraBuilder().combine_rules(
+                result.get("rule_texts", [result.get("rule_text", "")]),
+                mode=args.combine_mode,
+            )
+            rule_path.write_text(rule_txt, encoding="utf-8")
 
             if result.get("detected"):
                 rule_dir = args.sample_rules_out / "rule"
                 rule_dir.mkdir(parents=True, exist_ok=True)
                 (rule_dir / f"{args.sample.stem}.yar").write_text(
-                    result.get("rule_text", ""), encoding="utf-8"
+                    rule_txt, encoding="utf-8"
                 )
 
 

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -311,6 +311,44 @@ class YaraBuilder:
             _LOG.warning("yara match failed for %s: %s", sample_path, exc)
             return False
 
+    def combine_rules(self, rules: List[str], mode: str = "or") -> str:
+        """Return a YARA file combining ``rules`` with a wrapper rule.
+
+        Parameters
+        ----------
+        rules : List[str]
+            Individual rule texts to combine.
+        mode : str, optional
+            "or" (default) creates a wrapper rule that triggers if any rule
+            matches.  ``"and"`` requires all rules to match.
+
+        Notes
+        -----
+        The returned text contains the original rules followed by a final rule
+        named ``combined_rule`` referencing them.
+        """
+
+        if mode not in {"or", "and"}:
+            raise ValueError("mode must be 'or' or 'and'")
+
+        names: List[str] = []
+        cleaned: List[str] = []
+        for idx, text in enumerate(rules):
+            text = text.strip()
+            cleaned.append(text)
+            m = re.search(r"rule\s+(\w+)", text)
+            names.append(m.group(1) if m else f"rule_{idx}")
+
+        operator = " or " if mode == "or" else " and "
+        cond = operator.join(names) if names else "false"
+        wrapper = [
+            "rule combined_rule {",
+            "  condition:",
+            f"    {cond}",
+            "}",
+        ]
+        return "\n\n".join(cleaned + ["\n".join(wrapper)])
+
     # ─────────────────────────────────── helpers ───────────────
     def _extract_features(self, tokens: Sequence[str]) -> List[str]:
         """

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -471,8 +471,8 @@ def test_evaluate_single_json_feature_filter(tmp_path, monkeypatch):
     )
 
     assert res["rule_length"] == 1
-    assert "foo" in res["rule_text"]
-    assert "bar" not in res["rule_text"]
+    assert "foo" in res["rule_texts"][0]
+    assert "bar" not in res["rule_texts"][0]
 
 
 def test_evaluate_single_json_feature_filter_fallback(tmp_path, monkeypatch):
@@ -524,7 +524,7 @@ def test_evaluate_single_json_feature_filter_fallback(tmp_path, monkeypatch):
     )
 
     assert res["rule_length"] == 1
-    assert "foo" in res["rule_text"]
+    assert "foo" in res["rule_texts"][0]
 
 
 def test_verify_features_combo_percentage(tmp_path):

--- a/tests/test_yara_builder_combine_rules.py
+++ b/tests/test_yara_builder_combine_rules.py
@@ -1,0 +1,19 @@
+import re
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_combine_rules_or_and():
+    b = YaraBuilder()
+    r1 = b.build(["foo"])
+    r2 = b.build(["bar"])
+    txt_or = b.combine_rules([r1, r2], mode="or")
+    assert "combined_rule" in txt_or
+    assert re.search(r"\b(or|and)\b", txt_or)
+    ok, err = b.validate(txt_or)
+    assert ok, err
+
+    txt_and = b.combine_rules([r1, r2], mode="and")
+    assert "combined_rule" in txt_and
+    assert " and " in txt_and
+    ok, err = b.validate(txt_and)
+    assert ok, err


### PR DESCRIPTION
## Summary
- add `combine_rules()` to `YaraBuilder`
- support `--combine-mode` option in `explainer_rule_eval` CLI
- save combined rules when writing output
- adjust CLI tests for `rule_texts`
- add unit test for rule combining

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68830d97d06c832eb359b7db6257d656