### PR TITLE
Enhance feature verification with saliency stats

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -150,6 +150,7 @@ def verify_features(
     group_percentage: int | None = None,
     group_min_count: int | None = None,
     adjust_group_percentage: bool = False,
+    saliency_stats: dict[str, tuple[float, float]] | None = None,
 ) -> bool:
     """Return True if ``features`` satisfy the condition in sample JSON."""
     try:
@@ -170,7 +171,16 @@ def verify_features(
                 return True
         return False
 
-    matched = [f for f in features if _feat_present(f)]
+    def _feat_valid(feat: str) -> bool:
+        if not saliency_stats:
+            return True
+        val = saliency_stats.get(feat)
+        if val is None:
+            return True
+        mal, ben = val
+        return mal > ben and mal > 0.0
+
+    matched = [f for f in features if _feat_present(f) and _feat_valid(f)]
 
     if condition_type != "combo":
         if condition_type == "all":
@@ -252,6 +262,7 @@ def evaluate_single(
     clean_paths: Sequence[Path] | None = None,
     sample_json: Path | None = None,
     json_match: bool = False,
+    saliency_stats: dict[str, tuple[float, float]] | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -279,7 +290,7 @@ def evaluate_single(
         benign_freqs=benign_freqs,
         freq_threshold=freq_threshold,
     )
-    features = miner.mine(graph, saliency)
+    features = miner.mine(graph, saliency, saliency_stats)
     group_pct = group_percentage
     if condition_type == "combo" and group_min_count is not None:
         group_pct = None
@@ -294,6 +305,7 @@ def evaluate_single(
                 group_percentage=group_pct,
                 group_min_count=group_min_count,
                 adjust_group_percentage=adjust_group_percentage,
+                saliency_stats=saliency_stats,
             )
         ]
         if not filtered and features:
@@ -349,6 +361,7 @@ def evaluate_single(
                     group_percentage=group_pct,
                     group_min_count=group_min_count,
                     adjust_group_percentage=adjust_group_percentage,
+                    saliency_stats=saliency_stats,
                 )
             coverage = 0.0
             LOGGER.debug("Skipping YARA match; using JSON verification only")
@@ -381,6 +394,7 @@ def evaluate_single(
                     group_percentage=group_pct,
                     group_min_count=group_min_count,
                     adjust_group_percentage=adjust_group_percentage,
+                    saliency_stats=saliency_stats,
                 )
 
             if clean_dir is not None and clean_dir.is_dir():
@@ -468,6 +482,7 @@ def evaluate_single(
             group_percentage=group_pct,
             group_min_count=group_min_count,
             adjust_group_percentage=adjust_group_percentage,
+            saliency_stats=saliency_stats,
         )
 
     return result
@@ -514,6 +529,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--min-saliency", type=float, default=1e-3)
     p.add_argument(
         "--benign-freqs", type=Path, help="JSON with benign feature frequencies"
+    )
+    p.add_argument(
+        "--saliency-stats", type=Path, help="JSON with feature saliency stats"
     )
     p.add_argument(
         "--freq-threshold",
@@ -596,6 +614,10 @@ def main(argv: list[str] | None = None) -> None:
     if args.benign_freqs and args.benign_freqs.is_file():
         benign_freqs = json.loads(args.benign_freqs.read_text(encoding="utf-8"))
 
+    saliency_stats = None
+    if args.saliency_stats and args.saliency_stats.is_file():
+        saliency_stats = json.loads(args.saliency_stats.read_text(encoding="utf-8"))
+
     device = torch.device(args.device)
 
     if args.graph_dir and args.meta_csv:
@@ -654,6 +676,7 @@ def main(argv: list[str] | None = None) -> None:
                     ),
                     sample_json=jpath,
                     json_match=args.json_match,
+                    saliency_stats=saliency_stats,
                 )
             except FileNotFoundError as exc:
                 skipped += 1
@@ -741,6 +764,7 @@ def main(argv: list[str] | None = None) -> None:
                 else None
             ),
             json_match=args.json_match,
+            saliency_stats=saliency_stats,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -613,3 +613,21 @@ def test_verify_features_combo_adjust_pct(tmp_path):
         is True
     )
 
+
+def test_verify_features_saliency_stats(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["foo"]}))
+    feats = ["call:foo"]
+
+    stats = {"call:foo": [0.1, 0.2]}
+    assert (
+        mod.verify_features(js, feats, saliency_stats=stats) is False
+    )
+
+    stats = {"call:foo": [0.3, 0.1]}
+    assert (
+        mod.verify_features(js, feats, saliency_stats=stats) is True
+    )
+


### PR DESCRIPTION
## Summary
- allow `verify_features()` to take optional saliency statistics for stricter feature checks
- propagate saliency stats through `evaluate_single()` and CLI
- add `--saliency-stats` CLI option
- test saliency-aware feature verification

## Testing
- `pytest -k test_verify_features_saliency_stats -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68830f741284832e9d0c5c9d36c030f3