### PR TITLE
Update rule evaluation aggregation logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -263,6 +263,8 @@ def evaluate_single(
     sample_json: Path | None = None,
     json_match: bool = False,
     saliency_stats: dict[str, tuple[float, float]] | None = None,
+    *,
+    combine_mode: str = "or",
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -362,6 +364,7 @@ def evaluate_single(
                     group_min_count=group_min_count,
                     adjust_group_percentage=adjust_group_percentage,
                     saliency_stats=saliency_stats,
+                    combine_mode=args.combine_mode,
                 )
             coverage = 0.0
             LOGGER.debug("Skipping YARA match; using JSON verification only")
@@ -462,14 +465,23 @@ def evaluate_single(
         float(1.0 - num_selected / flat.numel()) if flat.numel() > 0 else 0.0
     )
 
+    combined_det = any(detections) if combine_mode == "or" else all(detections)
+    max_cov = 0.0
+    for det, cov in zip(detections, coverages):
+        if det and cov > max_cov:
+            max_cov = cov
+    combined_fp = (
+        any(false_positives) if combine_mode == "or" else all(false_positives)
+    )
+
     result: Dict[str, Any] = {
-        "detected": detections[0] if detections else False,
+        "detected": combined_det,
         "rule_length": len(first_feats),
         "avg_importance": avg_importance,
         "mask_sparsity": mask_sparsity,
-        "coverage": coverages[0] if coverages else 0.0,
+        "coverage": max_cov,
         "rule_text": rule_texts[0] if rule_texts else "",
-        "false_positive": false_positives[0] if false_positives else False,
+        "false_positive": combined_fp,
     }
     result["rule_texts"] = rule_texts
     result["false_positives"] = false_positives
@@ -774,6 +786,7 @@ def main(argv: list[str] | None = None) -> None:
             ),
             json_match=args.json_match,
             saliency_stats=saliency_stats,
+            combine_mode=args.combine_mode,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 from pathlib import Path
+import sys
 
 import pytest
 pytest.importorskip("torch")
@@ -360,6 +361,7 @@ def test_evaluate_single_json_match_fp_with_clean_sample(tmp_path, monkeypatch):
         clean_paths=None,
         sample_json=sample_json,
         json_match=True,
+        combine_mode="or",
     )
 
     assert res["false_positive"] is True
@@ -417,6 +419,7 @@ def test_evaluate_single_json_match_fp_with_clean_dir(tmp_path, monkeypatch):
         clean_paths=None,
         sample_json=sample_json,
         json_match=True,
+        combine_mode="or",
     )
 
     assert res["false_positive"] is True
@@ -468,6 +471,7 @@ def test_evaluate_single_json_feature_filter(tmp_path, monkeypatch):
         clean_paths=None,
         sample_json=sample_json,
         json_match=True,
+        combine_mode="or",
     )
 
     assert res["rule_length"] == 1
@@ -521,10 +525,119 @@ def test_evaluate_single_json_feature_filter_fallback(tmp_path, monkeypatch):
         clean_paths=None,
         sample_json=sample_json,
         json_match=True,
+        combine_mode="or",
     )
 
     assert res["rule_length"] == 1
     assert "foo" in res["rule_texts"][0]
+
+
+def test_evaluate_single_combine_mode(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"abcdefghij")
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"abcdefghij")
+
+    sample_json = None
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["foo", "bar"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self, length):
+            self.strings = [(0, "$a", b"x" * length)]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            p = str(path)
+            if "foo" in self.text:
+                return [] if "clean" in p else [FakeMatch(8)]
+            if "bar" in self.text:
+                return [FakeMatch(4)] if "clean" in p else []
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res_or = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=2,
+        chunk_size=1,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=False,
+        combine_mode="or",
+    )
+
+    assert res_or["detected"] is True
+    assert abs(res_or["coverage"] - 0.8) < 1e-6
+    assert res_or["false_positive"] is True
+
+    res_and = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=2,
+        chunk_size=1,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=False,
+        combine_mode="and",
+    )
+
+    assert res_and["detected"] is False
+    assert abs(res_and["coverage"] - 0.8) < 1e-6
+    assert res_and["false_positive"] is False
 
 
 def test_verify_features_combo_percentage(tmp_path):


### PR DESCRIPTION
## Summary
- support `combine_mode` in `evaluate_single` to aggregate multiple rules
- aggregate detection, coverage, and false positives using selected mode
- extend CLI calls and tests to pass `combine_mode`
- add unit test for rule combination logic

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688316ae4008832e970dc217804b3a1d