### PR TITLE
Fix group min count verification logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -217,7 +217,8 @@ def verify_features(
             continue
         mcount = matched_groups.get(tag, 0)
         if group_min_count is not None:
-            if mcount < group_min_count:
+            required = min(group_min_count, len(feats_list))
+            if mcount < required:
                 return False
         elif group_percentage is not None:
             pct = group_percentage
@@ -263,7 +264,6 @@ def evaluate_single(
     sample_json: Path | None = None,
     json_match: bool = False,
     saliency_stats: dict[str, tuple[float, float]] | None = None,
-    *,
     combine_mode: str = "or",
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -698,6 +698,35 @@ def test_verify_features_combo_min_count(tmp_path):
     )
 
 
+def test_verify_features_combo_min_count_capped(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["foo"]}))
+    feats = ["call:foo", "import:bar"]
+
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_min_count=2,
+        )
+        is False
+    )
+
+    js.write_text(json.dumps({"c_code": ["foo", "bar"]}))
+    assert (
+        mod.verify_features(
+            js,
+            feats,
+            condition_type="combo",
+            group_min_count=2,
+        )
+        is True
+    )
+
+
 def test_verify_features_combo_adjust_pct(tmp_path):
     mod = importlib.import_module("src.cli.explainer_rule_eval")
 


### PR DESCRIPTION
## Summary
- cap the min-count per group in `verify_features`
- add regression test for oversized `group_min_count`
- clean up `evaluate_single` signature

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k verify_features -q`

------
https://chatgpt.com/codex/tasks/task_e_688318796460832e94d8ba67933cc29b