### PR TITLE
Optimize model loading in rule eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -58,16 +58,12 @@ def _ensure_fallback_features(
 
 def _compute_saliency_with_explainer(
     graph: HeteroData,
-    classifier_ckpt: Path,
-    explainer_ckpt: Path | None,
+    classifier: Any,
+    explainer: Any | None,
     device: torch.device,
 ) -> Dict[str, torch.Tensor]:
     """Return node saliency from an explainer or plain gradients."""
-    from src.models.gnn.res_wrapper import RESGCLClassifier
-
-    LOGGER.debug(f"Loading classifier from {classifier_ckpt}")
-    clf = RESGCLClassifier.load_pretrained(str(classifier_ckpt), map_location=device)
-    clf.to(device).eval()
+    clf = classifier.to(device).eval()
 
     g = GraphDataset._ensure_num_nodes(graph)
     g = GraphDataset._ensure_x(g)
@@ -78,12 +74,10 @@ def _compute_saliency_with_explainer(
 
     LOGGER.debug(
         "Generating saliency via %s",
-        "explainer" if explainer_ckpt is not None else "gradients",
+        "explainer" if explainer is not None else "gradients",
     )
 
-    if explainer_ckpt is not None:
-        LOGGER.debug(f"Loading explainer from {explainer_ckpt}")
-        explainer = torch.load(explainer_ckpt, map_location=device, weights_only=False)
+    if explainer is not None:
         if hasattr(explainer, "eval"):
             explainer.eval()
 
@@ -237,8 +231,10 @@ def evaluate_single(
     graph_path: Path,
     sample_path: Path,
     *,
-    classifier_ckpt: Path,
-    explainer_ckpt: Path | None,
+    classifier_ckpt: Path | None = None,
+    explainer_ckpt: Path | None = None,
+    classifier: Any | None = None,
+    explainer: Any | None = None,
     saliency_path: Path | None,
     device: torch.device,
     top_k: int,
@@ -263,7 +259,6 @@ def evaluate_single(
     sample_json: Path | None = None,
     json_match: bool = False,
     saliency_stats: dict[str, tuple[float, float]] | None = None,
-    *,
     combine_mode: str = "or",
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
@@ -278,8 +273,21 @@ def evaluate_single(
         LOGGER.info("Loading saliency from %s", saliency_path)
         saliency = _load_saliency(saliency_path)
     else:
+        if classifier is None:
+            if classifier_ckpt is None:
+                raise ValueError("classifier or classifier_ckpt must be provided")
+            from src.models.gnn.res_wrapper import RESGCLClassifier
+
+            LOGGER.debug(f"Loading classifier from {classifier_ckpt}")
+            classifier = RESGCLClassifier.load_pretrained(
+                str(classifier_ckpt), map_location=device
+            )
+        if explainer is None and explainer_ckpt is not None:
+            LOGGER.debug(f"Loading explainer from {explainer_ckpt}")
+            explainer = torch.load(explainer_ckpt, map_location=device, weights_only=False)
+
         saliency = _compute_saliency_with_explainer(
-            graph, classifier_ckpt, explainer_ckpt, device
+            graph, classifier, explainer, device
         )
 
     miner = FeatureMiner(
@@ -292,7 +300,10 @@ def evaluate_single(
         benign_freqs=benign_freqs,
         freq_threshold=freq_threshold,
     )
-    features = miner.mine(graph, saliency, saliency_stats)
+    if saliency_stats is None:
+        features = miner.mine(graph, saliency)
+    else:
+        features = miner.mine(graph, saliency, saliency_stats)
     group_pct = group_percentage
     if condition_type == "combo" and group_min_count is not None:
         group_pct = None
@@ -364,7 +375,6 @@ def evaluate_single(
                     group_min_count=group_min_count,
                     adjust_group_percentage=adjust_group_percentage,
                     saliency_stats=saliency_stats,
-                    combine_mode=args.combine_mode,
                 )
             coverage = 0.0
             LOGGER.debug("Skipping YARA match; using JSON verification only")
@@ -638,6 +648,18 @@ def main(argv: list[str] | None = None) -> None:
 
     device = torch.device(args.device)
 
+    classifier = None
+    explainer = None
+    need_model = args.saliency is None or (args.graph_dir and args.meta_csv)
+    if need_model:
+        from src.models.gnn.res_wrapper import RESGCLClassifier
+
+        LOGGER.debug("Loading classifier from %s", args.classifier)
+        classifier = RESGCLClassifier.load_pretrained(str(args.classifier), map_location=device)
+        if args.explainer and Path(args.explainer).is_file():
+            LOGGER.debug("Loading explainer from %s", args.explainer)
+            explainer = torch.load(args.explainer, map_location=device, weights_only=False)
+
     if args.graph_dir and args.meta_csv:
         import pandas as pd
 
@@ -665,8 +687,10 @@ def main(argv: list[str] | None = None) -> None:
                 res = evaluate_single(
                     gpath,
                     spath,
-                    classifier_ckpt=args.classifier,
-                    explainer_ckpt=args.explainer,
+                    classifier_ckpt=None,
+                    explainer_ckpt=None,
+                    classifier=classifier,
+                    explainer=explainer,
                     saliency_path=None,
                     device=device,
                     top_k=args.top_k,
@@ -756,8 +780,10 @@ def main(argv: list[str] | None = None) -> None:
         result = evaluate_single(
             args.graph,
             args.sample,
-            classifier_ckpt=args.classifier,
-            explainer_ckpt=args.explainer,
+            classifier_ckpt=None,
+            explainer_ckpt=None,
+            classifier=classifier,
+            explainer=explainer,
             saliency_path=args.saliency,
             device=device,
             top_k=args.top_k,

--- a/tests/test_explainer_rule_eval_saliency.py
+++ b/tests/test_explainer_rule_eval_saliency.py
@@ -57,18 +57,12 @@ def test_compute_saliency_handles_tuple(monkeypatch):
 
     classifier = DummyClassifier()
     explainer = DummyExplainer(classifier)
-
-    monkeypatch.setattr(
-        "src.models.gnn.res_wrapper.RESGCLClassifier.load_pretrained",
-        lambda *a, **k: classifier,
-    )
-    monkeypatch.setattr(torch, "load", lambda *a, **k: explainer)
     stub = types.ModuleType("src.cli.explainer_train")
     stub._compute_node_embeddings = lambda g, enc: {"n": torch.zeros(g["n"].num_nodes, 1)}
     sys.modules["src.cli.explainer_train"] = stub
 
     sal = mod._compute_saliency_with_explainer(
-        g, Path("clf.pt"), Path("exp.pt"), torch.device("cpu")
+        g, classifier, explainer, torch.device("cpu")
     )
 
     assert isinstance(sal, dict)


### PR DESCRIPTION
## Summary
- update `_compute_saliency_with_explainer` to accept loaded models
- allow `evaluate_single` to receive classifier and explainer instances
- load models once in `main` and reuse
- adjust test for new helper API

## Testing
- `pytest tests/test_explainer_rule_eval_saliency.py::test_compute_saliency_handles_tuple -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_json_match_fp_with_clean_sample -q`


------
https://chatgpt.com/codex/tasks/task_e_68831884fd04832ea32538ad203762c2