### PR TITLE
Fix combine_mode variable usage in explainer rule eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -639,6 +639,8 @@ def main(argv: list[str] | None = None) -> None:
     if args.verbose:
         LOGGER.setLevel(logging.DEBUG)
 
+    combine_mode = args.combine_mode
+
     benign_freqs = None
     if args.benign_freqs and args.benign_freqs.is_file():
         benign_freqs = json.loads(args.benign_freqs.read_text(encoding="utf-8"))
@@ -743,7 +745,7 @@ def main(argv: list[str] | None = None) -> None:
                 fname = f"{sha}.yar"
                 rule_txt = YaraBuilder().combine_rules(
                     res.get("rule_texts", [res.get("rule_text", "")]),
-                    mode=args.combine_mode,
+                    mode=combine_mode,
                 )
                 (rule_dir / fname).write_text(rule_txt, encoding="utf-8")
 
@@ -769,7 +771,7 @@ def main(argv: list[str] | None = None) -> None:
                 selected = random.sample(rule_texts, min(5, len(rule_texts)))
                 for i, (sha, texts) in enumerate(selected, start=1):
                     fname = f"{sha}.yar" if sha else f"rule_{i}.yar"
-                    combined = YaraBuilder().combine_rules(texts, mode=args.combine_mode)
+                    combined = YaraBuilder().combine_rules(texts, mode=combine_mode)
                     (args.sample_rules_out / fname).write_text(combined, encoding="utf-8")
         else:
             LOGGER.warning("No samples evaluated")
@@ -813,7 +815,7 @@ def main(argv: list[str] | None = None) -> None:
             ),
             json_match=args.json_match,
             saliency_stats=saliency_stats,
-            combine_mode=args.combine_mode,
+            combine_mode=combine_mode,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)
@@ -826,7 +828,7 @@ def main(argv: list[str] | None = None) -> None:
             rule_path = args.sample_rules_out / f"{args.sample.stem}.yar"
             rule_txt = YaraBuilder().combine_rules(
                 result.get("rule_texts", [result.get("rule_text", "")]),
-                mode=args.combine_mode,
+                mode=combine_mode,
             )
             rule_path.write_text(rule_txt, encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- avoid referencing `args.combine_mode` multiple times in `explainer_rule_eval`
- store CLI argument in local variable and pass/use it consistently

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_combine_mode -q` *(fails: 1 skipped, found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_68832d165eb0832eb500167da7902809