### PR TITLE
Fix YaraBuilder combo fallback

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -240,10 +240,7 @@ class YaraBuilder:
         else:  # combo
             group_count = sum(1 for v in groups.values() if v)
             feat_count = len(unique_feats)
-            if (
-                self.group_percentage is not None
-                and (group_count <= 1 or feat_count <= 2)
-            ):
+            if group_count <= 1 or feat_count <= 2:
                 cond_line = "    any of them"
             else:
                 parts = []
@@ -251,7 +248,8 @@ class YaraBuilder:
                     if not feats_list:
                         continue
                     if self.group_min_count is not None:
-                        parts.append(f"{self.group_min_count} of (${tag}*)")
+                        required = min(self.group_min_count, len(feats_list))
+                        parts.append(f"{required} of (${tag}*)")
                     elif self.group_percentage is not None:
                         pct = self.group_percentage
                         if self.adjust_group_percentage:

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -4,8 +4,7 @@ from src.rulegen.yara_builder import YaraBuilder
 def test_combo_basic():
     builder = YaraBuilder(condition_type="combo")
     rule = builder.build(["call:CreateFileW", "import:WS2_32.dll"])
-    assert "any of ($c*)" in rule
-    assert "any of ($i*)" in rule
+    assert "any of them" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 
@@ -15,6 +14,22 @@ def test_combo_group_min_count():
     rule = builder.build(["call:A", "call:B", "import:X", "import:Y"])
     assert "2 of ($c*)" in rule
     assert "2 of ($i*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err
+
+
+def test_combo_group_min_count_caps_at_len():
+    builder = YaraBuilder(condition_type="combo", group_min_count=2)
+    rule = builder.build(["call:A", "import:X", "feat"])
+    assert "1 of ($o*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err
+
+
+def test_combo_group_min_count_falls_back_any():
+    builder = YaraBuilder(condition_type="combo", group_min_count=2)
+    rule = builder.build(["call:A", "call:B", "call:C"])
+    assert "any of them" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 


### PR DESCRIPTION
## Summary
- refine combo condition logic in `YaraBuilder` for edge cases
- update combo test expectations
- add tests for group count fallback and min cap

## Testing
- `pytest tests/test_yara_builder_*.py -q`
- `pytest tests/test_yara_builder_combo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68834b9c8b38832ebc1a518c148cef38