### PR TITLE
Add min_match_ratio for YARA rule combination

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -615,6 +615,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Combine multiple rules with logical OR/AND when saving",
     )
     p.add_argument(
+        "--combine-min-ratio",
+        type=float,
+        default=0.5,
+        help="When combining rules in OR mode, require this fraction to match",
+    )
+    p.add_argument(
         "--clean-sample", type=Path, help="Optional clean sample for FP check"
     )
     p.add_argument("--out", type=Path, help="Save JSON result path")
@@ -746,6 +752,7 @@ def main(argv: list[str] | None = None) -> None:
                 rule_txt = YaraBuilder().combine_rules(
                     res.get("rule_texts", [res.get("rule_text", "")]),
                     mode=combine_mode,
+                    min_match_ratio=args.combine_min_ratio,
                 )
                 (rule_dir / fname).write_text(rule_txt, encoding="utf-8")
 
@@ -771,7 +778,11 @@ def main(argv: list[str] | None = None) -> None:
                 selected = random.sample(rule_texts, min(5, len(rule_texts)))
                 for i, (sha, texts) in enumerate(selected, start=1):
                     fname = f"{sha}.yar" if sha else f"rule_{i}.yar"
-                    combined = YaraBuilder().combine_rules(texts, mode=combine_mode)
+                    combined = YaraBuilder().combine_rules(
+                        texts,
+                        mode=combine_mode,
+                        min_match_ratio=args.combine_min_ratio,
+                    )
                     (args.sample_rules_out / fname).write_text(combined, encoding="utf-8")
         else:
             LOGGER.warning("No samples evaluated")
@@ -829,6 +840,7 @@ def main(argv: list[str] | None = None) -> None:
             rule_txt = YaraBuilder().combine_rules(
                 result.get("rule_texts", [result.get("rule_text", "")]),
                 mode=combine_mode,
+                min_match_ratio=args.combine_min_ratio,
             )
             rule_path.write_text(rule_txt, encoding="utf-8")
 

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -42,6 +42,7 @@ import random
 import re
 import string
 import math
+import itertools
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
 
@@ -309,7 +310,9 @@ class YaraBuilder:
             _LOG.warning("yara match failed for %s: %s", sample_path, exc)
             return False
 
-    def combine_rules(self, rules: List[str], mode: str = "or") -> str:
+    def combine_rules(
+        self, rules: List[str], mode: str = "or", min_match_ratio: float = 0.5
+    ) -> str:
         """Return a YARA file combining ``rules`` with a wrapper rule.
 
         Parameters
@@ -319,6 +322,13 @@ class YaraBuilder:
         mode : str, optional
             "or" (default) creates a wrapper rule that triggers if any rule
             matches.  ``"and"`` requires all rules to match.
+        min_match_ratio : float, optional
+            Minimum fraction of rules that must match when ``mode`` is ``"or"``.
+            When the ratio results in more than one but fewer than all rules,
+            the wrapper condition is formed by OR'ing together every
+            combination of ``k`` rules joined with AND, where
+            ``k = ceil(n * min_match_ratio)`` and ``n`` is the number of input
+            rules.
 
         Notes
         -----
@@ -337,8 +347,21 @@ class YaraBuilder:
             m = re.search(r"rule\s+(\w+)", text)
             names.append(m.group(1) if m else f"rule_{idx}")
 
-        operator = " or " if mode == "or" else " and "
-        cond = operator.join(names) if names else "false"
+        cond = "false"
+        if names:
+            if mode == "or":
+                k = max(1, math.ceil(len(names) * min_match_ratio))
+                if k <= 1:
+                    cond = " or ".join(names)
+                elif k >= len(names):
+                    cond = " and ".join(names)
+                else:
+                    parts = [
+                        "(" + " and ".join(c) + ")" for c in itertools.combinations(names, k)
+                    ]
+                    cond = " or ".join(parts) if parts else "false"
+            else:  # mode == "and"
+                cond = " and ".join(names)
         wrapper = [
             "rule combined_rule {",
             "  condition:",

--- a/tests/test_yara_builder_combine_rules.py
+++ b/tests/test_yara_builder_combine_rules.py
@@ -1,4 +1,5 @@
 import re
+import itertools
 from src.rulegen.yara_builder import YaraBuilder
 
 
@@ -16,4 +17,23 @@ def test_combine_rules_or_and():
     assert "combined_rule" in txt_and
     assert " and " in txt_and
     ok, err = b.validate(txt_and)
+    assert ok, err
+
+
+def test_combine_rules_min_ratio():
+    b = YaraBuilder()
+    r1 = b.build(["foo"])
+    r2 = b.build(["bar"])
+    r3 = b.build(["baz"])
+    txt = b.combine_rules([r1, r2, r3], min_match_ratio=0.6)
+
+    names = [re.search(r"rule\s+(\w+)", t).group(1) for t in (r1, r2, r3)]
+    m = re.search(r"rule combined_rule \{\n  condition:\n    (.+)\n\}", txt)
+    assert m, "wrapper rule missing"
+    cond = m.group(1)
+    assert cond.count(" or ") >= 2
+    for a, bname in itertools.combinations(names, 2):
+        assert f"{a} and {bname}" in cond
+
+    ok, err = b.validate(txt)
     assert ok, err


### PR DESCRIPTION
## Summary
- extend `YaraBuilder.combine_rules` with `min_match_ratio`
- expose ratio via `--combine-min-ratio` on `explainer_rule_eval` CLI
- support k-of-n combination logic when saving rules
- test combination when requiring two of three rules to match

## Testing
- `pytest tests/test_yara_builder_combine_rules.py::test_combine_rules_min_ratio -q`

------
https://chatgpt.com/codex/tasks/task_e_68834d2721d8832ea8cc50d3f762f033