### PR TITLE
Fix token extraction for quoted wide ASCII

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Sequence
 import math
+import re
 
 import logging
 from src.common.utils import get_logger, tqdm_wrap
@@ -128,10 +129,19 @@ def _extract_tokens(feature: str) -> list[str]:
             part = part[len("import:") :]
         if "!" in part:
             part = part.split("!")[-1]
-        part = part.strip().strip('"')
+
+        part = part.strip()
+        m = re.search(r'"([^\"]+)"', part)
+        if m:
+            part = m.group(1)
+        else:
+            part = part.strip('"')
+            if not part or part.startswith("{") or part.startswith("/"):
+                continue
+            part = part.split()[0]
+
         if not part or part.startswith("{") or part.startswith("/"):
             continue
-        part = part.split()[0]
         tokens.append(part)
     return tokens
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -773,3 +773,14 @@ def test_verify_features_saliency_stats(tmp_path):
         mod.verify_features(js, feats, saliency_stats=stats) is True
     )
 
+
+def test_verify_features_string_wide_ascii(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["ProcessWindowStation"]}))
+
+    feats = ['"ProcessWindowStation" wide ascii']
+
+    assert mod.verify_features(js, feats) is True
+


### PR DESCRIPTION
## Summary
- improve `_extract_tokens` to handle `"..." wide ascii` patterns
- test detection of quoted wide-ascii string in JSON

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_verify_features_string_wide_ascii -q`

------
https://chatgpt.com/codex/tasks/task_e_688350f95aac832ea9bb91ec1a00a8ef