### PR TITLE
Fix single-token YARA condition

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -229,18 +229,21 @@ class YaraBuilder:
                 strings_section_lines.append(f"    $s{idx} = {yara_str}")
 
         # 4) condition
-        if self.condition_type == "any":
+        n_feats = len(unique_feats)
+        if n_feats == 1:
+            cond_line = "    all of them"
+        elif self.condition_type == "any":
             cond_line = "    any of them"
         elif self.condition_type == "all":
             cond_line = "    all of them"
         elif self.condition_type == "percentage":
-            thresh = max(1, math.ceil(len(unique_feats) * self.percentage / 100.0))
+            thresh = max(1, math.ceil(n_feats * self.percentage / 100.0))
             cond_line = f"    {thresh} of them"
         elif self.condition_type == "count":
             cond_line = f"    {self.min_count} of them"
         else:  # combo
             group_count = sum(1 for v in groups.values() if v)
-            feat_count = len(unique_feats)
+            feat_count = n_feats
             if group_count <= 1 or feat_count <= 2:
                 cond_line = "    any of them"
             else:

--- a/tests/test_yara_builder_single_token.py
+++ b/tests/test_yara_builder_single_token.py
@@ -1,0 +1,15 @@
+import pytest
+from src.rulegen.yara_builder import YaraBuilder
+
+@pytest.mark.parametrize("cond", ["any", "percentage", "count", "combo"])
+def test_single_token_all_condition(cond):
+    kwargs = {"condition_type": cond}
+    if cond == "count":
+        kwargs["min_count"] = 2
+    if cond == "percentage":
+        kwargs["percentage"] = 50
+    builder = YaraBuilder(**kwargs)
+    rule = builder.build(["featA"])
+    assert "all of them" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- handle single feature case in `YaraBuilder.build`
- test that single token results in `all of them`

## Testing
- `pytest tests/test_yara_builder_single_token.py tests/test_yara_builder_percentage.py tests/test_yara_builder_count.py tests/test_yara_builder_combo.py tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_prefix_strip.py tests/test_yara_builder_quotes.py tests/test_yara_builder_combine_rules.py tests/test_chain_builders.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688353769d90832e8f88579f6113ede6