### PR TITLE
Add marker features and combo rule support

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -461,6 +461,7 @@ class FeatureMiner:
                 s = sec.strip("\x00 ").strip()
                 if s and s not in {".text", ".data", ".rdata"}:
                     candidates.append(f'"{s}" ascii nocase')
+                    candidates.append(f"marker:{s}")
 
         # 6) 기타 Heuristic
         #    예) ntype == 'syscall' 등

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -212,7 +212,7 @@ class YaraBuilder:
         strings_section_lines = []
         groups: dict[str, list[str]] = {}
         if self.condition_type == "combo":
-            prefix_map = {"call:": "c", "import:": "i"}
+            prefix_map = {"call:": "c", "import:": "i", "marker:": "m"}
             for feat in unique_feats:
                 tag = "o"
                 for p, t in prefix_map.items():
@@ -247,6 +247,9 @@ class YaraBuilder:
                 parts = []
                 for tag, feats_list in groups.items():
                     if not feats_list:
+                        continue
+                    if tag == "m":
+                        parts.append(f"{len(feats_list)} of ($m*)")
                         continue
                     if self.group_min_count is not None:
                         required = min(self.group_min_count, len(feats_list))
@@ -407,7 +410,7 @@ class YaraBuilder:
         """
         if self.strip_prefix:
             lowered = feat.lower()
-            for prefix in ("call:", "syscall:", "import:"):
+            for prefix in ("call:", "syscall:", "import:", "marker:"):
                 if lowered.startswith(prefix):
                     feat = feat.split(":", 1)[1]
                     lowered = feat.lower()

--- a/tests/test_feature_miner_additional_fields.py
+++ b/tests/test_feature_miner_additional_fields.py
@@ -45,3 +45,4 @@ def test_miner_extracts_section_name():
     sal = torch.tensor([0.9])
     feats = FeatureMiner(top_k=1)(g, sal)
     assert '".foo" ascii nocase' in feats
+    assert "marker:.foo" in feats

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -54,3 +54,11 @@ def test_combo_adjust_group_percentage():
     assert "2 of ($i*)" in rule
     ok, err = builder.validate(rule)
     assert ok, err
+
+
+def test_combo_marker_group_mandatory():
+    builder = YaraBuilder(condition_type="combo")
+    rule = builder.build(["call:A", "import:X", "marker:.foo"])
+    assert "1 of ($m*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- add `marker:` tokens for unusual PE sections in `FeatureMiner`
- treat `marker:` features as group `m` in `YaraBuilder` combo mode
- ensure marker group always matches all features
- test new marker behavior for feature miner and combo rules

## Testing
- `pytest tests/test_yara_builder_combo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688350dbb3e8832e9c53cf7d101abd44