### PR TITLE
Add low FP rule save option

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -641,6 +641,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory to write example rules",
     )
     p.add_argument(
+        "--low-fp-rules-out",
+        type=Path,
+        help="Directory to write rules with no false positives",
+    )
+    p.add_argument(
         "--json-match",
         action="store_true",
         help="Verify features in sample JSON instead of YARA match",
@@ -765,6 +770,11 @@ def main(argv: list[str] | None = None) -> None:
                     min_match_ratio=args.combine_min_ratio,
                 )
                 (rule_dir / fname).write_text(rule_txt, encoding="utf-8")
+                if args.low_fp_rules_out and not res.get("false_positive"):
+                    args.low_fp_rules_out.mkdir(parents=True, exist_ok=True)
+                    (args.low_fp_rules_out / fname).write_text(
+                        rule_txt, encoding="utf-8"
+                    )
 
         if args.out_csv:
             pd.DataFrame(results).to_csv(args.out_csv, index=False)
@@ -860,6 +870,11 @@ def main(argv: list[str] | None = None) -> None:
                 (rule_dir / f"{args.sample.stem}.yar").write_text(
                     rule_txt, encoding="utf-8"
                 )
+                if args.low_fp_rules_out and not result.get("false_positive"):
+                    args.low_fp_rules_out.mkdir(parents=True, exist_ok=True)
+                    (args.low_fp_rules_out / f"{args.sample.stem}.yar").write_text(
+                        rule_txt, encoding="utf-8"
+                    )
 
 
 __all__ = ["main"]

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -208,6 +208,52 @@ def test_cli_sample_rules_out_detected(tmp_path, monkeypatch):
     assert (det_dir / f"{sample.stem}.yar").is_file()
 
 
+def test_cli_low_fp_rules_out(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    low_dir = tmp_path / "low"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--json-match",
+        "--low-fp-rules-out",
+        str(low_dir),
+    ])
+
+    assert (low_dir / f"{sample.stem}.yar").is_file()
+
+
 def test_cli_json_match_detects(tmp_path, monkeypatch):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)


### PR DESCRIPTION
## Summary
- allow saving rules with no false positives via `--low-fp-rules-out`
- test the new CLI feature

## Testing
- `pytest -k low_fp_rules_out -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688355fbdab8832e98c0560a59939116