### PR TITLE
Extend YaraBuilder.combine_rules

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -317,7 +317,12 @@ class YaraBuilder:
             return False
 
     def combine_rules(
-        self, rules: List[str], mode: str = "or", min_match_ratio: float = 0.5
+        self,
+        rules: List[str],
+        mode: str = "or",
+        min_match_ratio: float = 0.5,
+        wrapper_name: str | None = None,
+        private: bool = False,
     ) -> str:
         """Return a YARA file combining ``rules`` with a wrapper rule.
 
@@ -338,12 +343,21 @@ class YaraBuilder:
 
         Notes
         -----
-        The returned text contains the original rules followed by a final rule
-        named ``combined_rule`` referencing them.
+        The returned text contains the original rules followed by a final wrapper
+        rule referencing them.  The wrapper rule name can be customized via
+        ``wrapper_name``; when omitted a unique name is automatically generated.
         """
 
         if mode not in {"or", "and"}:
             raise ValueError("mode must be 'or' or 'and'")
+
+        if len(rules) <= 1:
+            return rules[0].strip() if rules else ""
+
+        if wrapper_name is None:
+            ts = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            rand = random.randint(0, 9999)
+            wrapper_name = f"combined_rule_{ts}_{rand:04}"
 
         names: List[str] = []
         cleaned: List[str] = []
@@ -368,8 +382,11 @@ class YaraBuilder:
                     cond = " or ".join(parts) if parts else "false"
             else:  # mode == "and"
                 cond = " and ".join(names)
+        header = "rule"
+        if private:
+            header = "private " + header
         wrapper = [
-            "rule combined_rule {",
+            f"{header} {wrapper_name} {{",
             "  condition:",
             f"    {cond}",
             "}",

--- a/tests/test_yara_builder_combine_rules.py
+++ b/tests/test_yara_builder_combine_rules.py
@@ -7,13 +7,13 @@ def test_combine_rules_or_and():
     b = YaraBuilder()
     r1 = b.build(["foo"])
     r2 = b.build(["bar"])
-    txt_or = b.combine_rules([r1, r2], mode="or")
+    txt_or = b.combine_rules([r1, r2], mode="or", wrapper_name="combined_rule")
     assert "combined_rule" in txt_or
     assert re.search(r"\b(or|and)\b", txt_or)
     ok, err = b.validate(txt_or)
     assert ok, err
 
-    txt_and = b.combine_rules([r1, r2], mode="and")
+    txt_and = b.combine_rules([r1, r2], mode="and", wrapper_name="combined_rule")
     assert "combined_rule" in txt_and
     assert " and " in txt_and
     ok, err = b.validate(txt_and)
@@ -25,7 +25,7 @@ def test_combine_rules_min_ratio():
     r1 = b.build(["foo"])
     r2 = b.build(["bar"])
     r3 = b.build(["baz"])
-    txt = b.combine_rules([r1, r2, r3], min_match_ratio=0.6)
+    txt = b.combine_rules([r1, r2, r3], min_match_ratio=0.6, wrapper_name="combined_rule")
 
     names = [re.search(r"rule\s+(\w+)", t).group(1) for t in (r1, r2, r3)]
     m = re.search(r"rule combined_rule \{\n  condition:\n    (.+)\n\}", txt)
@@ -37,3 +37,10 @@ def test_combine_rules_min_ratio():
 
     ok, err = b.validate(txt)
     assert ok, err
+
+
+def test_combine_rules_single_rule():
+    b = YaraBuilder()
+    r = b.build(["foo"])
+    txt = b.combine_rules([r])
+    assert txt.strip() == r.strip()


### PR DESCRIPTION
## Summary
- extend `combine_rules` interface with `wrapper_name` and `private` options
- support single-rule passthrough
- auto-generate wrapper name when not provided
- update combine rules tests and add new single-rule test

## Testing
- `pytest tests/test_yara_builder_combine_rules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68835ca8b3d8832eb67b9482ecc26fa5