### PR TITLE
Fix YaraBuilder to preserve modifiers

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -69,6 +69,11 @@ _PUNCT = {":", ",", ".", ";", ")", "]", "}", "?", "!"}
 _OPEN_PUNCT = {"(", "[", "{"}
 _WHITESPACE_RX = re.compile(r"\s+")
 
+# Pre-existing YARA string literal with allowed modifiers
+_YARA_STR_MOD_RX = re.compile(
+    r'^"(?P<content>(?:[^"\\]|\\.)*)"(?P<mods>(?:\s+(?:wide|ascii|nocase))*)$'
+)
+
 
 def _token_is_feature(tok: str) -> bool:
     """Return True if ``tok`` resembles a feature string.
@@ -437,6 +442,12 @@ class YaraBuilder:
                     break
             if "!" in feat:
                 feat = feat.split("!", 1)[1]
+
+        m = _YARA_STR_MOD_RX.fullmatch(feat)
+        if m:
+            escaped = m.group("content").replace("\\", r"\\").replace('"', r'\"')
+            mods = m.group("mods") or ""
+            return f'"{escaped}"{mods}'
 
         if feat.startswith("/") and feat.endswith("/"):
             return feat

--- a/tests/test_yara_builder_modifiers.py
+++ b/tests/test_yara_builder_modifiers.py
@@ -1,0 +1,11 @@
+from src.rulegen.yara_builder import YaraBuilder
+
+
+def test_existing_string_modifiers_kept():
+    builder = YaraBuilder()
+    feat = '"unsigned" wide ascii nocase'
+    rule = builder.build([feat])
+    assert '"unsigned" wide ascii nocase" nocase ascii' not in rule
+    assert '"unsigned" wide ascii nocase' in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- detect pre-existing YARA string modifiers and skip adding `nocase ascii`
- test that modifiers like `wide ascii nocase` are kept

## Testing
- `pytest tests/test_yara_builder_modifiers.py -q`
- `pytest tests/test_yara_builder_* -q`

------
https://chatgpt.com/codex/tasks/task_e_68835e3b6dfc832e959ea27e72867e4e