### PR TITLE
Add YaraBuilder ID mapping utility

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -365,7 +365,7 @@ def evaluate_single(
             group_min_count=group_min_count,
             adjust_group_percentage=adjust_group_percentage,
         )
-        rule_text = builder.build(feats)
+        rule_text, id_map = builder.build(feats, return_map=True)
         builder.validate(rule_text)
 
         if json_match:
@@ -405,6 +405,9 @@ def evaluate_single(
                     coverage = float(total) / float(size) if size > 0 else 0.0
                 except Exception:
                     coverage = 0.0
+
+                matched_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
+                LOGGER.debug("Matched tokens: %s", matched_tokens)
 
         fp = False
         if json_match:

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -172,9 +172,18 @@ class YaraBuilder:
         return "".join(out)
 
     # ──────────────────────────────────────────── public api ──
-    def build(self, tokens: Sequence[str]) -> str:
-        """
-        토큰 → YARA rule 문자열
+    def build(
+        self, tokens: Sequence[str], *, return_map: bool = False
+    ) -> str | Tuple[str, dict[str, str]]:
+        """Return a YARA rule text assembled from ``tokens``.
+
+        Parameters
+        ----------
+        tokens : Sequence[str]
+            Input token sequence.
+        return_map : bool, optional
+            When ``True`` also return a mapping from generated string
+            identifiers (e.g. ``"$s0"``) to the originating feature.
         """
         # 1) rule name
         ts = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
@@ -216,6 +225,7 @@ class YaraBuilder:
         # 3) strings section
         strings_section_lines = []
         groups: dict[str, list[str]] = {}
+        id_map: dict[str, str] = {}
         if self.condition_type == "combo":
             prefix_map = {"call:": "c", "import:": "i", "marker:": "m"}
             for feat in unique_feats:
@@ -225,13 +235,17 @@ class YaraBuilder:
                         tag = t
                         break
                 idx = len(groups.setdefault(tag, []))
+                ident = f"${tag}{idx}"
                 yara_str = self._to_yara_string(feat)
-                strings_section_lines.append(f"    ${tag}{idx} = {yara_str}")
+                strings_section_lines.append(f"    {ident} = {yara_str}")
                 groups[tag].append(feat)
+                id_map[ident] = feat
         else:
             for idx, feat in enumerate(unique_feats):
                 yara_str = self._to_yara_string(feat)
-                strings_section_lines.append(f"    $s{idx} = {yara_str}")
+                ident = f"$s{idx}"
+                strings_section_lines.append(f"    {ident} = {yara_str}")
+                id_map[ident] = feat
 
         # 4) condition
         n_feats = len(unique_feats)
@@ -281,7 +295,10 @@ class YaraBuilder:
             f"{cond_line}",
             "}",
         ]
-        return "\n".join(rule_lines)
+        text = "\n".join(rule_lines)
+        if return_map:
+            return text, id_map
+        return text
 
     def validate(self, rule_text: str) -> Tuple[bool, str | None]:
         """


### PR DESCRIPTION
## Summary
- extend `YaraBuilder.build` with optional `return_map` for mapping string identifiers back to features
- track generated identifiers when building rules and optionally return the map
- show matched tokens in `explainer_rule_eval` by requesting the map from the builder

## Testing
- `pytest tests/test_yara_builder_single_token.py::test_single_token_all_condition[any] -q`
- `pytest tests/test_yara_builder_single_token.py tests/test_yara_builder_prefix_strip.py tests/test_yara_builder_combo.py tests/test_yara_builder_count.py tests/test_yara_builder_percentage.py tests/test_yara_builder_modifiers.py tests/test_yara_builder_feature_fallback.py tests/test_yara_builder_quotes.py tests/test_yara_builder_combine_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6883a020c33c832eb43d1f0b579131ed