### PR TITLE
Add option to return matched features

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -155,8 +155,13 @@ def verify_features(
     group_min_count: int | None = None,
     adjust_group_percentage: bool = False,
     saliency_stats: dict[str, tuple[float, float]] | None = None,
-) -> bool:
-    """Return True if ``features`` satisfy the condition in sample JSON."""
+    return_matched: bool = False,
+) -> bool | tuple[bool, list[str]]:
+    """Return True if ``features`` satisfy the condition in sample JSON.
+
+    When ``return_matched`` is ``True`` the function returns a tuple of the
+    result and the list of matched feature strings.
+    """
     try:
         js = json.loads(json_path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
@@ -188,13 +193,17 @@ def verify_features(
 
     if condition_type != "combo":
         if condition_type == "all":
-            return len(matched) == len(features)
+            result = len(matched) == len(features)
+            return (result, matched) if return_matched else result
         if condition_type == "percentage" and group_percentage is not None:
             thresh = max(1, math.ceil(len(features) * group_percentage / 100.0))
-            return len(matched) >= thresh
+            result = len(matched) >= thresh
+            return (result, matched) if return_matched else result
         if condition_type == "count" and group_min_count is not None:
-            return len(matched) >= group_min_count
-        return bool(matched)
+            result = len(matched) >= group_min_count
+            return (result, matched) if return_matched else result
+        result = bool(matched)
+        return (result, matched) if return_matched else result
 
     # combo mode
     prefix_map = {"call:": "c", "import:": "i"}
@@ -214,7 +223,8 @@ def verify_features(
     feat_count = sum(len(v) for v in groups.values())
 
     if group_percentage is not None and (group_count <= 1 or feat_count <= 2):
-        return bool(matched)
+        result = bool(matched)
+        return (result, matched) if return_matched else result
 
     for tag, feats_list in groups.items():
         if not feats_list:
@@ -223,7 +233,8 @@ def verify_features(
         if group_min_count is not None:
             required = min(group_min_count, len(feats_list))
             if mcount < required:
-                return False
+                result = False
+                return (result, matched) if return_matched else result
         elif group_percentage is not None:
             pct = group_percentage
             if adjust_group_percentage:
@@ -231,11 +242,14 @@ def verify_features(
                 pct = max(1, min(pct, scaled))
             req = max(1, math.ceil(len(feats_list) * pct / 100.0))
             if mcount < req:
-                return False
+                result = False
+                return (result, matched) if return_matched else result
         else:
             if mcount == 0:
-                return False
-    return True
+                result = False
+                return (result, matched) if return_matched else result
+    result = True
+    return (result, matched) if return_matched else result
 
 
 def evaluate_single(

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -830,3 +830,17 @@ def test_verify_features_string_wide_ascii(tmp_path):
 
     assert mod.verify_features(js, feats) is True
 
+
+def test_verify_features_return_matched(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["foo", "bar"]}))
+
+    feats = ["call:foo", "call:baz"]
+
+    result, matched = mod.verify_features(js, feats, return_matched=True)
+
+    assert result is True
+    assert matched == ["call:foo"]
+


### PR DESCRIPTION
## Summary
- allow `verify_features` to optionally return matched feature strings
- test returning matched features

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_verify_features_return_matched -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a1f42c78832ebff6b2bef5781677