### PR TITLE
Add preprocessing script for single JSON

### DIFF
--- a/scripts/preprocess_single.py
+++ b/scripts/preprocess_single.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Convert a single PE JSON into a hetero graph and node embeddings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Callable
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Convert one JSON → hetero graph")
+    p.add_argument("--input", type=Path, required=True, help="PE metadata JSON")
+    p.add_argument("--out-dir", type=Path, required=True, help="Output directory root")
+    p.add_argument(
+        "--views",
+        nargs="+",
+        default=["ast", "cfg", "fcg", "syscall"],
+        help="Views to generate",
+    )
+    p.add_argument("--normalise", action="store_true", help="Apply schema normaliser")
+    p.add_argument("--with-feats", action="store_true", help="Fill missing node feats")
+    p.add_argument(
+        "--feat-policy",
+        default="TRIM",
+        help="Overlength feature policy (ERROR|TRIM|EXPAND|MASKPAD)",
+    )
+    p.add_argument(
+        "--model-name",
+        default="microsoft/codebert-base",
+        help="HuggingFace model for embeddings",
+    )
+    p.add_argument("--batch-size", type=int, default=64, help="Embedding batch size")
+    p.add_argument("--device", default="cpu", help="Embedding device")
+    return p.parse_args(argv)
+
+# allow running as a standalone script
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.graphs.builders.hetero_builder import (
+    HeteroGraphBuilder,
+    fill_missing_node_feats,
+    _ensure_num_nodes_any,
+    OverLengthPolicy,
+)
+from src.graphs.dataset.graph_dataset import GraphDataset
+from src.graphs.loaders.factory import get_loader
+from src.graphs.loaders.ast_loader import ASTLoader
+from src.graphs.loaders.cfg_loader import CFGLoader
+from src.graphs.loaders.fcg_loader import FCGLoader
+from src.graphs.loaders.syscall_loader import SysCallLoader
+from src.graphs.normalizers.base import get_normalizer
+from src.graphs.utils import ensure_dir
+from src.models.llm_embed import CodeLLMNodeFeat
+from src.graphs.features.cache import save_tensor
+
+import torch
+
+
+_CONVERTERS: Dict[str, Callable[[dict], dict]] = {
+    "ast": ASTLoader._convert_pejson_to_ast,
+    "cfg": CFGLoader._convert_pejson_to_cfg,
+    "fcg": FCGLoader._convert_pejson_to_fcg,
+    "syscall": SysCallLoader._convert_pejson_to_syscalls,
+}
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _convert_view(view: str, js: dict):
+    conv = _CONVERTERS.get(view)
+    if conv is None:
+        raise ValueError(f"unknown view '{view}'")
+    return conv(js)
+
+
+def _embed_tokens(
+    encoder: CodeLLMNodeFeat,
+    store: torch.nn.Module,
+    *,
+    batch_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    none_idx = []
+    if "input_ids" in store:
+        input_ids = store["input_ids"]
+        attn_mask = store.get("attention_mask")
+    else:
+        texts = store.get("text") or store.get("kind_str")
+        if texts is None:
+            raise RuntimeError("token store lacks text or input_ids")
+        if isinstance(texts, str):
+            texts = [texts]
+        else:
+            try:
+                texts = list(texts)
+            except TypeError:
+                texts = [texts]
+        clean = []
+        for idx, t in enumerate(texts):
+            if t is None:
+                none_idx.append(idx)
+                clean.append("")
+            else:
+                clean.append(str(t))
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(encoder.config._name_or_path)
+        enc = tok(
+            clean,
+            padding=True,
+            truncation=True,
+            max_length=encoder.max_length,
+            return_tensors="pt",
+        )
+        input_ids = enc["input_ids"]
+        attn_mask = enc["attention_mask"]
+
+    embeddings = []
+    for start in range(0, input_ids.size(0), batch_size):
+        ids = input_ids[start : start + batch_size].to(device)
+        mask = attn_mask[start : start + batch_size].to(device) if attn_mask is not None else None
+        emb = encoder(ids, mask).cpu()
+        embeddings.append(emb)
+
+    feat = torch.cat(embeddings, dim=0)
+    if none_idx:
+        feat[none_idx] = 0
+    return feat
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+
+    js = _load_json(args.input)
+    sha = js.get("get_metadata", {}).get("sha256", args.input.stem)
+
+    builder = HeteroGraphBuilder()
+    for view in args.views:
+        view_js = _convert_view(view, js)
+        data_bytes = json.dumps(view_js).encode()
+        g = get_loader(view).load(data_bytes)
+        if args.normalise:
+            g = get_normalizer(view).normalize(g)
+        g = _ensure_num_nodes_any(g)
+        builder.add_view(g, view)
+
+    hetero = builder.build()
+
+    hetero = GraphDataset._sanitize_attrs(hetero)
+    hetero = GraphDataset._ensure_num_nodes(hetero)
+    hetero = GraphDataset._ensure_x(hetero, policy=OverLengthPolicy[args.feat_policy])
+    hetero = GraphDataset._sanitize_edges(hetero)
+
+    if args.with_feats:
+        fill_missing_node_feats(hetero, policy=OverLengthPolicy[args.feat_policy])
+
+    hetero_dir = args.out_dir / "hetero"
+    embeds_dir = args.out_dir / "embeds"
+    ensure_dir(hetero_dir)
+    ensure_dir(embeds_dir)
+
+    out_path = hetero_dir / f"{sha}.pt"
+    torch.save(hetero, out_path)
+
+    encoder = CodeLLMNodeFeat(args.model_name)
+    encoder.to(args.device)
+    if "token" not in hetero.node_types:
+        raise RuntimeError("no token nodes in graph")
+
+    feat = _embed_tokens(
+        encoder,
+        hetero["token"],
+        batch_size=args.batch_size,
+        device=torch.device(args.device),
+    )
+
+    save_tensor(sha, feat, embeds_dir)
+
+    print(f"✔ saved hetero graph -> {out_path}\n✔ saved embeddings -> {embeds_dir / (sha + '.ftr')}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add `preprocess_single.py` to convert one PE JSON to hetero graph and node features
- implement CLI flags for view selection, embedding model, and other options
- compute CodeLLM features for token nodes and save outputs

## Testing
- `pytest tests/test_embed_stage.py::test_embed_corpus -q`
- `python scripts/preprocess_single.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6883a2f4f3d0832eabf125250acb8f84