### PR TITLE
Add fp rules output option

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -663,6 +663,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory to write rules with no false positives",
     )
     p.add_argument(
+        "--fp-rules-out",
+        type=Path,
+        help="Directory to write rules that triggered false positives",
+    )
+    p.add_argument(
         "--json-match",
         action="store_true",
         help="Verify features in sample JSON instead of YARA match",
@@ -792,6 +797,11 @@ def main(argv: list[str] | None = None) -> None:
                     (args.low_fp_rules_out / fname).write_text(
                         rule_txt, encoding="utf-8"
                     )
+                if args.fp_rules_out and res.get("false_positive"):
+                    args.fp_rules_out.mkdir(parents=True, exist_ok=True)
+                    (args.fp_rules_out / fname).write_text(
+                        rule_txt, encoding="utf-8"
+                    )
 
         if args.out_csv:
             pd.DataFrame(results).to_csv(args.out_csv, index=False)
@@ -871,14 +881,15 @@ def main(argv: list[str] | None = None) -> None:
             args.out.write_text(text, encoding="utf-8")
         print(text)
 
+        rule_txt = YaraBuilder().combine_rules(
+            result.get("rule_texts", [result.get("rule_text", "")]),
+            mode=combine_mode,
+            min_match_ratio=args.combine_min_ratio,
+        )
+
         if args.sample_rules_out:
             args.sample_rules_out.mkdir(parents=True, exist_ok=True)
             rule_path = args.sample_rules_out / f"{args.sample.stem}.yar"
-            rule_txt = YaraBuilder().combine_rules(
-                result.get("rule_texts", [result.get("rule_text", "")]),
-                mode=combine_mode,
-                min_match_ratio=args.combine_min_ratio,
-            )
             rule_path.write_text(rule_txt, encoding="utf-8")
 
             if result.get("detected"):
@@ -892,6 +903,12 @@ def main(argv: list[str] | None = None) -> None:
                     (args.low_fp_rules_out / f"{args.sample.stem}.yar").write_text(
                         rule_txt, encoding="utf-8"
                     )
+
+        if args.fp_rules_out and result.get("false_positive"):
+            args.fp_rules_out.mkdir(parents=True, exist_ok=True)
+            (args.fp_rules_out / f"{args.sample.stem}.yar").write_text(
+                rule_txt, encoding="utf-8"
+            )
 
 
 __all__ = ["main"]

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -254,6 +254,59 @@ def test_cli_low_fp_rules_out(tmp_path, monkeypatch):
     assert (low_dir / f"{sample.stem}.yar").is_file()
 
 
+def test_cli_fp_rules_out(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+    clean_json = tmp_path / "clean.json"
+    clean_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    fp_dir = tmp_path / "fp"
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--json-match",
+        "--clean-sample",
+        str(clean),
+        "--fp-rules-out",
+        str(fp_dir),
+    ])
+
+    assert (fp_dir / f"{sample.stem}.yar").is_file()
+
+
 def test_cli_json_match_detects(tmp_path, monkeypatch):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)


### PR DESCRIPTION
## Summary
- allow CLI to save rules which caused false positives via `--fp-rules-out`
- save FP rules for both single-sample and batch evaluation
- add regression test for `--fp-rules-out`

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_fp_rules_out -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a3d05e38832ea21f25c9d168a1f9