### PR TITLE
Update graph sanitiser to check node counts

### DIFF
--- a/scripts/sanitise_graphs.py
+++ b/scripts/sanitise_graphs.py
@@ -51,6 +51,7 @@ def main():
         dst_path = out_dir / rel
         try:
             graph = load_graph(src_path)
+            graph = GraphDataset._ensure_num_nodes(graph)
             graph = GraphDataset._sanitize_edges(graph)
             save_graph(graph, dst_path)
         except Exception as e:


### PR DESCRIPTION
## Summary
- call `GraphDataset._ensure_num_nodes` when sanitising graphs

## Testing
- `pytest tests/test_graph_dataset_sanitize.py::test_sanitize_edges` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_6883a7d6179c832ebb976565efd3054a