### PR TITLE
Enhance rule evaluation logging

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -370,7 +370,7 @@ def evaluate_single(
     coverages: list[float] = []
     false_positives: list[bool] = []
 
-    def _eval_group(feats: list[str]) -> tuple[bool, float, bool, str]:
+    def _eval_group(feats: list[str]) -> tuple[bool, float, bool, str, list[str] | None]:
         builder = YaraBuilder(
             condition_type=condition_type,
             percentage=percentage,
@@ -381,6 +381,8 @@ def evaluate_single(
         )
         rule_text, id_map = builder.build(feats, return_map=True)
         builder.validate(rule_text)
+
+        fp_tokens: list[str] | None = None
 
         if json_match:
             jpath = (
@@ -456,21 +458,28 @@ def evaluate_single(
                     if not fp_path.is_file():
                         continue
                     try:
-                        if compiled.match(str(fp_path)):
+                        matches = compiled.match(str(fp_path))
+                        if matches:
                             fp = True
+                            fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
                             break
                     except Exception:
                         continue
             elif clean_sample is not None and compiled is not None:
                 try:
-                    fp = bool(compiled.match(str(clean_sample)))
+                    matches = compiled.match(str(clean_sample))
+                    fp = bool(matches)
+                    if fp:
+                        fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
                 except Exception:
                     fp = False
             elif clean_paths is not None and compiled is not None:
                 for p in clean_paths:
                     try:
-                        if compiled.match(str(p)):
+                        matches = compiled.match(str(p))
+                        if matches:
                             fp = True
+                            fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
                             break
                     except Exception:
                         continue
@@ -481,14 +490,16 @@ def evaluate_single(
             ):
                 fp = False
 
-        return detected, coverage, fp, rule_text
+        return detected, coverage, fp, rule_text, fp_tokens
 
+    fp_tokens_all: list[list[str] | None] = []
     for grp in groups:
-        det, cov, fp, rt = _eval_group(grp)
+        det, cov, fp, rt, fp_tok = _eval_group(grp)
         detections.append(det)
         coverages.append(cov)
         false_positives.append(fp)
         rule_texts.append(rt)
+        fp_tokens_all.append(fp_tok)
 
     if isinstance(saliency, dict):
         flat = torch.cat(list(saliency.values()))
@@ -512,6 +523,12 @@ def evaluate_single(
         any(false_positives) if combine_mode == "or" else all(false_positives)
     )
 
+    matched_tokens_fp: list[str] = []
+    for toks in fp_tokens_all:
+        if toks:
+            matched_tokens_fp = toks
+            break
+
     result: Dict[str, Any] = {
         "detected": combined_det,
         "rule_length": len(first_feats),
@@ -520,9 +537,13 @@ def evaluate_single(
         "coverage": max_cov,
         "rule_text": rule_texts[0] if rule_texts else "",
         "false_positive": combined_fp,
+        "group_min_count": group_min_count,
+        "freq_threshold": freq_threshold,
     }
     result["rule_texts"] = rule_texts
     result["false_positives"] = false_positives
+    if matched_tokens_fp:
+        result["matched_tokens"] = matched_tokens_fp
 
     if sample_json is not None and sample_json.is_file() and first_feats:
         result["feature_verified"] = verify_features(
@@ -534,6 +555,16 @@ def evaluate_single(
             adjust_group_percentage=adjust_group_percentage,
             saliency_stats=saliency_stats,
         )
+
+    LOGGER.info(
+        "detected=%s rule_len=%d avg_importance=%.4f mask_sparsity=%.4f coverage=%.4f false_positive=%s",
+        combined_det,
+        len(first_feats),
+        avg_importance,
+        mask_sparsity,
+        max_cov,
+        combined_fp,
+    )
 
     return result
 


### PR DESCRIPTION
## Summary
- record false positive token details during evaluation
- include group_min_count and freq_threshold in evaluation output
- log evaluation metrics such as importance and coverage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883a7b0caf8832e9e37b692b6e29edf