### PR TITLE
Implement false-positive retries for rule evaluation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -285,6 +285,8 @@ def evaluate_single(
     json_match: bool = False,
     saliency_stats: dict[str, tuple[float, float]] | None = None,
     combine_mode: str = "or",
+    combine_min_ratio: float = 0.5,
+    fp_retries: int = 0,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -315,258 +317,285 @@ def evaluate_single(
             graph, classifier, explainer, device
         )
 
-    miner = FeatureMiner(
-        top_k=top_k,
-        top_k_percent=top_k_percent,
-        saliency_top_percent=saliency_top_percent,
-        dynamic_k=dynamic_k,
-        min_saliency=min_saliency,
-        keep_per_type=keep_per_type,
-        benign_freqs=benign_freqs,
-        freq_threshold=freq_threshold,
-    )
-    if saliency_stats is None:
-        features = miner.mine(graph, saliency)
-    else:
-        features = miner.mine(graph, saliency, saliency_stats)
-    group_pct = group_percentage
-    if condition_type == "combo" and group_min_count is not None:
-        group_pct = None
-    if sample_json is not None and sample_json.is_file():
-        filtered = [
-            f
-            for f in features
-            if verify_features(
+    def _build_and_eval(freq_thresh: float | int, group_cnt: int | None, comb_ratio: float) -> Dict[str, Any]:
+        miner = FeatureMiner(
+            top_k=top_k,
+            top_k_percent=top_k_percent,
+            saliency_top_percent=saliency_top_percent,
+            dynamic_k=dynamic_k,
+            min_saliency=min_saliency,
+            keep_per_type=keep_per_type,
+            benign_freqs=benign_freqs,
+            freq_threshold=freq_thresh,
+        )
+
+        if saliency_stats is None:
+            features = miner.mine(graph, saliency)
+        else:
+            features = miner.mine(graph, saliency, saliency_stats)
+
+        group_pct = group_percentage
+        if condition_type == "combo" and group_cnt is not None:
+            group_pct = None
+
+        if sample_json is not None and sample_json.is_file():
+            filtered = [
+                f
+                for f in features
+                if verify_features(
+                    sample_json,
+                    [f],
+                    condition_type=condition_type,
+                    group_percentage=group_pct,
+                    group_min_count=group_cnt,
+                    adjust_group_percentage=adjust_group_percentage,
+                    saliency_stats=saliency_stats,
+                )
+            ]
+            if not filtered and features:
+                filtered = [features[0]]
+            features = filtered
+
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug("Mined %d features", len(features))
+
+        LOGGER.debug("Building YARA rule with %d features", len(features))
+
+        csize = chunk_size
+        if csize is None or csize <= 0:
+            csize = max(1, math.ceil(len(features) / max(1, num_rules)))
+
+        groups: list[list[str]] = []
+        start = 0
+        for _ in range(max(1, num_rules)):
+            if start >= len(features):
+                break
+            groups.append(features[start : start + csize])
+            start += csize
+
+        rule_texts: list[str] = []
+        detections: list[bool] = []
+        coverages: list[float] = []
+        false_positives: list[bool] = []
+
+        def _eval_group(feats: list[str]) -> tuple[bool, float, bool, str, list[str] | None]:
+            builder = YaraBuilder(
+                condition_type=condition_type,
+                percentage=percentage,
+                min_count=min_count,
+                group_percentage=group_pct,
+                group_min_count=group_cnt,
+                adjust_group_percentage=adjust_group_percentage,
+            )
+            rule_text, id_map = builder.build(feats, return_map=True)
+            builder.validate(rule_text)
+
+            fp_tokens: list[str] | None = None
+
+            if json_match:
+                jpath = (
+                    sample_json if sample_json is not None else sample_path.with_suffix(".json")
+                )
+                if not jpath.is_file():
+                    LOGGER.warning("json_match enabled but JSON %s not found", jpath)
+                    detected = False
+                else:
+                    detected = verify_features(
+                        jpath,
+                        feats,
+                        condition_type=condition_type,
+                        group_percentage=group_pct,
+                        group_min_count=group_cnt,
+                        adjust_group_percentage=adjust_group_percentage,
+                        saliency_stats=saliency_stats,
+                    )
+                coverage = 0.0
+                LOGGER.debug("Skipping YARA match; using JSON verification only")
+                compiled = None
+            else:
+                import yara
+
+                compiled = yara.compile(source=rule_text)
+                matches = compiled.match(str(sample_path))
+                detected = bool(matches)
+
+                coverage = 0.0
+                if detected:
+                    total = sum(len(s[2]) for s in matches[0].strings)
+                    try:
+                        size = sample_path.stat().st_size
+                        coverage = float(total) / float(size) if size > 0 else 0.0
+                    except Exception:
+                        coverage = 0.0
+
+                    matched_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
+                    LOGGER.debug("Matched tokens: %s", matched_tokens)
+
+            fp = False
+            if json_match:
+
+                def _check_json(p: Path) -> bool:
+                    j = p.with_suffix(".json")
+                    return j.is_file() and verify_features(
+                        j,
+                        feats,
+                        condition_type=condition_type,
+                        group_percentage=group_pct,
+                        group_min_count=group_cnt,
+                        adjust_group_percentage=adjust_group_percentage,
+                        saliency_stats=saliency_stats,
+                    )
+
+                if clean_dir is not None and clean_dir.is_dir():
+                    fp = any(_check_json(p) for p in clean_dir.iterdir() if p.is_file())
+                elif clean_sample is not None:
+                    fp = _check_json(clean_sample)
+                elif clean_paths is not None:
+                    fp = any(_check_json(p) for p in clean_paths)
+                elif (
+                    clean_dir is not None
+                    or clean_sample is not None
+                    or clean_paths is not None
+                ):
+                    fp = False
+            else:
+                if clean_dir is not None and clean_dir.is_dir() and compiled is not None:
+                    for fp_path in clean_dir.iterdir():
+                        if not fp_path.is_file():
+                            continue
+                        try:
+                            matches = compiled.match(str(fp_path))
+                            if matches:
+                                fp = True
+                                fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
+                                break
+                        except Exception:
+                            continue
+                elif clean_sample is not None and compiled is not None:
+                    try:
+                        matches = compiled.match(str(clean_sample))
+                        fp = bool(matches)
+                        if fp:
+                            fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
+                    except Exception:
+                        fp = False
+                elif clean_paths is not None and compiled is not None:
+                    for p in clean_paths:
+                        try:
+                            matches = compiled.match(str(p))
+                            if matches:
+                                fp = True
+                                fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
+                                break
+                        except Exception:
+                            continue
+                elif (
+                    clean_dir is not None
+                    or clean_sample is not None
+                    or clean_paths is not None
+                ):
+                    fp = False
+
+            return detected, coverage, fp, rule_text, fp_tokens
+
+        fp_tokens_all: list[list[str] | None] = []
+        for grp in groups:
+            det, cov, fp, rt, fp_tok = _eval_group(grp)
+            detections.append(det)
+            coverages.append(cov)
+            false_positives.append(fp)
+            rule_texts.append(rt)
+            fp_tokens_all.append(fp_tok)
+
+        if isinstance(saliency, dict):
+            flat = torch.cat(list(saliency.values()))
+        else:
+            flat = saliency
+
+        first_feats = groups[0] if groups else []
+        num_selected = min(len(first_feats), flat.numel())
+        avg_importance = (
+            float(flat.topk(num_selected).values.mean().item()) if num_selected > 0 else 0.0
+        )
+        mask_sparsity = float(1.0 - num_selected / flat.numel()) if flat.numel() > 0 else 0.0
+
+        if combine_mode == "or":
+            required = max(1, math.ceil(len(detections) * comb_ratio))
+            combined_det = sum(detections) >= required
+            combined_fp = sum(false_positives) >= required
+        else:
+            combined_det = all(detections)
+            combined_fp = all(false_positives)
+
+        max_cov = 0.0
+        for det, cov in zip(detections, coverages):
+            if det and cov > max_cov:
+                max_cov = cov
+
+        matched_tokens_fp: list[str] = []
+        for toks in fp_tokens_all:
+            if toks:
+                matched_tokens_fp = toks
+                break
+
+        result: Dict[str, Any] = {
+            "detected": combined_det,
+            "rule_length": len(first_feats),
+            "avg_importance": avg_importance,
+            "mask_sparsity": mask_sparsity,
+            "coverage": max_cov,
+            "rule_text": rule_texts[0] if rule_texts else "",
+            "false_positive": combined_fp,
+            "group_min_count": group_cnt,
+            "freq_threshold": freq_thresh,
+        }
+        result["rule_texts"] = rule_texts
+        result["false_positives"] = false_positives
+        if matched_tokens_fp:
+            result["matched_tokens"] = matched_tokens_fp
+
+        if sample_json is not None and sample_json.is_file() and first_feats:
+            result["feature_verified"] = verify_features(
                 sample_json,
-                [f],
+                first_feats,
                 condition_type=condition_type,
                 group_percentage=group_pct,
-                group_min_count=group_min_count,
+                group_min_count=group_cnt,
                 adjust_group_percentage=adjust_group_percentage,
                 saliency_stats=saliency_stats,
             )
-        ]
-        if not filtered and features:
-            filtered = [features[0]]
-        features = filtered
-    if LOGGER.isEnabledFor(logging.DEBUG):
-        LOGGER.debug("Mined %d features", len(features))
 
-    LOGGER.debug("Building YARA rule with %d features", len(features))
-
-    if chunk_size is None or chunk_size <= 0:
-        chunk_size = max(1, math.ceil(len(features) / max(1, num_rules)))
-
-    groups: list[list[str]] = []
-    start = 0
-    for _ in range(max(1, num_rules)):
-        if start >= len(features):
-            break
-        groups.append(features[start : start + chunk_size])
-        start += chunk_size
-
-    rule_texts: list[str] = []
-    detections: list[bool] = []
-    coverages: list[float] = []
-    false_positives: list[bool] = []
-
-    def _eval_group(feats: list[str]) -> tuple[bool, float, bool, str, list[str] | None]:
-        builder = YaraBuilder(
-            condition_type=condition_type,
-            percentage=percentage,
-            min_count=min_count,
-            group_percentage=group_pct,
-            group_min_count=group_min_count,
-            adjust_group_percentage=adjust_group_percentage,
+        LOGGER.info(
+            "detected=%s rule_len=%d avg_importance=%.4f mask_sparsity=%.4f coverage=%.4f false_positive=%s",
+            combined_det,
+            len(first_feats),
+            avg_importance,
+            mask_sparsity,
+            max_cov,
+            combined_fp,
         )
-        rule_text, id_map = builder.build(feats, return_map=True)
-        builder.validate(rule_text)
 
-        fp_tokens: list[str] | None = None
+        return result
 
-        if json_match:
-            jpath = (
-                sample_json
-                if sample_json is not None
-                else sample_path.with_suffix(".json")
-            )
-            if not jpath.is_file():
-                LOGGER.warning("json_match enabled but JSON %s not found", jpath)
-                detected = False
+    result = _build_and_eval(freq_threshold, group_min_count, combine_min_ratio)
+
+    if result.get("false_positive") and fp_retries > 0:
+        retries = fp_retries
+        freq_thresh = 1
+        group_cnt = group_min_count
+        comb_ratio = combine_min_ratio
+        while retries > 0 and result.get("false_positive"):
+            retries -= 1
+            if group_min_count is not None:
+                group_cnt = (group_cnt or 0) + 1
             else:
-                detected = verify_features(
-                    jpath,
-                    feats,
-                    condition_type=condition_type,
-                    group_percentage=group_pct,
-                    group_min_count=group_min_count,
-                    adjust_group_percentage=adjust_group_percentage,
-                    saliency_stats=saliency_stats,
-                )
-            coverage = 0.0
-            LOGGER.debug("Skipping YARA match; using JSON verification only")
-            compiled = None
-        else:
-            import yara
-
-            compiled = yara.compile(source=rule_text)
-            matches = compiled.match(str(sample_path))
-            detected = bool(matches)
-
-            coverage = 0.0
-            if detected:
-                total = sum(len(s[2]) for s in matches[0].strings)
-                try:
-                    size = sample_path.stat().st_size
-                    coverage = float(total) / float(size) if size > 0 else 0.0
-                except Exception:
-                    coverage = 0.0
-
-                matched_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
-                LOGGER.debug("Matched tokens: %s", matched_tokens)
-
-        fp = False
-        if json_match:
-
-            def _check_json(p: Path) -> bool:
-                j = p.with_suffix(".json")
-                return j.is_file() and verify_features(
-                    j,
-                    feats,
-                    condition_type=condition_type,
-                    group_percentage=group_pct,
-                    group_min_count=group_min_count,
-                    adjust_group_percentage=adjust_group_percentage,
-                    saliency_stats=saliency_stats,
-                )
-
-            if clean_dir is not None and clean_dir.is_dir():
-                fp = any(_check_json(p) for p in clean_dir.iterdir() if p.is_file())
-            elif clean_sample is not None:
-                fp = _check_json(clean_sample)
-            elif clean_paths is not None:
-                fp = any(_check_json(p) for p in clean_paths)
-            elif (
-                clean_dir is not None
-                or clean_sample is not None
-                or clean_paths is not None
-            ):
-                fp = False
-        else:
-            if clean_dir is not None and clean_dir.is_dir() and compiled is not None:
-                for fp_path in clean_dir.iterdir():
-                    if not fp_path.is_file():
-                        continue
-                    try:
-                        matches = compiled.match(str(fp_path))
-                        if matches:
-                            fp = True
-                            fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
-                            break
-                    except Exception:
-                        continue
-            elif clean_sample is not None and compiled is not None:
-                try:
-                    matches = compiled.match(str(clean_sample))
-                    fp = bool(matches)
-                    if fp:
-                        fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
-                except Exception:
-                    fp = False
-            elif clean_paths is not None and compiled is not None:
-                for p in clean_paths:
-                    try:
-                        matches = compiled.match(str(p))
-                        if matches:
-                            fp = True
-                            fp_tokens = [id_map.get(s[1], s[1]) for s in matches[0].strings]
-                            break
-                    except Exception:
-                        continue
-            elif (
-                clean_dir is not None
-                or clean_sample is not None
-                or clean_paths is not None
-            ):
-                fp = False
-
-        return detected, coverage, fp, rule_text, fp_tokens
-
-    fp_tokens_all: list[list[str] | None] = []
-    for grp in groups:
-        det, cov, fp, rt, fp_tok = _eval_group(grp)
-        detections.append(det)
-        coverages.append(cov)
-        false_positives.append(fp)
-        rule_texts.append(rt)
-        fp_tokens_all.append(fp_tok)
-
-    if isinstance(saliency, dict):
-        flat = torch.cat(list(saliency.values()))
-    else:
-        flat = saliency
-    first_feats = groups[0] if groups else []
-    num_selected = min(len(first_feats), flat.numel())
-    avg_importance = (
-        float(flat.topk(num_selected).values.mean().item()) if num_selected > 0 else 0.0
-    )
-    mask_sparsity = (
-        float(1.0 - num_selected / flat.numel()) if flat.numel() > 0 else 0.0
-    )
-
-    combined_det = any(detections) if combine_mode == "or" else all(detections)
-    max_cov = 0.0
-    for det, cov in zip(detections, coverages):
-        if det and cov > max_cov:
-            max_cov = cov
-    combined_fp = (
-        any(false_positives) if combine_mode == "or" else all(false_positives)
-    )
-
-    matched_tokens_fp: list[str] = []
-    for toks in fp_tokens_all:
-        if toks:
-            matched_tokens_fp = toks
-            break
-
-    result: Dict[str, Any] = {
-        "detected": combined_det,
-        "rule_length": len(first_feats),
-        "avg_importance": avg_importance,
-        "mask_sparsity": mask_sparsity,
-        "coverage": max_cov,
-        "rule_text": rule_texts[0] if rule_texts else "",
-        "false_positive": combined_fp,
-        "group_min_count": group_min_count,
-        "freq_threshold": freq_threshold,
-    }
-    result["rule_texts"] = rule_texts
-    result["false_positives"] = false_positives
-    if matched_tokens_fp:
-        result["matched_tokens"] = matched_tokens_fp
-
-    if sample_json is not None and sample_json.is_file() and first_feats:
-        result["feature_verified"] = verify_features(
-            sample_json,
-            first_feats,
-            condition_type=condition_type,
-            group_percentage=group_pct,
-            group_min_count=group_min_count,
-            adjust_group_percentage=adjust_group_percentage,
-            saliency_stats=saliency_stats,
-        )
-
-    LOGGER.info(
-        "detected=%s rule_len=%d avg_importance=%.4f mask_sparsity=%.4f coverage=%.4f false_positive=%s",
-        combined_det,
-        len(first_feats),
-        avg_importance,
-        mask_sparsity,
-        max_cov,
-        combined_fp,
-    )
+                comb_ratio = min(1.0, comb_ratio + 0.1)
+            result = _build_and_eval(freq_thresh, group_cnt, comb_ratio)
+            if not result.get("false_positive"):
+                break
 
     return result
+
 
 
 # ---------------------------------------------------------------------------
@@ -677,6 +706,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=float,
         default=0.5,
         help="When combining rules in OR mode, require this fraction to match",
+    )
+    p.add_argument(
+        "--fp-retries",
+        type=int,
+        default=0,
+        help="Retry rule generation this many times if false positives occur",
     )
     p.add_argument(
         "--clean-sample", type=Path, help="Optional clean sample for FP check"
@@ -796,6 +831,8 @@ def main(argv: list[str] | None = None) -> None:
                     sample_json=jpath,
                     json_match=args.json_match,
                     saliency_stats=saliency_stats,
+                    combine_min_ratio=args.combine_min_ratio,
+                    fp_retries=args.fp_retries,
                 )
             except FileNotFoundError as exc:
                 skipped += 1
@@ -905,6 +942,8 @@ def main(argv: list[str] | None = None) -> None:
             json_match=args.json_match,
             saliency_stats=saliency_stats,
             combine_mode=combine_mode,
+            combine_min_ratio=args.combine_min_ratio,
+            fp_retries=args.fp_retries,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -11,6 +11,22 @@ import torch
 from torch_geometric.data import HeteroData
 
 
+def test_build_parser_fp_retries():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args([
+        "--graph",
+        "g.pt",
+        "--sample",
+        "s.bin",
+        "--classifier",
+        "c.pt",
+        "--fp-retries",
+        "2",
+    ])
+    assert args.fp_retries == 2
+
+
 def test_cli_runs_and_writes_json(tmp_path, caplog):
     g = HeteroData()
     g["bb"].x = torch.zeros(2, 1)


### PR DESCRIPTION
## Summary
- support adjusting rules to reduce false positives via `fp_retries`
- refactor rule generation into `_build_and_eval`
- expose new CLI option `--fp-retries`
- test argument parsing for the new option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_fp_retries -q` *(fails: found no collectors due to missing torch)*

------
https://chatgpt.com/codex/tasks/task_e_6883a9810d2c832ebfec470847318542