### PR TITLE
Improve rule evaluation logging

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -566,14 +566,18 @@ def evaluate_single(
             )
 
         LOGGER.info(
-            "detected=%s rule_len=%d avg_importance=%.4f mask_sparsity=%.4f coverage=%.4f false_positive=%s",
+            "detected=%s rule_len=%d avg_importance=%.4f mask_sparsity=%.4f coverage=%.4f false_positive=%s group_min_count=%s freq_threshold=%s",
             combined_det,
             len(first_feats),
             avg_importance,
             mask_sparsity,
             max_cov,
             combined_fp,
+            group_cnt,
+            freq_thresh,
         )
+        if matched_tokens_fp:
+            LOGGER.info("matched_tokens: %s", matched_tokens_fp)
 
         return result
 
@@ -847,7 +851,11 @@ def main(argv: list[str] | None = None) -> None:
             row_iter.set_postfix(avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}")
 
             if args.out_csv:
-                pd.DataFrame(results).to_csv(args.out_csv, index=False)
+                df = pd.DataFrame(results)
+                for col in ("matched_tokens", "group_min_count", "freq_threshold"):
+                    if col not in df.columns:
+                        df[col] = None
+                df.to_csv(args.out_csv, index=False)
 
             if args.sample_rules_out and res.get("detected"):
                 # 탐지된 경우 규칙을 바로 저장하여 누락을 방지합니다.
@@ -872,7 +880,11 @@ def main(argv: list[str] | None = None) -> None:
                     )
 
         if args.out_csv:
-            pd.DataFrame(results).to_csv(args.out_csv, index=False)
+            df = pd.DataFrame(results)
+            for col in ("matched_tokens", "group_min_count", "freq_threshold"):
+                if col not in df.columns:
+                    df[col] = None
+            df.to_csv(args.out_csv, index=False)
 
         LOGGER.info("Skipped %d graphs due to missing files", skipped)
 

--- a/src/rulegen/rl_env.py
+++ b/src/rulegen/rl_env.py
@@ -1021,9 +1021,10 @@ class RuleGenEnv(gym.Env):
                 + (self.fp_penalty_end - self.fp_penalty_start) * progress
             )
 
-        _, FP, _, _ = counts
+        TP, FP, FN, TN = counts
         n = len(clean_set)
         fp_rate = 0.0 if n == 0 else FP / n
+        false_positive = FP > 0
 
         w = self.reward_weights
         weighted_f1 = w["f1_clean"] * f1_clean + w["f1_dummy"] * f1_dummy
@@ -1091,6 +1092,8 @@ class RuleGenEnv(gym.Env):
             off_target_matches=off_matches,
             off_target_penalty=off_target_pen,
             off_target_penalty_factor=curr_off_penalty,
+            counts=counts,
+            false_positive=false_positive,
             no_tp=no_tp,
             no_tp_penalty=self.no_tp_penalty if no_tp else 0.0,
             reward=reward,


### PR DESCRIPTION
## Summary
- add more info logs for `evaluate_single`
- ensure batch CSV includes matched_tokens, group_min_count and freq_threshold
- record false positive details in `rule_eval_history`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6883b03fbf08832e9b9b03d69d389519