### PR TITLE
Add matched token reporting in rule eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -378,7 +378,9 @@ def evaluate_single(
         coverages: list[float] = []
         false_positives: list[bool] = []
 
-        def _eval_group(feats: list[str]) -> tuple[bool, float, bool, str, list[str] | None]:
+        def _eval_group(
+            feats: list[str],
+        ) -> tuple[bool, float, bool, str, list[str] | None, list[str] | None]:
             builder = YaraBuilder(
                 condition_type=condition_type,
                 percentage=percentage,
@@ -391,6 +393,7 @@ def evaluate_single(
             builder.validate(rule_text)
 
             fp_tokens: list[str] | None = None
+            matched_tokens: list[str] | None = None
 
             if json_match:
                 jpath = (
@@ -400,7 +403,7 @@ def evaluate_single(
                     LOGGER.warning("json_match enabled but JSON %s not found", jpath)
                     detected = False
                 else:
-                    detected = verify_features(
+                    detected, matched = verify_features(
                         jpath,
                         feats,
                         condition_type=condition_type,
@@ -408,7 +411,9 @@ def evaluate_single(
                         group_min_count=group_cnt,
                         adjust_group_percentage=adjust_group_percentage,
                         saliency_stats=saliency_stats,
+                        return_matched=True,
                     )
+                    matched_tokens = matched
                 coverage = 0.0
                 LOGGER.debug("Skipping YARA match; using JSON verification only")
                 compiled = None
@@ -434,9 +439,11 @@ def evaluate_single(
             fp = False
             if json_match:
 
-                def _check_json(p: Path) -> bool:
+                def _check_json(p: Path) -> list[str] | None:
                     j = p.with_suffix(".json")
-                    return j.is_file() and verify_features(
+                    if not j.is_file():
+                        return None
+                    ok, mt = verify_features(
                         j,
                         feats,
                         condition_type=condition_type,
@@ -444,14 +451,31 @@ def evaluate_single(
                         group_min_count=group_cnt,
                         adjust_group_percentage=adjust_group_percentage,
                         saliency_stats=saliency_stats,
+                        return_matched=True,
                     )
+                    return mt if ok else None
 
                 if clean_dir is not None and clean_dir.is_dir():
-                    fp = any(_check_json(p) for p in clean_dir.iterdir() if p.is_file())
+                    for p in clean_dir.iterdir():
+                        if not p.is_file():
+                            continue
+                        toks = _check_json(p)
+                        if toks is not None:
+                            fp = True
+                            fp_tokens = toks
+                            break
                 elif clean_sample is not None:
-                    fp = _check_json(clean_sample)
+                    toks = _check_json(clean_sample)
+                    fp = toks is not None
+                    if fp:
+                        fp_tokens = toks
                 elif clean_paths is not None:
-                    fp = any(_check_json(p) for p in clean_paths)
+                    for p in clean_paths:
+                        toks = _check_json(p)
+                        if toks is not None:
+                            fp = True
+                            fp_tokens = toks
+                            break
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
@@ -496,16 +520,18 @@ def evaluate_single(
                 ):
                     fp = False
 
-            return detected, coverage, fp, rule_text, fp_tokens
+            return detected, coverage, fp, rule_text, fp_tokens, matched_tokens
 
         fp_tokens_all: list[list[str] | None] = []
+        matched_tokens_all: list[list[str] | None] = []
         for grp in groups:
-            det, cov, fp, rt, fp_tok = _eval_group(grp)
+            det, cov, fp, rt, fp_tok, match_tok = _eval_group(grp)
             detections.append(det)
             coverages.append(cov)
             false_positives.append(fp)
             rule_texts.append(rt)
             fp_tokens_all.append(fp_tok)
+            matched_tokens_all.append(match_tok)
 
         if isinstance(saliency, dict):
             flat = torch.cat(list(saliency.values()))
@@ -538,6 +564,11 @@ def evaluate_single(
                 matched_tokens_fp = toks
                 break
 
+        matched_tokens_all_flat: list[str] = []
+        for toks in matched_tokens_all:
+            if toks:
+                matched_tokens_all_flat.extend(toks)
+
         result: Dict[str, Any] = {
             "detected": combined_det,
             "rule_length": len(first_feats),
@@ -551,8 +582,10 @@ def evaluate_single(
         }
         result["rule_texts"] = rule_texts
         result["false_positives"] = false_positives
+        if matched_tokens_all_flat:
+            result["matched_tokens"] = matched_tokens_all_flat
         if matched_tokens_fp:
-            result["matched_tokens"] = matched_tokens_fp
+            result["fp_matched_tokens"] = matched_tokens_fp
 
         if sample_json is not None and sample_json.is_file() and first_feats:
             result["feature_verified"] = verify_features(
@@ -576,8 +609,10 @@ def evaluate_single(
             group_cnt,
             freq_thresh,
         )
+        if matched_tokens_all_flat:
+            LOGGER.info("matched_tokens: %s", matched_tokens_all_flat)
         if matched_tokens_fp:
-            LOGGER.info("matched_tokens: %s", matched_tokens_fp)
+            LOGGER.info("fp_matched_tokens: %s", matched_tokens_fp)
 
         return result
 
@@ -852,7 +887,7 @@ def main(argv: list[str] | None = None) -> None:
 
             if args.out_csv:
                 df = pd.DataFrame(results)
-                for col in ("matched_tokens", "group_min_count", "freq_threshold"):
+                for col in ("matched_tokens", "fp_matched_tokens", "group_min_count", "freq_threshold"):
                     if col not in df.columns:
                         df[col] = None
                 df.to_csv(args.out_csv, index=False)
@@ -881,7 +916,7 @@ def main(argv: list[str] | None = None) -> None:
 
         if args.out_csv:
             df = pd.DataFrame(results)
-            for col in ("matched_tokens", "group_min_count", "freq_threshold"):
+            for col in ("matched_tokens", "fp_matched_tokens", "group_min_count", "freq_threshold"):
                 if col not in df.columns:
                     df[col] = None
             df.to_csv(args.out_csv, index=False)


### PR DESCRIPTION
## Summary
- capture matched token list in `_eval_group`
- collect tokens from all groups and store under `matched_tokens`
- keep false positive tokens in `fp_matched_tokens`
- ensure new fields are written to CSV

## Testing
- `pytest -k explainer_rule_eval -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883b7e0dac8832eac45100b47d2d97f