### PR TITLE
Update combo condition logic in YaraBuilder

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -263,8 +263,37 @@ class YaraBuilder:
         else:  # combo
             group_count = sum(1 for v in groups.values() if v)
             feat_count = n_feats
-            if group_count <= 1 or feat_count <= 2:
-                cond_line = "    any of them"
+            if feat_count <= 2:
+                if group_count == 1:
+                    # Require all available features when only a single group exists
+                    cond_line = "    all of them"
+                else:
+                    parts = []
+                    for tag, feats_list in groups.items():
+                        if not feats_list:
+                            continue
+                        if tag == "m":
+                            parts.append(f"{len(feats_list)} of ($m*)")
+                        else:
+                            parts.append(f"1 of (${tag}*)")
+                    cond_line = "    " + " and ".join(parts)
+            elif group_count <= 1:
+                # Single feature group but more than two features: require all
+                tag = next(t for t, v in groups.items() if v)
+                feats_list = groups[tag]
+                if tag == "m":
+                    cond_line = f"    {len(feats_list)} of ($m*)"
+                elif self.group_min_count is not None:
+                    required = min(self.group_min_count, len(feats_list))
+                    cond_line = f"    {required} of (${tag}*)"
+                elif self.group_percentage is not None:
+                    pct = self.group_percentage
+                    if self.adjust_group_percentage:
+                        pct = self._scaled_group_percentage(len(feats_list))
+                    n = max(1, math.ceil(len(feats_list) * pct / 100.0))
+                    cond_line = f"    {n} of (${tag}*)"
+                else:
+                    cond_line = "    all of them"
             else:
                 parts = []
                 for tag, feats_list in groups.items():

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -4,7 +4,8 @@ from src.rulegen.yara_builder import YaraBuilder
 def test_combo_basic():
     builder = YaraBuilder(condition_type="combo")
     rule = builder.build(["call:CreateFileW", "import:WS2_32.dll"])
-    assert "any of them" in rule
+    assert "1 of ($c*)" in rule
+    assert "1 of ($i*)" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 
@@ -29,7 +30,7 @@ def test_combo_group_min_count_caps_at_len():
 def test_combo_group_min_count_falls_back_any():
     builder = YaraBuilder(condition_type="combo", group_min_count=2)
     rule = builder.build(["call:A", "call:B", "call:C"])
-    assert "any of them" in rule
+    assert "2 of ($c*)" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 
@@ -37,7 +38,7 @@ def test_combo_group_min_count_falls_back_any():
 def test_combo_percentage_falls_back_any():
     builder = YaraBuilder(condition_type="combo", group_percentage=50)
     rule = builder.build(["call:A", "call:B"])
-    assert "any of them" in rule
+    assert "all of them" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 


### PR DESCRIPTION
## Summary
- handle small feature counts in `YaraBuilder` combo condition without falling back to `any of them`
- update combo tests for new behaviour

## Testing
- `pytest -q tests/test_yara_builder_combo.py`
- `pytest -q` *(fails: missing many optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_6883ba73d7f4832eb035e819aed87d5f