### PR TITLE
Add feature exclude tokens to rule eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -287,6 +287,7 @@ def evaluate_single(
     combine_mode: str = "or",
     combine_min_ratio: float = 0.5,
     fp_retries: int = 0,
+    exclude_tokens: Sequence[str] | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -317,7 +318,13 @@ def evaluate_single(
             graph, classifier, explainer, device
         )
 
-    def _build_and_eval(freq_thresh: float | int, group_cnt: int | None, comb_ratio: float) -> Dict[str, Any]:
+    def _build_and_eval(
+        freq_thresh: float | int,
+        group_cnt: int | None,
+        comb_ratio: float,
+        *,
+        exclude: Sequence[str] | None = None,
+    ) -> Dict[str, Any]:
         miner = FeatureMiner(
             top_k=top_k,
             top_k_percent=top_k_percent,
@@ -333,6 +340,17 @@ def evaluate_single(
             features = miner.mine(graph, saliency)
         else:
             features = miner.mine(graph, saliency, saliency_stats)
+
+        if exclude:
+            excl = {t.lower() for t in exclude}
+            before = len(features)
+            features = [
+                f
+                for f in features
+                if not any(tok.lower() in excl for tok in _extract_tokens(f))
+            ]
+            if LOGGER.isEnabledFor(logging.DEBUG) and before != len(features):
+                LOGGER.debug("Excluded %d features by token", before - len(features))
 
         group_pct = group_percentage
         if condition_type == "combo" and group_cnt is not None:
@@ -616,7 +634,14 @@ def evaluate_single(
 
         return result
 
-    result = _build_and_eval(freq_threshold, group_min_count, combine_min_ratio)
+    exclude_set: set[str] = set(t.lower() for t in (exclude_tokens or []))
+
+    result = _build_and_eval(
+        freq_threshold,
+        group_min_count,
+        combine_min_ratio,
+        exclude=exclude_set,
+    )
 
     if result.get("false_positive") and fp_retries > 0:
         retries = fp_retries
@@ -625,11 +650,17 @@ def evaluate_single(
         comb_ratio = combine_min_ratio
         while retries > 0 and result.get("false_positive"):
             retries -= 1
+            exclude_set.update(t.lower() for t in result.get("matched_tokens", []))
             if group_min_count is not None:
                 group_cnt = (group_cnt or 0) + 1
             else:
                 comb_ratio = min(1.0, comb_ratio + 0.1)
-            result = _build_and_eval(freq_thresh, group_cnt, comb_ratio)
+            result = _build_and_eval(
+                freq_thresh,
+                group_cnt,
+                comb_ratio,
+                exclude=exclude_set,
+            )
             if not result.get("false_positive"):
                 break
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -913,3 +913,83 @@ def test_verify_features_return_matched(tmp_path):
     assert result is True
     assert matched == ["call:foo"]
 
+
+def test_fp_retry_exclude_tokens(tmp_path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self, ident="$s0"):
+            self.strings = [(0, ident, b"x")]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            if "foo" in self.text:
+                return [FakeMatch()]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=None,
+        json_match=False,
+        combine_mode="or",
+        fp_retries=1,
+    )
+
+    assert res["false_positive"] is False
+    assert res["rule_length"] == 0
+


### PR DESCRIPTION
## Summary
- allow excluding tokens when building rules in `evaluate_single`
- retry FP detection while removing matched tokens
- test token exclusion behavior in FP retry loop

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k fp_retry_exclude_tokens -vv` *(fails: collected 0 items / 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6883bc29ad00832eb2fce2b45e854528