### PR TITLE
Fix CLI imports for single sample script

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Sequence
 
 repo_root = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(repo_root))
+# Insert the project "src" directory so the CLI packages can be imported when
+# running this script from outside the repository root.
+sys.path.insert(0, str(repo_root / "src"))
 
 import torch
 from torch_geometric.loader import DataLoader as GeoDataLoader


### PR DESCRIPTION
## Summary
- update `scripts/single_sample_classify.py` to include `src` when adjusting `sys.path`
- clarify comment for why path is inserted

## Testing
- `PYTHONPATH=/tmp/stubs:/workspace/robust-malware-graph python scripts/single_sample_classify.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6883bec0d6ac832e91c7d5e4e4dd2840