### PR TITLE
Update single sample inference script with embedding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,5 +382,6 @@ Epoch 1 Val Fidelity: 0.9123  Val Sparsity: 0.0731  Val Stability: 0.0321  Val N
 python scripts/single_sample_classify.py \
     --json path/to/sample.json \
     --model models/gnn/res_gcl.pt \
-    --out result.csv
+    --out result.csv \
+    --work-dir ./tmp_work
 ```

--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -13,9 +13,37 @@ sys.path.insert(0, str(repo_root / "src"))
 
 import torch
 from torch_geometric.loader import DataLoader as GeoDataLoader
+from torch_geometric.data import InMemoryDataset, HeteroData
+
+from src.graphs.features.cache import load_tensor
 
 from cli.preprocessing import run_json, run_graphs, run_embeds
-from cli.detect import GraphFileDataset, collate_graphs, load_model, infer
+from cli.detect import collate_graphs, load_model, infer
+
+
+class SingleGraphDataset(InMemoryDataset):
+    def __init__(self, graph_path: Path, embed_dir: Path | None):
+        self.graph_path = graph_path
+        self.embed_dir = embed_dir
+        super().__init__(None, None, None, None)
+
+    def len(self) -> int:  # type: ignore[override]
+        return 1
+
+    def get(self, idx: int) -> HeteroData:  # type: ignore[override]
+        g = torch.load(self.graph_path, map_location="cpu", weights_only=False)
+        sha = self.graph_path.stem
+        if self.embed_dir:
+            embed_file = self.embed_dir / f"{sha}.ftr"
+            if embed_file.is_file():
+                feat = load_tensor(sha, self.embed_dir, mmap=False)
+                store = g["token"]
+                if hasattr(store, "x") and store.x is not None:
+                    store.x = torch.cat([store.x, feat], dim=-1)
+                else:
+                    store.x = feat
+        g.sha256 = sha
+        return g
 
 
 def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
@@ -60,12 +88,20 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
     return pt_files[0]
 
 
-def classify(graph: Path, ckpt: Path, out_csv: Path, device: str, threshold: float, amp: bool) -> None:
+def classify(
+    graph: Path,
+    ckpt: Path,
+    out_csv: Path,
+    work_dir: Path,
+    device: str,
+    threshold: float,
+    amp: bool,
+) -> None:
     device_t = torch.device(device)
     model = load_model(ckpt, device_t)
     attr = getattr(getattr(model, "encoder", None), "attr_names", None)
 
-    ds = GraphFileDataset([graph])
+    ds = SingleGraphDataset(graph, work_dir / "data" / "embeds")
     loader = GeoDataLoader(
         ds,
         batch_size=1,
@@ -99,7 +135,15 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = p.parse_args(argv)
 
     graph = preprocess(args.json, args.work_dir, args.device)
-    classify(graph, args.model, args.out, args.device, args.threshold, args.amp)
+    classify(
+        graph,
+        args.model,
+        args.out,
+        args.work_dir,
+        args.device,
+        args.threshold,
+        args.amp,
+    )
     print(f"[OK] saved predictions -> {args.out}")
 
 


### PR DESCRIPTION
## Summary
- load `load_tensor` helper for embeddings
- integrate new `SingleGraphDataset` that merges embeddings
- use the dataset in `classify()`
- document example `--work-dir` usage in README

## Testing
- `pytest -k dataset_loads_embeds -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883c4ebb6e8832e8cd5a80342899182