### PR TITLE
Fix single sample preprocessing cleanup

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -49,9 +50,25 @@ class SingleGraphDataset(InMemoryDataset):
 def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
     """Run preprocessing stages for a single JSON sample."""
     raw_dir = work_dir / "raw"
+    views_dir = work_dir / "data" / "views"
+    hetero_dir = work_dir / "data" / "hetero"
+
+    # Remove leftovers from previous runs
+    for fp in raw_dir.glob("*.json"):
+        fp.unlink()
+    if views_dir.exists():
+        for fp in views_dir.rglob("*.json"):
+            fp.unlink()
+    if hetero_dir.exists():
+        for fp in hetero_dir.glob("*.pt"):
+            fp.unlink()
+
     raw_dir.mkdir(parents=True, exist_ok=True)
     dst = raw_dir / json_path.name
     shutil.copy2(json_path, dst)
+
+    with dst.open("r", encoding="utf-8") as f:
+        sha = json.load(f).get("get_metadata", {}).get("sha256", dst.stem)
 
     common = dict(
         input_dir=str(raw_dir),
@@ -82,10 +99,10 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
     )
 
     hetero_dir = work_dir / "data" / "hetero"
-    pt_files = list(hetero_dir.glob("*.pt"))
-    if not pt_files:
-        raise RuntimeError(f"No graph generated in {hetero_dir}")
-    return pt_files[0]
+    graph_path = hetero_dir / f"{sha}.pt"
+    if not graph_path.is_file():
+        raise RuntimeError(f"Expected graph not generated: {graph_path}")
+    return graph_path
 
 
 def classify(


### PR DESCRIPTION
## Summary
- ensure `preprocess()` clears previous intermediate files
- derive graph path from JSON SHA rather than listing directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: torch)*

------
https://chatgpt.com/codex/tasks/task_e_6883ca83e5ac832eb7c25e00899ab540