### PR TITLE
Add exclude tokens option to rule evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,11 @@ python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt \
     --condition-type count --min-count 3
+# exclude specific tokens when generating
+python -m src.cli.explainer_rule_eval \
+    --graph graph.pt --sample sample.bin \
+    --saliency sal.pt --classifier models/gnn/res_gcl.pt \
+    --exclude-tokens foo bar
 ```
 # XAI selector 학습
 # 분류기가 HeteroData 그래프를 입력으로 받아도 동일하게 사용할 수 있습니다.

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -808,6 +808,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Verify features in sample JSON instead of YARA match",
     )
+    p.add_argument(
+        "--exclude-tokens",
+        nargs="*",
+        help="특정 토큰을 제외하고 규칙을 생성",
+    )
     p.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
     return p
 
@@ -903,6 +908,7 @@ def main(argv: list[str] | None = None) -> None:
                     saliency_stats=saliency_stats,
                     combine_min_ratio=args.combine_min_ratio,
                     fp_retries=args.fp_retries,
+                    exclude_tokens=args.exclude_tokens,
                 )
             except FileNotFoundError as exc:
                 skipped += 1
@@ -1022,6 +1028,7 @@ def main(argv: list[str] | None = None) -> None:
             combine_mode=combine_mode,
             combine_min_ratio=args.combine_min_ratio,
             fp_retries=args.fp_retries,
+            exclude_tokens=args.exclude_tokens,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -27,6 +27,23 @@ def test_build_parser_fp_retries():
     assert args.fp_retries == 2
 
 
+def test_build_parser_exclude_tokens():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args([
+        "--graph",
+        "g.pt",
+        "--sample",
+        "s.bin",
+        "--classifier",
+        "c.pt",
+        "--exclude-tokens",
+        "foo",
+        "bar",
+    ])
+    assert args.exclude_tokens == ["foo", "bar"]
+
+
 def test_cli_runs_and_writes_json(tmp_path, caplog):
     g = HeteroData()
     g["bb"].x = torch.zeros(2, 1)


### PR DESCRIPTION
## Summary
- support `--exclude-tokens` argument in `explainer_rule_eval` CLI
- propagate argument to `evaluate_single`
- document example usage in README
- test parser for new option

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k "test_build_parser_fp_retries or test_build_parser_exclude_tokens" -vv`

------
https://chatgpt.com/codex/tasks/task_e_6883ca700704832e80bd60e65797a3ce