### PR TITLE
Fix single-sample classification preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,4 +389,5 @@ python scripts/single_sample_classify.py \
     --model models/gnn/res_gcl.pt \
     --out result.csv \
     --work-dir ./tmp_work
+# JSON의 sha256 값을 읽어 <tmp_work>/data/hetero/<sha>.pt 그래프가 준비됩니다.
 ```

--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -89,12 +89,13 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
             **common,
         )
     )
+    embed_args = {k: v for k, v in common.items() if k != "input_dir"}
     run_embeds(
         argparse.Namespace(
             model_name="microsoft/codebert-base",
             batch_size=32,
             device=device,
-            **common,
+            **embed_args,
         )
     )
 


### PR DESCRIPTION
## Summary
- ensure `single_sample_classify.py` does not forward `input_dir` to `run_embeds`
- document sha256-derived hetero path in example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883ce410cf4832eae9d8431b7a193be