### PR TITLE
Fix module imports for compute scripts

### DIFF
--- a/scripts/compute_benign_freqs.py
+++ b/scripts/compute_benign_freqs.py
@@ -1,7 +1,10 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 import argparse
 import csv
 import json
-from pathlib import Path
 from collections import Counter
 
 import torch

--- a/scripts/compute_feature_freqs.py
+++ b/scripts/compute_feature_freqs.py
@@ -1,7 +1,10 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 import argparse
 import csv
 import json
-from pathlib import Path
 from collections import Counter
 
 import torch


### PR DESCRIPTION
## Summary
- add repo root to `sys.path` in compute scripts
- ensure `Path` is only imported once
- verify scripts run via `--help`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python scripts/compute_feature_freqs.py --help`
- `python scripts/compute_benign_freqs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6883d40c4844832eb2fb8c2d4d9cee8f