### PR TITLE
Switch compute_feature_freqs output to JSON

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -28,7 +28,7 @@
   python scripts/compute_feature_freqs.py \
       --graph-dir data/graphs \
       --meta-csv data/meta.csv \
-      --out feature_freqs.csv
+      --out feature_freqs.json
   ```
 
 

--- a/scripts/compute_feature_freqs.py
+++ b/scripts/compute_feature_freqs.py
@@ -3,7 +3,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import argparse
-import csv
 import json
 from collections import Counter
 
@@ -29,7 +28,7 @@ def main(argv: list[str] | None = None) -> None:
     p = argparse.ArgumentParser(description="Compute feature frequency statistics")
     p.add_argument("--graph-dir", type=Path, required=True, help="Directory containing graphs")
     p.add_argument("--meta-csv", type=Path, help="CSV with filename,sha256,label")
-    p.add_argument("--out", type=Path, required=True, help="Output CSV path")
+    p.add_argument("--out", type=Path, required=True, help="Output JSON path")
     args = p.parse_args(argv)
 
     miner = FeatureMiner(top_k_percent=1.0, min_saliency=0.0)
@@ -79,11 +78,7 @@ def main(argv: list[str] | None = None) -> None:
         counts.update(feats)
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
-    with args.out.open("w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["feature", "count"])
-        for feat, c in counts.most_common():
-            writer.writerow([feat, c])
+    args.out.write_text(json.dumps(dict(counts), indent=2), encoding="utf-8")
     print(f"[OK] saved -> {args.out}")
 
 


### PR DESCRIPTION
## Summary
- export feature frequency data in JSON rather than CSV
- update documentation with new file name

## Testing
- `pytest -k compute_feature_freqs -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883d844b5ec832ebc573c50f6d2e941