### PR TITLE
Fix script missing import

### DIFF
--- a/scripts/compute_feature_freqs.py
+++ b/scripts/compute_feature_freqs.py
@@ -5,6 +5,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import argparse
 import json
 from collections import Counter
+import csv
 
 import torch
 from torch_geometric.data import Data, HeteroData


### PR DESCRIPTION
## Summary
- import csv in compute_feature_freqs

## Testing
- `python scripts/compute_feature_freqs.py -h` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883dc5c6678832e950767b4c1615bbb