### PR TITLE
Change logging of matched_tokens in explainer_rule_eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -628,9 +628,9 @@ def evaluate_single(
             freq_thresh,
         )
         if matched_tokens_all_flat:
-            LOGGER.info("matched_tokens: %s", matched_tokens_all_flat)
+            LOGGER.debug("matched_tokens: %s", matched_tokens_all_flat)
         if matched_tokens_fp:
-            LOGGER.info("fp_matched_tokens: %s", matched_tokens_fp)
+            LOGGER.debug("fp_matched_tokens: %s", matched_tokens_fp)
 
         return result
 


### PR DESCRIPTION
## Summary
- lower the log level of `matched_tokens` and `fp_matched_tokens` messages in `explainer_rule_eval`

## Testing
- `pytest tests/test_rule_eval_logging.py -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6883ec8dae3c832e811f047801f38197