### PR TITLE
Fix single sample classifier loading

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -18,7 +18,8 @@ from torch_geometric.data import InMemoryDataset, HeteroData
 
 from src.graphs.features.cache import load_tensor
 from src.cli.preprocessing import run_json, run_graphs, run_embeds
-from src.cli.detect import collate_graphs, load_model, infer
+from src.cli.detect import collate_graphs, infer
+from src.models.gnn.res_wrapper import RESGCLClassifier
 
 
 class SingleGraphDataset(InMemoryDataset):
@@ -108,7 +109,6 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
 def classify(
     graph: Path,
     ckpt: Path,
-    meta_path: Path,
     out_csv: Path,
     work_dir: Path,
     device: str,
@@ -116,7 +116,7 @@ def classify(
     amp: bool,
 ) -> None:
     device_t = torch.device(device)
-    model = load_model(ckpt, device_t, meta_path=meta_path)
+    model = RESGCLClassifier.load_from_checkpoint(ckpt, map_location=device_t)
     attr = getattr(getattr(model, "encoder", None), "attr_names", None)
 
     ds = SingleGraphDataset(graph, work_dir / "data" / "embeds")
@@ -154,15 +154,9 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     graph = preprocess(args.json, args.work_dir, args.device)
     
-    meta_path = args.model.with_suffix(".meta.pkl")
-    if not meta_path.is_file():
-        # Fallback for older models/different naming conventions
-        meta_path = args.model.parent / f"{args.model.stem}.meta.pkl"
-
     classify(
         graph,
         args.model,
-        meta_path,
         args.out,
         args.work_dir,
         args.device,


### PR DESCRIPTION
## Summary
- update single sample classification script to use `RESGCLClassifier`
- remove deprecated meta file handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883f1ffc390832ea949e2afc02d7b7a