### PR TITLE
Fix FP retry to use FP tokens

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -650,7 +650,10 @@ def evaluate_single(
         comb_ratio = combine_min_ratio
         while retries > 0 and result.get("false_positive"):
             retries -= 1
-            exclude_set.update(t.lower() for t in result.get("matched_tokens", []))
+            tokens_to_exclude = result.get("fp_matched_tokens", result.get("matched_tokens", []))
+            exclude_set.update(t.lower() for t in tokens_to_exclude)
+            if LOGGER.isEnabledFor(logging.DEBUG) and tokens_to_exclude:
+                LOGGER.debug("Excluding tokens due to FP retry: %s", tokens_to_exclude)
             if group_min_count is not None:
                 group_cnt = (group_cnt or 0) + 1
             else:

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -974,8 +974,12 @@ def test_fp_retry_exclude_tokens(tmp_path, monkeypatch):
             self.text = text
 
         def match(self, path):
-            if "foo" in self.text:
-                return [FakeMatch()]
+            if "foo" not in self.text:
+                return []
+            if str(path) == str(sample):
+                return [FakeMatch("$sample")]  # token not mapped to feature
+            if str(path) == str(clean):
+                return [FakeMatch("$s0")]  # mapped to feature 'foo'
             return []
 
     class FakeYara:


### PR DESCRIPTION
## Summary
- only exclude tokens associated with false-positive matches
- add debug logging for excluded tokens
- update test to verify fp_matched_tokens usage

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k test_fp_retry_exclude_tokens -vv`

------
https://chatgpt.com/codex/tasks/task_e_6883f5fcda28832e970391d799f554bd