### PR TITLE
Fix nullcontext import for detection CLI

### DIFF
--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -36,6 +36,7 @@ import sys
 from pathlib import Path
 from typing import Iterator, Tuple
 from functools import partial
+from contextlib import nullcontext
 
 import torch
 from torch import nn
@@ -233,6 +234,4 @@ def main(argv: list[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    from contextlib import nullcontext
-
     main()


### PR DESCRIPTION
## Summary
- ensure `nullcontext` is imported at module load time for `src.cli.detect`
- remove redundant import inside `__main__`

## Testing
- `pytest -q tests/test_labels.py`
- `python scripts/single_sample_classify.py --help` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6883f5f1461c832ea97625c87d0f7572