### PR TITLE
Handle fp_retries detection rollback

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -648,6 +648,7 @@ def evaluate_single(
         freq_thresh = 1
         group_cnt = group_min_count
         comb_ratio = combine_min_ratio
+        prev_result = result
         while retries > 0 and result.get("false_positive"):
             retries -= 1
             tokens_to_exclude = result.get("fp_matched_tokens", result.get("matched_tokens", []))
@@ -658,6 +659,7 @@ def evaluate_single(
                 group_cnt = (group_cnt or 0) + 1
             else:
                 comb_ratio = min(1.0, comb_ratio + 0.1)
+            prev_result = result
             result = _build_and_eval(
                 freq_thresh,
                 group_cnt,
@@ -665,6 +667,8 @@ def evaluate_single(
                 exclude=exclude_set,
             )
             if not result.get("false_positive"):
+                if not result.get("detected", False) and prev_result.get("detected", False):
+                    result = prev_result
                 break
 
     return result

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1011,6 +1011,7 @@ def test_fp_retry_exclude_tokens(tmp_path, monkeypatch):
         fp_retries=1,
     )
 
-    assert res["false_positive"] is False
-    assert res["rule_length"] == 0
+    assert res["detected"] is True
+    assert res["false_positive"] is True
+    assert res["rule_length"] == 1
 


### PR DESCRIPTION
## Summary
- preserve detection when FP retries result in losing detection
- test that rollback occurs when FP is removed but detection fails

## Testing
- `pytest -k fp_retry_exclude_tokens tests/test_explainer_rule_eval_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f701ce3c832eaa0f23dee36f0daf