### PR TITLE
Fix encoder device mismatch

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -189,6 +189,7 @@ class RGCNEncoder(nn.Module):
                     # 실제 차원이 더 크면 기대 차원에 맞게 자릅니다.
                     final_feat = final_feat[:, :expected_dim]
             
+            final_feat = final_feat.to(proj_layer.weight.device)
             x_dict[nt] = proj_layer(final_feat)
 
         for i, conv in enumerate(self.convs):


### PR DESCRIPTION
## Summary
- handle tensor device mismatch before projecting node features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gensim')*
- `python scripts/single_sample_classify.py --json data/raw/test.json --model models/gnn/res_gcl/res_gcl.pt --out ./temp.csv --work-dir ./tmp_work --device cpu --threshold 0.5` *(fails: No module named 'gensim')*

------
https://chatgpt.com/codex/tasks/task_e_6883fa3a51b8832eb863b15debe8edfe