### PR TITLE
Add retry step options to rule evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt
 
+# retry with gradual threshold adjustments
+python -m src.cli.explainer_rule_eval \
+    --graph graph.pt --sample sample.bin \
+    --saliency sal.pt --classifier models/gnn/res_gcl.pt \
+    --fp-retries 2 --freq-threshold-step 1 --comb-ratio-step 0.2
+
 # require at least two matches per group
 python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -211,6 +211,9 @@ python -m src.cli.explainer_rule_eval \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt
 ```
 
+`--freq-threshold-step`과 `--comb-ratio-step`을 사용하면 재시도 과정에서
+빈도 임계값을 낮추거나 병합 비율을 높여가며 규칙을 조정할 수 있습니다.
+
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로
 낮춰집니다.

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -287,6 +287,8 @@ def evaluate_single(
     combine_mode: str = "or",
     combine_min_ratio: float = 0.5,
     fp_retries: int = 0,
+    freq_threshold_step: float = 0.0,
+    comb_ratio_step: float = 0.1,
     exclude_tokens: Sequence[str] | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
@@ -668,7 +670,7 @@ def evaluate_single(
 
     if result.get("false_positive") and fp_retries > 0:
         retries = fp_retries
-        freq_thresh = 1
+        freq_thresh = freq_threshold
         group_cnt = group_min_count
         comb_ratio = combine_min_ratio
         prev_result = result
@@ -683,7 +685,8 @@ def evaluate_single(
             if group_min_count is not None:
                 group_cnt = (group_cnt or 0) + 1
             else:
-                comb_ratio = min(1.0, comb_ratio + 0.1)
+                comb_ratio = min(1.0, comb_ratio + comb_ratio_step)
+            freq_thresh = max(1, freq_thresh - freq_threshold_step) if freq_threshold_step > 0 else 1
             prev_result = result
             result = _build_and_eval(
                 freq_thresh,
@@ -817,6 +820,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Retry rule generation this many times if false positives occur",
     )
     p.add_argument(
+        "--freq-threshold-step",
+        type=float,
+        default=0.0,
+        help="Decrease freq_threshold by this value on each FP retry",
+    )
+    p.add_argument(
+        "--comb-ratio-step",
+        type=float,
+        default=0.1,
+        help="Increase combine_min_ratio by this value on each FP retry",
+    )
+    p.add_argument(
         "--clean-sample", type=Path, help="Optional clean sample for FP check"
     )
     p.add_argument("--out", type=Path, help="Save JSON result path")
@@ -945,6 +960,8 @@ def main(argv: list[str] | None = None) -> None:
                     saliency_stats=saliency_stats,
                     combine_min_ratio=args.combine_min_ratio,
                     fp_retries=args.fp_retries,
+                    freq_threshold_step=args.freq_threshold_step,
+                    comb_ratio_step=args.comb_ratio_step,
                     exclude_tokens=args.exclude_tokens,
                 )
             except FileNotFoundError as exc:
@@ -1075,6 +1092,8 @@ def main(argv: list[str] | None = None) -> None:
             combine_mode=combine_mode,
             combine_min_ratio=args.combine_min_ratio,
             fp_retries=args.fp_retries,
+            freq_threshold_step=args.freq_threshold_step,
+            comb_ratio_step=args.comb_ratio_step,
             exclude_tokens=args.exclude_tokens,
         )
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -25,9 +25,15 @@ def test_build_parser_fp_retries():
             "c.pt",
             "--fp-retries",
             "2",
+            "--freq-threshold-step",
+            "1",
+            "--comb-ratio-step",
+            "0.2",
         ]
     )
     assert args.fp_retries == 2
+    assert args.freq_threshold_step == 1.0
+    assert args.comb_ratio_step == 0.2
 
 
 def test_build_parser_exclude_tokens():


### PR DESCRIPTION
## Summary
- extend `evaluate_single` with `freq_threshold_step` and `comb_ratio_step`
- expose these options in the CLI parser
- adjust FP retry loop to use the step values
- document new parameters in README and quick start guide
- update parser test for new arguments

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_fp_retries -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fcb90298832eaac4f721a6bd89a8