### PR TITLE
Fix sanitization during inference

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -43,6 +43,13 @@ class SingleGraphDataset(InMemoryDataset):
                     store.x = torch.cat([store.x, feat], dim=-1)
                 else:
                     store.x = feat
+        # ensure basic integrity when loading graphs directly
+        from src.graphs.dataset.graph_dataset import (
+            GraphDataset,
+        )
+        g = GraphDataset._ensure_num_nodes(g)
+        g = GraphDataset._ensure_x(g)
+        g = GraphDataset._sanitize_edges(g)
         g.sha256 = sha
         return g
 

--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -86,6 +86,7 @@ def collate_graphs(
 
     fixed = [GraphDataset._ensure_num_nodes(g) for g in graphs]
     fixed = [GraphDataset._ensure_x(g) for g in fixed]
+    fixed = [GraphDataset._sanitize_edges(g) for g in fixed]
     if attr_names is not None:
         fixed = [GraphDataset._ensure_meta_ids(g, attr_names) for g in fixed]
 


### PR DESCRIPTION
## Summary
- ensure edges are pruned in detection pipeline
- validate and sanitize graphs when loading a single sample

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883fd18bc44832eb0ebb14c97fbcec4