### PR TITLE
Fix device handling in RGCNEncoder forward

### DIFF
--- a/src/models/gnn/encoder.py
+++ b/src/models/gnn/encoder.py
@@ -138,6 +138,11 @@ class RGCNEncoder(nn.Module):
         g: HeteroData,
         edge_weight_dict: dict[str, Tensor] | None = None,
     ) -> Tensor:
+        device = next(self.parameters()).device
+        g = g.to(device, non_blocking=True)
+        if edge_weight_dict is not None:
+            edge_weight_dict = {k: v.to(device) for k, v in edge_weight_dict.items()}
+
         x_dict = {}
         for nt in g.node_types:
             # --- [파이프라인 재설계] forward의 역할 단순화 ---


### PR DESCRIPTION
## Summary
- move input graph and optional edge weights to the model's device at the start of `RGCNEncoder.forward`

## Testing
- `pytest -k encoder -q` *(fails: ModuleNotFoundError: No module named 'pandas', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688400c7cdf4832eb34ce95ce895828d