### PR TITLE
Ensure fp tokens column exists

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -985,7 +985,10 @@ def main(argv: list[str] | None = None) -> None:
                     "freq_threshold",
                 ):
                     if col not in df.columns:
-                        df[col] = None
+                        df[col] = [
+                            [] if col == "fp_matched_tokens" else None
+                            for _ in range(len(df))
+                        ]
                 df.to_csv(args.out_csv, index=False)
 
             if args.sample_rules_out and res.get("detected"):
@@ -1017,7 +1020,10 @@ def main(argv: list[str] | None = None) -> None:
                 "freq_threshold",
             ):
                 if col not in df.columns:
-                    df[col] = None
+                    df[col] = [
+                        [] if col == "fp_matched_tokens" else None
+                        for _ in range(len(df))
+                    ]
             df.to_csv(args.out_csv, index=False)
 
         LOGGER.info("Skipped %d graphs due to missing files", skipped)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -471,6 +471,64 @@ def test_batch_fp_ratio_from_benign(tmp_path, monkeypatch, caplog):
     assert any("FP ratio=1.000" in rec.message for rec in caplog.records)
 
 
+def test_batch_out_csv_has_fp_tokens_column(tmp_path, monkeypatch):
+    import pandas as pd
+
+    import torch
+    import src.models.gnn.res_wrapper as res_wrapper
+
+    csv = tmp_path / "meta.csv"
+    pd.DataFrame({"sha256": ["a"], "label": [1], "filename": ["a.bin"]}).to_csv(
+        csv, index=False
+    )
+
+    gdir = tmp_path / "graphs"
+    gdir.mkdir()
+    (gdir / "a.pt").write_text("stub")
+
+    sdir = tmp_path / "samples"
+    sdir.mkdir()
+    (sdir / "a.bin").write_text("mal")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyClf(torch.nn.Module):
+        def forward(self, x):
+            return torch.zeros(1)
+
+    monkeypatch.setattr(
+        res_wrapper.RESGCLClassifier,
+        "load_pretrained",
+        classmethod(lambda cls, *a, **k: DummyClf()),
+    )
+
+    def fake_eval(*args, **kwargs):
+        # return result without fp_matched_tokens
+        return {"detected": True}
+
+    monkeypatch.setattr(mod, "evaluate_single", fake_eval)
+
+    out_csv = tmp_path / "res.csv"
+    mod.main(
+        [
+            "--graph-dir",
+            str(gdir),
+            "--sample-dir",
+            str(sdir),
+            "--meta-csv",
+            str(csv),
+            "--classifier",
+            str(sdir / "a.bin"),
+            "--out-csv",
+            str(out_csv),
+        ]
+    )
+
+    df = pd.read_csv(out_csv)
+    assert "fp_matched_tokens" in df.columns
+    assert df.loc[0, "fp_matched_tokens"] == "[]"
+
+
 def test_evaluate_single_json_match_fp_with_clean_sample(tmp_path, monkeypatch):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)


### PR DESCRIPTION
## Summary
- keep `fp_matched_tokens` column in batch CSV outputs
- verify the column via CLI test

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_batch_out_csv_has_fp_tokens_column -vv`

------
https://chatgpt.com/codex/tasks/task_e_6884012731e0832ea650b35caec13c7d