### PR TITLE
Fix graph sanitization

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -19,6 +19,7 @@ from torch_geometric.data import InMemoryDataset, HeteroData
 from src.graphs.features.cache import load_tensor
 from src.cli.preprocessing import run_json, run_graphs, run_embeds
 from src.cli.detect import collate_graphs, infer
+from src.graphs.dataset import GraphDataset
 from src.models.gnn.res_wrapper import RESGCLClassifier
 
 
@@ -44,6 +45,9 @@ class SingleGraphDataset(InMemoryDataset):
                 else:
                     store.x = feat
         g.sha256 = sha
+        g = GraphDataset._ensure_num_nodes(g)
+        g = GraphDataset._ensure_x(g)
+        g = GraphDataset._sanitize_edges(g)
         return g
 
 

--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -86,6 +86,7 @@ def collate_graphs(
 
     fixed = [GraphDataset._ensure_num_nodes(g) for g in graphs]
     fixed = [GraphDataset._ensure_x(g) for g in fixed]
+    fixed = [GraphDataset._sanitize_edges(g) for g in fixed]
     if attr_names is not None:
         fixed = [GraphDataset._ensure_meta_ids(g, attr_names) for g in fixed]
 

--- a/src/explain/train_selector.py
+++ b/src/explain/train_selector.py
@@ -118,7 +118,10 @@ def main():
         def __len__(self):
             return 1
         def __getitem__(self, idx):
-            return self.graph
+            g = GraphDataset._ensure_num_nodes(self.graph)
+            g = GraphDataset._ensure_x(g)
+            g = GraphDataset._sanitize_edges(g)
+            return g
 
     _, in_dims, _, _ = collect_dataset_metadata(
         [SingleGraphDataset(graph)], attr_dim=model.encoder.attr_dim


### PR DESCRIPTION
## Summary
- sanitize edges when collating graphs for detection
- ensure SingleGraphDataset removes invalid edges

## Testing
- `pytest tests/test_graph_dataset_sanitize.py::test_dataset_filters_invalid_edges_data -q` *(fails: Negative index found in edge_index)*

------
https://chatgpt.com/codex/tasks/task_e_688401ea1358832e94dde4cc035b3777