### PR TITLE
Extend single-sample classification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,9 +391,16 @@ Epoch 1 Val Fidelity: 0.9123  Val Sparsity: 0.0731  Val Stability: 0.0321  Val N
 
 ```bash
 python scripts/single_sample_classify.py \
-    --json path/to/sample.json \
+    --json-dir path/to/json_dir \
+    --meta-csv data/meta.csv \
     --model models/gnn/res_gcl.pt \
     --out result.csv \
     --work-dir ./tmp_work
 # JSON의 sha256 값을 읽어 <tmp_work>/data/hetero/<sha>.pt 그래프가 준비됩니다.
+```
+
+`meta.csv`는 다음과 같이 생성합니다.
+```bash
+python -m cli.preprocessing --input-dir ../maldata/benign --out . labels --label 0 --csv data/meta.csv
+python -m cli.preprocessing --input-dir ../maldata/malware --out . labels --label 1 --csv data/meta.csv
 ```

--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -51,7 +51,7 @@ class SingleGraphDataset(InMemoryDataset):
         return g
 
 
-def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
+def preprocess(json_path: Path, work_dir: Path, device: str) -> tuple[Path, str]:
     """Run preprocessing stages for a single JSON sample."""
     raw_dir = work_dir / "raw"
     views_dir = work_dir / "data" / "views"
@@ -107,18 +107,17 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> Path:
     graph_path = hetero_dir / f"{sha}.pt"
     if not graph_path.is_file():
         raise RuntimeError(f"Expected graph not generated: {graph_path}")
-    return graph_path
+    return graph_path, sha
 
 
 def classify(
     graph: Path,
     ckpt: Path,
-    out_csv: Path,
     work_dir: Path,
     device: str,
     threshold: float,
     amp: bool,
-) -> None:
+) -> tuple[int, float, float]:
     device_t = torch.device(device)
     model = RESGCLClassifier.load_from_checkpoint(ckpt, map_location=device_t)
     attr = getattr(getattr(model, "encoder", None), "attr_names", None)
@@ -133,16 +132,16 @@ def classify(
         collate_fn=lambda batch: collate_graphs(batch, attr_names=attr),
     )
 
-    out_csv.parent.mkdir(parents=True, exist_ok=True)
-    with out_csv.open("w", encoding="utf-8") as f:
-        f.write("sha256,pred,prob,cert_radius\n")
-        for sha, pred, prob, radius in infer(model, loader, device_t, threshold, amp):
-            f.write(f"{sha},{pred},{prob:.6f},{radius}\n")
+    for _, pred, prob, radius in infer(model, loader, device_t, threshold, amp):
+        return pred, prob, radius
+    raise RuntimeError("Inference returned no results")
 
 
 def main(argv: Sequence[str] | None = None) -> None:
     p = argparse.ArgumentParser(description="Classify a single sample JSON")
-    p.add_argument("--json", type=Path, required=True, help="Path to PE JSON")
+    p.add_argument("--json", type=Path, help="Path to PE JSON")
+    p.add_argument("--json-dir", type=Path, help="Directory of JSON samples")
+    p.add_argument("--meta-csv", type=Path, help="CSV with sha256,label mapping")
     p.add_argument("--model", type=Path, required=True, help="Classifier checkpoint")
     p.add_argument("--out", type=Path, required=True, help="Output CSV path")
     p.add_argument(
@@ -156,19 +155,51 @@ def main(argv: Sequence[str] | None = None) -> None:
     p.add_argument("--amp", action="store_true")
     args = p.parse_args(argv)
 
-    graph = preprocess(args.json, args.work_dir, args.device)
-    
-    classify(
-        graph,
-        args.model,
-        args.out,
-        args.work_dir,
-        args.device,
-        args.threshold,
-        args.amp,
-    )
-    print(f"[OK] saved predictions -> {args.out}")
+    if not args.json_dir and not args.json:
+        p.error("--json or --json-dir required")
 
+    json_files = []
+    if args.json_dir:
+        json_files.extend(sorted(Path(args.json_dir).glob("*.json")))
+    if args.json:
+        json_files.append(args.json)
+
+    labels = {}
+    if args.meta_csv and args.meta_csv.is_file():
+        import csv
+
+        with args.meta_csv.open("r", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                labels[row["sha256"]] = int(row["label"])
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    y_true = []
+    y_pred = []
+    with args.out.open("w", encoding="utf-8") as f:
+        f.write("sha256,pred,prob,cert_radius\n")
+        for json_fp in json_files:
+            graph, sha = preprocess(json_fp, args.work_dir, args.device)
+            pred, prob, radius = classify(
+                graph,
+                args.model,
+                args.work_dir,
+                args.device,
+                args.threshold,
+                args.amp,
+            )
+            f.write(f"{sha},{pred},{prob:.6f},{radius}\n")
+            if sha in labels:
+                y_true.append(labels[sha])
+                y_pred.append(pred)
+
+    if y_true:
+        from sklearn.metrics import accuracy_score, f1_score
+
+        acc = accuracy_score(y_true, y_pred)
+        f1 = f1_score(y_true, y_pred)
+        print(f"Accuracy: {acc:.4f}  F1: {f1:.4f}")
+
+    print(f"[OK] saved predictions -> {args.out}")
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- support `--json-dir` and `--meta-csv` for batch inference
- track labels from a meta CSV and report overall metrics
- document meta.csv creation in README

## Testing
- `pytest -q` *(fails: missing heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_6884069d01c4832ea91fe7d089b35bcf