### PR TITLE
Add callable single-sample classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,21 @@ python scripts/single_sample_classify.py \
 # JSON의 sha256 값을 읽어 <tmp_work>/data/hetero/<sha>.pt 그래프가 준비됩니다.
 ```
 
+외부 파이썬 코드에서 동일한 기능을 사용하려면 다음과 같이 `classify_from_json`
+함수를 호출하면 됩니다.
+
+```python
+from pathlib import Path
+import json
+from scripts.single_sample_classify import classify_from_json
+
+with open("sample.json", "r", encoding="utf-8") as f:
+    js = json.load(f)
+
+label, prob, _ = classify_from_json(js, Path("models/gnn/res_gcl.pt"))
+print(label, prob)
+```
+
 `meta.csv`는 다음과 같이 생성합니다.
 ```bash
 python -m cli.preprocessing --input-dir ../maldata/benign --out . labels --label 0 --csv data/meta.csv

--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -4,8 +4,11 @@ import argparse
 import json
 import shutil
 import sys
+import tempfile
 from pathlib import Path
 from typing import Sequence
+
+__all__ = ["classify_from_json", "main"]
 
 repo_root = Path(__file__).resolve().parents[1]
 # Insert the project root directory so the CLI packages can be imported when
@@ -135,6 +138,32 @@ def classify(
     for _, pred, prob, radius in infer(model, loader, device_t, threshold, amp):
         return pred, prob, radius
     raise RuntimeError("Inference returned no results")
+
+
+def classify_from_json(
+    json_obj: dict,
+    ckpt: Path,
+    *,
+    device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    threshold: float = 0.5,
+    amp: bool = False,
+) -> tuple[int, float, float]:
+    """Classify a single JSON object and return (label, prob, cert_radius)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        work_dir = Path(tmpdir)
+        json_path = work_dir / "sample.json"
+        with json_path.open("w", encoding="utf-8") as f:
+            json.dump(json_obj, f)
+        graph, _ = preprocess(json_path, work_dir, device)
+        pred, prob, radius = classify(
+            graph,
+            ckpt,
+            work_dir,
+            device,
+            threshold,
+            amp,
+        )
+        return pred, prob, radius
 
 
 def main(argv: Sequence[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- add `classify_from_json` helper to `single_sample_classify.py`
- document how to use the helper in README

## Testing
- `pytest tests/test_rgcn_edge_type_check.py tests/test_score_cache.py tests/test_train_res_gcl_batch_size.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68840a6774c8832ebe194843936ceb42