### PR TITLE
Ensure saliency tensors moved to CPU

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -111,6 +111,7 @@ def _compute_saliency_with_explainer(
                 saliency[nt] = x.grad.abs().sum(dim=1).detach().cpu()
             else:
                 saliency[nt] = torch.zeros(g[nt].num_nodes)
+    saliency = {k: v.detach().cpu() for k, v in saliency.items()}
     return saliency
 
 

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -140,6 +140,8 @@ class FeatureMiner:
             flat_sal = saliency
             node_offsets = self._infer_offsets_from_data(data)
 
+        flat_sal = flat_sal.detach().cpu()
+
         # 1) saliency 상위 노드 선택
         selected_indices = self._select_nodes(flat_sal)
 


### PR DESCRIPTION
## Summary
- detach and move saliency tensors in `FeatureMiner.mine`
- detach and move explainer saliency tensors in CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: matplotlib, sentencepiece, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68840a83c98c832ea925a286b3a2a933