### PR TITLE
Optimize clean JSON checks

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -148,7 +148,7 @@ def _extract_tokens(feature: str) -> list[str]:
 
 
 def verify_features(
-    json_path: Path,
+    json_path: Path | Dict[str, Any],
     features: list[str],
     *,
     condition_type: str = "any",
@@ -164,7 +164,10 @@ def verify_features(
     result and the list of matched feature strings.
     """
     try:
-        js = json.loads(json_path.read_text(encoding="utf-8"))
+        if isinstance(json_path, Path):
+            js = json.loads(json_path.read_text(encoding="utf-8"))
+        else:
+            js = json_path
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("failed to read %s: %s", json_path, exc)
         return False
@@ -323,6 +326,38 @@ def evaluate_single(
             graph, classifier, explainer, device
         )
 
+    clean_json_cache: Dict[Path, Any] = {}
+    if clean_dir is not None and clean_dir.is_dir():
+        files = [p for p in clean_dir.iterdir() if p.is_file()]
+        for p in tqdm_wrap(files, desc="load clean json", unit="file"):
+            j = p.with_suffix(".json")
+            if not j.is_file():
+                LOGGER.warning("JSON not found for %s", j)
+                continue
+            try:
+                clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("failed to read %s: %s", j, exc)
+    elif clean_paths is not None:
+        for p in tqdm_wrap(clean_paths, desc="load clean json", unit="file"):
+            j = p.with_suffix(".json")
+            if not j.is_file():
+                LOGGER.warning("JSON not found for %s", j)
+                continue
+            try:
+                clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("failed to read %s: %s", j, exc)
+    elif clean_sample is not None:
+        j = clean_sample.with_suffix(".json")
+        if not j.is_file():
+            LOGGER.warning("JSON not found for %s", j)
+        else:
+            try:
+                clean_json_cache[clean_sample] = json.loads(j.read_text(encoding="utf-8"))
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("failed to read %s: %s", j, exc)
+
     def _build_and_eval(
         freq_thresh: float | int,
         group_cnt: int | None,
@@ -467,11 +502,11 @@ def evaluate_single(
             if json_match:
 
                 def _check_json(p: Path) -> list[str] | None:
-                    j = p.with_suffix(".json")
-                    if not j.is_file():
+                    js_obj = clean_json_cache.get(p)
+                    if js_obj is None:
                         return None
                     ok, mt = verify_features(
-                        j,
+                        js_obj,
                         feats,
                         condition_type=condition_type,
                         group_percentage=group_pct,


### PR DESCRIPTION
## Summary
- preload clean sample JSON files once before evaluation
- allow `verify_features` to accept parsed JSON objects
- check FP JSONs from the in-memory cache

## Testing
- `pytest tests/test_beta_schedule.py tests/test_capa_map_atom.py tests/test_logger_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68840e93d638832eab9548809a869bd7