### PR TITLE
Add flush option to rule evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,11 @@ python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt \
     --exclude-tokens foo bar
+# periodically flush results to CSV during batch evaluation
+python -m src.cli.explainer_rule_eval \
+    --graph-dir graphs --meta-csv meta.csv \
+    --classifier models/gnn/res_gcl.pt \
+    --out-csv results.csv --flush-every 5
 ```
 # XAI selector 학습
 # 분류기가 HeteroData 그래프를 입력으로 받아도 동일하게 사용할 수 있습니다.

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -217,4 +217,5 @@ python -m src.cli.explainer_rule_eval \
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로
 낮춰집니다.
+배치 모드에서 `--flush-every`를 지정하면 중간 결과를 주기적으로 CSV에 저장할 수 있습니다.
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -873,6 +873,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")
     p.add_argument(
+        "--flush-every",
+        type=int,
+        default=None,
+        help="Write CSV results every N graphs (append mode)",
+    )
+    p.add_argument(
         "--sample-rules-out",
         type=Path,
         help="Directory to write example rules",
@@ -947,6 +953,8 @@ def main(argv: list[str] | None = None) -> None:
             bname = b_row.get("filename") or b_row.get("name") or f"{bsha}.bin"
             benign_paths.append(Path(args.sample_dir or args.graph_dir) / bname)
         results: list[dict[str, Any]] = []
+        flush_buffer: list[dict[str, Any]] = []
+        first_flush = True
         skipped = 0
         row_iter = tqdm_wrap(
             rows.iterrows(), desc="graphs", total=len(rows), unit="graph"
@@ -1012,20 +1020,29 @@ def main(argv: list[str] | None = None) -> None:
             fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
             row_iter.set_postfix(avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}")
 
-            if args.out_csv:
-                df = pd.DataFrame(results)
-                for col in (
-                    "matched_tokens",
-                    "fp_matched_tokens",
-                    "group_min_count",
-                    "freq_threshold",
-                ):
-                    if col not in df.columns:
-                        df[col] = [
-                            [] if col == "fp_matched_tokens" else None
-                            for _ in range(len(df))
-                        ]
-                df.to_csv(args.out_csv, index=False)
+            if args.out_csv and args.flush_every:
+                flush_buffer.append(res)
+                if len(flush_buffer) >= args.flush_every:
+                    df_flush = pd.DataFrame(flush_buffer)
+                    for col in (
+                        "matched_tokens",
+                        "fp_matched_tokens",
+                        "group_min_count",
+                        "freq_threshold",
+                    ):
+                        if col not in df_flush.columns:
+                            df_flush[col] = [
+                                [] if col == "fp_matched_tokens" else None
+                                for _ in range(len(df_flush))
+                            ]
+                    df_flush.to_csv(
+                        args.out_csv,
+                        mode="a" if not first_flush else "w",
+                        header=first_flush,
+                        index=False,
+                    )
+                    first_flush = False
+                    flush_buffer.clear()
 
             if args.sample_rules_out and res.get("detected"):
                 # 탐지된 경우 규칙을 바로 저장하여 누락을 방지합니다.
@@ -1047,20 +1064,43 @@ def main(argv: list[str] | None = None) -> None:
                     args.fp_rules_out.mkdir(parents=True, exist_ok=True)
                     (args.fp_rules_out / fname).write_text(rule_txt, encoding="utf-8")
 
+        df = pd.DataFrame(results)
+
         if args.out_csv:
-            df = pd.DataFrame(results)
-            for col in (
-                "matched_tokens",
-                "fp_matched_tokens",
-                "group_min_count",
-                "freq_threshold",
-            ):
-                if col not in df.columns:
-                    df[col] = [
-                        [] if col == "fp_matched_tokens" else None
-                        for _ in range(len(df))
-                    ]
-            df.to_csv(args.out_csv, index=False)
+            if args.flush_every:
+                if flush_buffer:
+                    df_flush = pd.DataFrame(flush_buffer)
+                    for col in (
+                        "matched_tokens",
+                        "fp_matched_tokens",
+                        "group_min_count",
+                        "freq_threshold",
+                    ):
+                        if col not in df_flush.columns:
+                            df_flush[col] = [
+                                [] if col == "fp_matched_tokens" else None
+                                for _ in range(len(df_flush))
+                            ]
+                    df_flush.to_csv(
+                        args.out_csv,
+                        mode="a" if not first_flush else "w",
+                        header=first_flush,
+                        index=False,
+                    )
+                    first_flush = False
+            else:
+                for col in (
+                    "matched_tokens",
+                    "fp_matched_tokens",
+                    "group_min_count",
+                    "freq_threshold",
+                ):
+                    if col not in df.columns:
+                        df[col] = [
+                            [] if col == "fp_matched_tokens" else None
+                            for _ in range(len(df))
+                        ]
+                df.to_csv(args.out_csv, index=False)
 
         LOGGER.info("Skipped %d graphs due to missing files", skipped)
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -55,6 +55,26 @@ def test_build_parser_exclude_tokens():
     assert args.exclude_tokens == ["foo", "bar"]
 
 
+def test_build_parser_flush_every():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--out-csv",
+            "out.csv",
+            "--flush-every",
+            "10",
+        ]
+    )
+    assert args.flush_every == 10
+
+
 def test_cli_runs_and_writes_json(tmp_path, caplog):
     g = HeteroData()
     g["bb"].x = torch.zeros(2, 1)
@@ -527,6 +547,63 @@ def test_batch_out_csv_has_fp_tokens_column(tmp_path, monkeypatch):
     df = pd.read_csv(out_csv)
     assert "fp_matched_tokens" in df.columns
     assert df.loc[0, "fp_matched_tokens"] == "[]"
+
+
+def test_batch_flush_every(tmp_path, monkeypatch):
+    import pandas as pd
+    import torch
+    import src.models.gnn.res_wrapper as res_wrapper
+
+    csv = tmp_path / "meta.csv"
+    pd.DataFrame({"sha256": ["a"], "label": [1], "filename": ["a.bin"]}).to_csv(
+        csv, index=False
+    )
+
+    gdir = tmp_path / "graphs"
+    gdir.mkdir()
+    (gdir / "a.pt").write_text("stub")
+
+    sdir = tmp_path / "samples"
+    sdir.mkdir()
+    (sdir / "a.bin").write_text("mal")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyClf(torch.nn.Module):
+        def forward(self, x):
+            return torch.zeros(1)
+
+    monkeypatch.setattr(
+        res_wrapper.RESGCLClassifier,
+        "load_pretrained",
+        classmethod(lambda cls, *a, **k: DummyClf()),
+    )
+
+    def fake_eval(*args, **kwargs):
+        return {"detected": True}
+
+    monkeypatch.setattr(mod, "evaluate_single", fake_eval)
+
+    out_csv = tmp_path / "res.csv"
+    mod.main(
+        [
+            "--graph-dir",
+            str(gdir),
+            "--sample-dir",
+            str(sdir),
+            "--meta-csv",
+            str(csv),
+            "--classifier",
+            str(sdir / "a.bin"),
+            "--out-csv",
+            str(out_csv),
+            "--flush-every",
+            "1",
+        ]
+    )
+
+    df = pd.read_csv(out_csv)
+    assert len(df) == 1
 
 
 def test_evaluate_single_json_match_fp_with_clean_sample(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- support `--flush-every` for intermediate CSV results when evaluating rules
- remove per-iteration DataFrame creation in `explainer_rule_eval.py`
- update docs and README with new option
- test the new argument

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_flush_every tests/test_explainer_rule_eval_cli.py::test_batch_flush_every -q`
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68841095f5d8832eb800440555cebef8