### PR TITLE
Implement best result selection in FP retries

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -704,12 +704,34 @@ def evaluate_single(
         exclude=exclude_set,
     )
 
+    best_result = result
+
+    def _is_better(new: Dict[str, Any], current: Dict[str, Any]) -> bool:
+        """Return True if ``new`` should replace ``current`` based on prefs."""
+        new_fp = bool(new.get("false_positive"))
+        cur_fp = bool(current.get("false_positive"))
+        if new_fp != cur_fp:
+            return not new_fp
+
+        new_det = bool(new.get("detected"))
+        cur_det = bool(current.get("detected"))
+        if new_det != cur_det:
+            return new_det
+
+        new_cov = float(new.get("coverage", 0.0))
+        cur_cov = float(current.get("coverage", 0.0))
+        if not math.isclose(new_cov, cur_cov):
+            return new_cov > cur_cov
+
+        new_len = int(new.get("rule_length", 0))
+        cur_len = int(current.get("rule_length", 0))
+        return new_len < cur_len
+
     if result.get("false_positive") and fp_retries > 0:
         retries = fp_retries
         freq_thresh = freq_threshold
         group_cnt = group_min_count
         comb_ratio = combine_min_ratio
-        prev_result = result
         while retries > 0 and result.get("false_positive"):
             retries -= 1
             tokens_to_exclude = result.get(
@@ -723,21 +745,18 @@ def evaluate_single(
             else:
                 comb_ratio = min(1.0, comb_ratio + comb_ratio_step)
             freq_thresh = max(1, freq_thresh - freq_threshold_step) if freq_threshold_step > 0 else 1
-            prev_result = result
             result = _build_and_eval(
                 freq_thresh,
                 group_cnt,
                 comb_ratio,
                 exclude=exclude_set,
             )
+            if _is_better(result, best_result):
+                best_result = result
             if not result.get("false_positive"):
-                if not result.get("detected", False) and prev_result.get(
-                    "detected", False
-                ):
-                    result = prev_result
                 break
 
-    return result
+    return best_result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1164,3 +1164,79 @@ def test_fp_tokens_accumulation(tmp_path, monkeypatch):
 
     assert res["false_positive"] is True
     assert sorted(res.get("fp_matched_tokens", [])) == ["call:bar", "call:foo"]
+
+
+def test_fp_retry_selects_best_result(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+    (tmp_path / "clean.json").write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self):
+            self.strings = [(0, "$s0", b"x")]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            if "foo" in self.text:
+                return [FakeMatch()]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=None,
+        json_match=False,
+        combine_mode="or",
+        fp_retries=1,
+    )
+
+    assert res["false_positive"] is False
+    assert res["detected"] is False
+    assert res["rule_length"] == 0


### PR DESCRIPTION
## Summary
- update `evaluate_single` to track the best evaluation result during FP retries
- choose the result without false positives and prefer detected samples
- add regression test for retry logic

## Testing
- `pytest -q tests/test_explainer_rule_eval_cli.py::test_fp_retry_selects_best_result`

------
https://chatgpt.com/codex/tasks/task_e_688410c3d840832ea980c05317687717