### PR TITLE
Enable parallel rule evaluation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -760,6 +760,63 @@ def evaluate_single(
 
 
 # ---------------------------------------------------------------------------
+# multiprocessing helpers
+# ---------------------------------------------------------------------------
+
+_WORKER_CLASSIFIER = None
+_WORKER_EXPLAINER = None
+_WORKER_DEVICE: torch.device | None = None
+
+
+def _init_worker(classifier_ckpt: str | None, explainer_ckpt: str | None, device: str) -> None:
+    """Load models in subprocess."""
+    global _WORKER_CLASSIFIER, _WORKER_EXPLAINER, _WORKER_DEVICE
+    _WORKER_DEVICE = torch.device(device)
+    if classifier_ckpt:
+        from src.models.gnn.res_wrapper import RESGCLClassifier
+
+        _WORKER_CLASSIFIER = RESGCLClassifier.load_pretrained(
+            str(classifier_ckpt), map_location=_WORKER_DEVICE
+        )
+    if explainer_ckpt and Path(explainer_ckpt).is_file():
+        _WORKER_EXPLAINER = torch.load(
+            explainer_ckpt, map_location=_WORKER_DEVICE, weights_only=False
+        )
+
+
+def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
+    sha, gpath, spath, jpath, kwargs = task
+    return evaluate_single(
+        gpath,
+        spath,
+        classifier=_WORKER_CLASSIFIER,
+        explainer=_WORKER_EXPLAINER,
+        classifier_ckpt=None,
+        explainer_ckpt=None,
+        saliency_path=None,
+        device=_WORKER_DEVICE or torch.device("cpu"),
+        sample_json=jpath,
+        **kwargs,
+    )
+
+
+def _eval_task(task: tuple[str, Path, Path, Path, dict], classifier: Any, explainer: Any, device: torch.device) -> Dict[str, Any]:
+    sha, gpath, spath, jpath, kwargs = task
+    return evaluate_single(
+        gpath,
+        spath,
+        classifier=classifier,
+        explainer=explainer,
+        classifier_ckpt=None,
+        explainer_ckpt=None,
+        saliency_path=None,
+        device=device,
+        sample_json=jpath,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -913,6 +970,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory to write rules that triggered false positives",
     )
     p.add_argument(
+        "--num-workers",
+        type=int,
+        default=1,
+        help="Number of parallel worker processes for batch mode",
+    )
+    p.add_argument(
         "--json-match",
         action="store_true",
         help="Verify features in sample JSON instead of YARA match",
@@ -975,113 +1038,166 @@ def main(argv: list[str] | None = None) -> None:
         flush_buffer: list[dict[str, Any]] = []
         first_flush = True
         skipped = 0
-        row_iter = tqdm_wrap(
-            rows.iterrows(), desc="graphs", total=len(rows), unit="graph"
-        )
-        for _, row in row_iter:
+        tasks: list[tuple[str, Path, Path, Path, dict]] = []
+        for _, row in rows.iterrows():
             sha = row["sha256"]
             filename = row.get("filename") or row.get("name") or f"{sha}.bin"
             gpath = Path(args.graph_dir) / f"{sha}.pt"
             spath = Path(args.sample_dir or args.graph_dir) / filename
             jpath = Path(args.sample_dir or args.graph_dir) / f"{sha}.json"
 
-            try:
-                res = evaluate_single(
-                    gpath,
-                    spath,
-                    classifier_ckpt=None,
-                    explainer_ckpt=None,
-                    classifier=classifier,
-                    explainer=explainer,
-                    saliency_path=None,
-                    device=device,
-                    top_k=args.top_k,
-                    top_k_percent=args.top_k_percent,
-                    saliency_top_percent=args.saliency_top_percent,
-                    dynamic_k=args.dynamic_k,
-                    min_saliency=args.min_saliency,
-                    keep_per_type=args.keep_per_type,
-                    benign_freqs=benign_freqs,
-                    freq_threshold=args.freq_threshold,
-                    condition_type=args.condition_type,
-                    percentage=args.percentage,
-                    min_count=args.min_count,
-                    group_percentage=args.group_percentage,
-                    group_min_count=args.group_min_count,
-                    adjust_group_percentage=args.adjust_group_percentage,
-                    num_rules=args.num_rules,
-                    chunk_size=args.chunk_size,
-                    clean_dir=args.clean_dir,
-                    clean_sample=None,
-                    clean_paths=(
-                        benign_paths
-                        if args.clean_dir is None and args.clean_sample is None
-                        else None
-                    ),
-                    sample_json=jpath,
-                    json_match=args.json_match,
-                    saliency_stats=saliency_stats,
-                    combine_min_ratio=args.combine_min_ratio,
-                    fp_retries=args.fp_retries,
-                    freq_threshold_step=args.freq_threshold_step,
-                    comb_ratio_step=args.comb_ratio_step,
-                    exclude_tokens=args.exclude_tokens,
-                )
-            except FileNotFoundError as exc:
-                skipped += 1
-                LOGGER.warning("Skipping %s: %s", sha, exc)
-                continue
+            task_kwargs = {
+                "top_k": args.top_k,
+                "top_k_percent": args.top_k_percent,
+                "saliency_top_percent": args.saliency_top_percent,
+                "dynamic_k": args.dynamic_k,
+                "min_saliency": args.min_saliency,
+                "keep_per_type": args.keep_per_type,
+                "benign_freqs": benign_freqs,
+                "freq_threshold": args.freq_threshold,
+                "condition_type": args.condition_type,
+                "percentage": args.percentage,
+                "min_count": args.min_count,
+                "group_percentage": args.group_percentage,
+                "group_min_count": args.group_min_count,
+                "adjust_group_percentage": args.adjust_group_percentage,
+                "num_rules": args.num_rules,
+                "chunk_size": args.chunk_size,
+                "clean_dir": args.clean_dir,
+                "clean_sample": None,
+                "clean_paths": (
+                    benign_paths if args.clean_dir is None and args.clean_sample is None else None
+                ),
+                "json_match": args.json_match,
+                "saliency_stats": saliency_stats,
+                "combine_min_ratio": args.combine_min_ratio,
+                "fp_retries": args.fp_retries,
+                "freq_threshold_step": args.freq_threshold_step,
+                "comb_ratio_step": args.comb_ratio_step,
+                "exclude_tokens": args.exclude_tokens,
+            }
+            tasks.append((sha, gpath, spath, jpath, task_kwargs))
 
-            res["sha256"] = sha
-            results.append(res)
+        if args.num_workers > 1:
+            import multiprocessing as mp
+            from concurrent.futures import ProcessPoolExecutor, as_completed
 
-            det_rate = sum(r.get("detected", False) for r in results) / len(results)
-            fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
-            row_iter.set_postfix(avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}")
+            ctx = mp.get_context("forkserver")
+            with ProcessPoolExecutor(
+                max_workers=args.num_workers,
+                mp_context=ctx,
+                initializer=_init_worker,
+                initargs=(str(args.classifier), str(args.explainer) if args.explainer else None, args.device),
+            ) as executor:
+                future_map = {executor.submit(_worker_eval, t): t[0] for t in tasks}
+                progress = tqdm_wrap(as_completed(future_map), total=len(future_map), desc="graphs", unit="graph")
+                for fut in progress:
+                    sha = future_map[fut]
+                    try:
+                        res = fut.result()
+                    except FileNotFoundError as exc:
+                        skipped += 1
+                        LOGGER.warning("Skipping %s: %s", sha, exc)
+                        continue
 
-            if args.out_csv and args.flush_every:
-                flush_buffer.append(res)
-                if len(flush_buffer) >= args.flush_every:
-                    df_flush = pd.DataFrame(flush_buffer)
-                    for col in (
-                        "matched_tokens",
-                        "fp_matched_tokens",
-                        "group_min_count",
-                        "freq_threshold",
-                    ):
-                        if col not in df_flush.columns:
-                            df_flush[col] = [
-                                [] if col == "fp_matched_tokens" else None
-                                for _ in range(len(df_flush))
-                            ]
-                    df_flush.to_csv(
-                        args.out_csv,
-                        mode="a" if not first_flush else "w",
-                        header=first_flush,
-                        index=False,
+                    res["sha256"] = sha
+                    results.append(res)
+
+                    det_rate = sum(r.get("detected", False) for r in results) / len(results)
+                    fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
+                    progress.set_postfix(avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}")
+
+                    if args.out_csv and args.flush_every:
+                        flush_buffer.append(res)
+                        if len(flush_buffer) >= args.flush_every:
+                            df_flush = pd.DataFrame(flush_buffer)
+                            for col in (
+                                "matched_tokens",
+                                "fp_matched_tokens",
+                                "group_min_count",
+                                "freq_threshold",
+                            ):
+                                if col not in df_flush.columns:
+                                    df_flush[col] = [
+                                        [] if col == "fp_matched_tokens" else None
+                                        for _ in range(len(df_flush))
+                                    ]
+                            df_flush.to_csv(
+                                args.out_csv,
+                                mode="a" if not first_flush else "w",
+                                header=first_flush,
+                                index=False,
+                            )
+                            first_flush = False
+                            flush_buffer.clear()
+
+                    if args.sample_rules_out and res.get("detected"):
+                        rule_dir = args.sample_rules_out / "rule"
+                        rule_dir.mkdir(parents=True, exist_ok=True)
+                        fname = f"{sha}.yar"
+                        rule_txt = YaraBuilder().combine_rules(
+                            res.get("rule_texts", [res.get("rule_text", "")]),
+                            mode=combine_mode,
+                            min_match_ratio=args.combine_min_ratio,
+                        )
+                        (rule_dir / fname).write_text(rule_txt, encoding="utf-8")
+                        if args.low_fp_rules_out and not res.get("false_positive"):
+                            args.low_fp_rules_out.mkdir(parents=True, exist_ok=True)
+                            (args.low_fp_rules_out / fname).write_text(rule_txt, encoding="utf-8")
+                        if args.fp_rules_out and res.get("false_positive"):
+                            args.fp_rules_out.mkdir(parents=True, exist_ok=True)
+                            (args.fp_rules_out / fname).write_text(rule_txt, encoding="utf-8")
+        else:
+            for task in tasks:
+                res = _eval_task(task, classifier, explainer, device)
+                sha = task[0]
+
+                res["sha256"] = sha
+                results.append(res)
+
+                det_rate = sum(r.get("detected", False) for r in results) / len(results)
+                fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
+
+                if args.out_csv and args.flush_every:
+                    flush_buffer.append(res)
+                    if len(flush_buffer) >= args.flush_every:
+                        df_flush = pd.DataFrame(flush_buffer)
+                        for col in (
+                            "matched_tokens",
+                            "fp_matched_tokens",
+                            "group_min_count",
+                            "freq_threshold",
+                        ):
+                            if col not in df_flush.columns:
+                                df_flush[col] = [
+                                    [] if col == "fp_matched_tokens" else None
+                                    for _ in range(len(df_flush))
+                                ]
+                        df_flush.to_csv(
+                            args.out_csv,
+                            mode="a" if not first_flush else "w",
+                            header=first_flush,
+                            index=False,
+                        )
+                        first_flush = False
+                        flush_buffer.clear()
+
+                if args.sample_rules_out and res.get("detected"):
+                    rule_dir = args.sample_rules_out / "rule"
+                    rule_dir.mkdir(parents=True, exist_ok=True)
+                    fname = f"{sha}.yar"
+                    rule_txt = YaraBuilder().combine_rules(
+                        res.get("rule_texts", [res.get("rule_text", "")]),
+                        mode=combine_mode,
+                        min_match_ratio=args.combine_min_ratio,
                     )
-                    first_flush = False
-                    flush_buffer.clear()
-
-            if args.sample_rules_out and res.get("detected"):
-                # 탐지된 경우 규칙을 바로 저장하여 누락을 방지합니다.
-                rule_dir = args.sample_rules_out / "rule"
-                rule_dir.mkdir(parents=True, exist_ok=True)
-                fname = f"{sha}.yar"
-                rule_txt = YaraBuilder().combine_rules(
-                    res.get("rule_texts", [res.get("rule_text", "")]),
-                    mode=combine_mode,
-                    min_match_ratio=args.combine_min_ratio,
-                )
-                (rule_dir / fname).write_text(rule_txt, encoding="utf-8")
-                if args.low_fp_rules_out and not res.get("false_positive"):
-                    args.low_fp_rules_out.mkdir(parents=True, exist_ok=True)
-                    (args.low_fp_rules_out / fname).write_text(
-                        rule_txt, encoding="utf-8"
-                    )
-                if args.fp_rules_out and res.get("false_positive"):
-                    args.fp_rules_out.mkdir(parents=True, exist_ok=True)
-                    (args.fp_rules_out / fname).write_text(rule_txt, encoding="utf-8")
+                    (rule_dir / fname).write_text(rule_txt, encoding="utf-8")
+                    if args.low_fp_rules_out and not res.get("false_positive"):
+                        args.low_fp_rules_out.mkdir(parents=True, exist_ok=True)
+                        (args.low_fp_rules_out / fname).write_text(rule_txt, encoding="utf-8")
+                    if args.fp_rules_out and res.get("false_positive"):
+                        args.fp_rules_out.mkdir(parents=True, exist_ok=True)
+                        (args.fp_rules_out / fname).write_text(rule_txt, encoding="utf-8")
 
         df = pd.DataFrame(results)
 


### PR DESCRIPTION
## Summary
- add `--num-workers` option to explainer rule eval CLI
- add multiprocessing helpers and dispatch evaluation via `ProcessPoolExecutor`

## Testing
- `python -m py_compile src/cli/explainer_rule_eval.py`

------
https://chatgpt.com/codex/tasks/task_e_688413e5e0a8832eb98640b64f24a46f