### PR TITLE
Implement caching for clean JSONs in rule eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -294,6 +294,7 @@ def evaluate_single(
     freq_threshold_step: float = 0.0,
     comb_ratio_step: float = 0.1,
     exclude_tokens: Sequence[str] | None = None,
+    clean_json_cache: Dict[Path, Any] | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -326,37 +327,38 @@ def evaluate_single(
             graph, classifier, explainer, device
         )
 
-    clean_json_cache: Dict[Path, Any] = {}
-    if clean_dir is not None and clean_dir.is_dir():
-        files = [p for p in clean_dir.iterdir() if p.is_file()]
-        for p in tqdm_wrap(files, desc="load clean json", unit="file"):
-            j = p.with_suffix(".json")
+    if clean_json_cache is None:
+        clean_json_cache = {}
+        if clean_dir is not None and clean_dir.is_dir():
+            files = [p for p in clean_dir.iterdir() if p.is_file()]
+            for p in tqdm_wrap(files, desc="load clean json", unit="file"):
+                j = p.with_suffix(".json")
+                if not j.is_file():
+                    LOGGER.warning("JSON not found for %s", j)
+                    continue
+                try:
+                    clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("failed to read %s: %s", j, exc)
+        elif clean_paths is not None:
+            for p in tqdm_wrap(clean_paths, desc="load clean json", unit="file"):
+                j = p.with_suffix(".json")
+                if not j.is_file():
+                    LOGGER.warning("JSON not found for %s", j)
+                    continue
+                try:
+                    clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("failed to read %s: %s", j, exc)
+        elif clean_sample is not None:
+            j = clean_sample.with_suffix(".json")
             if not j.is_file():
                 LOGGER.warning("JSON not found for %s", j)
-                continue
-            try:
-                clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning("failed to read %s: %s", j, exc)
-    elif clean_paths is not None:
-        for p in tqdm_wrap(clean_paths, desc="load clean json", unit="file"):
-            j = p.with_suffix(".json")
-            if not j.is_file():
-                LOGGER.warning("JSON not found for %s", j)
-                continue
-            try:
-                clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning("failed to read %s: %s", j, exc)
-    elif clean_sample is not None:
-        j = clean_sample.with_suffix(".json")
-        if not j.is_file():
-            LOGGER.warning("JSON not found for %s", j)
-        else:
-            try:
-                clean_json_cache[clean_sample] = json.loads(j.read_text(encoding="utf-8"))
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning("failed to read %s: %s", j, exc)
+            else:
+                try:
+                    clean_json_cache[clean_sample] = json.loads(j.read_text(encoding="utf-8"))
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("failed to read %s: %s", j, exc)
 
     def _build_and_eval(
         freq_thresh: float | int,
@@ -1034,6 +1036,17 @@ def main(argv: list[str] | None = None) -> None:
             bsha = b_row["sha256"]
             bname = b_row.get("filename") or b_row.get("name") or f"{bsha}.bin"
             benign_paths.append(Path(args.sample_dir or args.graph_dir) / bname)
+
+        clean_json_cache: dict[Path, Any] = {}
+        if args.clean_dir is None and args.clean_sample is None:
+            for p in tqdm_wrap(benign_paths, desc="preload clean json", unit="file"):
+                j = p.with_suffix(".json")
+                if not j.is_file():
+                    continue
+                try:
+                    clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("failed to read %s: %s", j, exc)
         results: list[dict[str, Any]] = []
         flush_buffer: list[dict[str, Any]] = []
         first_flush = True
@@ -1075,6 +1088,7 @@ def main(argv: list[str] | None = None) -> None:
                 "freq_threshold_step": args.freq_threshold_step,
                 "comb_ratio_step": args.comb_ratio_step,
                 "exclude_tokens": args.exclude_tokens,
+                "clean_json_cache": clean_json_cache,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -721,6 +721,75 @@ def test_evaluate_single_json_match_fp_with_clean_dir(tmp_path, monkeypatch):
     assert res["false_positive"] is True
 
 
+def test_evaluate_single_uses_clean_json_cache(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+    clean_json = tmp_path / "clean.json"
+    clean_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    cache = {clean: json.loads(clean_json.read_text())}
+
+    orig_read = Path.read_text
+
+    def fake_read_text(self, *a, **k):
+        if self == clean_json:
+            raise AssertionError("cache not used")
+        return orig_read(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        clean_json_cache=cache,
+    )
+
+    assert res["false_positive"] is True
+
+
 def test_evaluate_single_json_feature_filter(tmp_path, monkeypatch):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)


### PR DESCRIPTION
## Summary
- add optional `clean_json_cache` to `evaluate_single`
- preload benign JSONs in batch mode and reuse across graphs
- add regression test ensuring cache prevents file reads

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k uses_clean_json_cache -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68841723db0c832e9d4ec7f95864500b