### PR TITLE
Update benign frequency filtering logic

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -174,18 +174,23 @@ class FeatureMiner:
 
         # 2) 노드별 메타 추출
         raw_features: List[str] = []
+        feat_sal_map: Dict[str, float] = {}
         for global_idx in selected_indices:
             ntype, local_idx = self._map_global_to_local(global_idx, node_offsets)
             meta = data[ntype]
-            raw_features.extend(
-                self._extract_candidates(
-                    data, ntype, local_idx, meta, node_offsets, selected_set
-                )
+            cand = self._extract_candidates(
+                data, ntype, local_idx, meta, node_offsets, selected_set
             )
+            raw_features.extend(cand)
+            sal_val = float(flat_sal[global_idx])
+            for feat in cand:
+                prev = feat_sal_map.get(feat)
+                if prev is None or sal_val > prev:
+                    feat_sal_map[feat] = sal_val
 
         # 3) 정규화 & dedup 정렬
         cleaned = self._normalize_and_rank(raw_features)
-        cleaned = self._filter_by_benign_freq(cleaned)
+        cleaned = self._filter_by_benign_freq(cleaned, feat_sal_map)
         if sal_stats is not None:
             cleaned = self._filter_by_saliency_stats(cleaned, sal_stats)
         _LOG.debug("FeatureMiner: mined %d distinct candidates", len(cleaned))
@@ -608,7 +613,9 @@ class FeatureMiner:
                 filtered.append(f)
         return filtered
 
-    def _filter_by_benign_freq(self, feats: Sequence[str]) -> List[str]:
+    def _filter_by_benign_freq(
+        self, feats: Sequence[str], sal_map: Dict[str, float] | None = None
+    ) -> List[str]:
         """정상 샘플에서 자주 등장하는 토큰을 제거한다."""
         if not self.benign_freqs:
             return list(feats)
@@ -619,11 +626,23 @@ class FeatureMiner:
             if freq is not None and freq >= threshold:
                 continue
             filtered.append(f)
-        if not filtered and feats:
-            # 모든 토큰이 필터링된 경우 최소 1개는 남기도록 한다.
-            first = feats[0]
-            filtered.append(first)
-        return filtered
+        if filtered or not feats:
+            return filtered
+
+        # 모든 후보가 제거된 경우: benign 빈도 최소 + saliency 최대 토큰 선택
+        best = None
+        best_freq = None
+        best_sal = None
+        for f in feats:
+            freq = self.benign_freqs.get(f, 0)
+            sal = sal_map.get(f, 0.0) if sal_map else 0.0
+            if best is None or freq < best_freq or (
+                freq == best_freq and sal > best_sal
+            ):
+                best = f
+                best_freq = freq
+                best_sal = sal
+        return [best] if best is not None else []
 
     # ──────────────────────────────────────────────────────────
 

--- a/tests/test_feature_miner_benign_freq.py
+++ b/tests/test_feature_miner_benign_freq.py
@@ -18,7 +18,7 @@ def test_benign_freq_filter_removes_common_token():
     assert feats == ["call:CreateFileW"]
 
 
-def test_benign_freq_filter_keeps_one_token_when_all_removed():
+def test_benign_freq_filter_selects_lowest_freq_token():
     g = HeteroData()
     g["func"].x = torch.zeros(2, 1)
     g["func"].name = ["CreateFileA", "CreateFileW"]
@@ -26,9 +26,25 @@ def test_benign_freq_filter_keeps_one_token_when_all_removed():
     sal = torch.tensor([1.0, 0.9])
     miner = FeatureMiner(
         top_k=2,
+        benign_freqs={"call:CreateFileA": 20, "call:CreateFileW": 10},
+        freq_threshold=5,
+    )
+    feats = miner(g, sal)
+
+    assert feats == ["call:CreateFileW"]
+
+
+def test_benign_freq_filter_breaks_tie_with_saliency():
+    g = HeteroData()
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["CreateFileA", "CreateFileW"]
+
+    sal = torch.tensor([0.5, 0.9])
+    miner = FeatureMiner(
+        top_k=2,
         benign_freqs={"call:CreateFileA": 10, "call:CreateFileW": 10},
         freq_threshold=5,
     )
     feats = miner(g, sal)
 
-    assert feats == ["call:CreateFileA"]
+    assert feats == ["call:CreateFileW"]


### PR DESCRIPTION
## Summary
- refine FeatureMiner's benign frequency filtering with saliency-based tie-break
- adapt unit tests for new behavior and add tie-breaking test

## Testing
- `pytest tests/test_feature_miner_benign_freq.py -q`
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884671ef338832ea79d17ede038154c