### PR TITLE
Update freq threshold step logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -746,7 +746,8 @@ def evaluate_single(
                 group_cnt = (group_cnt or 0) + 1
             else:
                 comb_ratio = min(1.0, comb_ratio + comb_ratio_step)
-            freq_thresh = max(1, freq_thresh - freq_threshold_step) if freq_threshold_step > 0 else 1
+            if freq_threshold_step > 0:
+                freq_thresh = max(1, freq_thresh - freq_threshold_step)
             result = _build_and_eval(
                 freq_thresh,
                 group_cnt,

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1386,3 +1386,4 @@ def test_fp_retry_selects_best_result(tmp_path, monkeypatch):
     assert res["false_positive"] is False
     assert res["detected"] is False
     assert res["rule_length"] == 0
+    assert res["freq_threshold"] == 10


### PR DESCRIPTION
## Summary
- keep freq_threshold unchanged when freq_threshold_step is zero
- verify freq_threshold stays at default in retry test

## Testing
- `python -m pytest tests/test_explainer_rule_eval_cli.py::test_fp_retry_selects_best_result -vv`
- `python -m pytest tests/test_explainer_rule_eval_cli.py::test_fp_retry_exclude_tokens -vv`

------
https://chatgpt.com/codex/tasks/task_e_688469f54c8c832ea217d0ff8486e178