### PR TITLE
Implement saliency-based candidate ranking

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -184,12 +184,10 @@ class FeatureMiner:
             raw_features.extend(cand)
             sal_val = float(flat_sal[global_idx])
             for feat in cand:
-                prev = feat_sal_map.get(feat)
-                if prev is None or sal_val > prev:
-                    feat_sal_map[feat] = sal_val
+                feat_sal_map[feat] = feat_sal_map.get(feat, 0.0) + sal_val
 
         # 3) 정규화 & dedup 정렬
-        cleaned = self._normalize_and_rank(raw_features)
+        cleaned = self._normalize_and_rank(raw_features, feat_sal_map)
         cleaned = self._filter_by_benign_freq(cleaned, feat_sal_map)
         if sal_stats is not None:
             cleaned = self._filter_by_saliency_stats(cleaned, sal_stats)
@@ -564,16 +562,22 @@ class FeatureMiner:
 
     # ───────────────────────────────────────── helpers (post) ―─
 
-    def _normalize_and_rank(self, feats: Sequence[str]) -> List[str]:
+    def _normalize_and_rank(
+        self, feats: Sequence[str], sal_map: Dict[str, float] | None = None
+    ) -> List[str]:
         """
         • 중복 제거
         • 출현 빈도 + saliency 기반 단순 정렬
           (현재 saliency는 node별이므로, 동일 스트링이 여러 노드서 나오면 freq 교차 반영)
         """
         cnt = Counter(feats)
-        ranked = sorted(cnt.items(), key=lambda kv: (-kv[1], kv[0]))
+        items = []
+        for feat, freq in cnt.items():
+            sal = sal_map.get(feat, 0.0) if sal_map else 0.0
+            items.append((feat, sal, freq))
+        ranked = sorted(items, key=lambda t: (-t[1], -t[2], t[0]))
         filtered: List[str] = []
-        for feat, _ in ranked:
+        for feat, _, _ in ranked:
             token = feat
             if token.startswith(
                 ("call:", "chain:", "import:", "syscall:", "path:", "reg:", "url:")
@@ -593,7 +597,8 @@ class FeatureMiner:
             if self._ADDR_RX.fullmatch(token):
                 continue
             if self._SEC_RX.fullmatch(token):
-                continue
+                if token.lower() in {".text", ".data", ".rdata", ".rsrc"}:
+                    continue
             filtered.append(feat)
         # 타입 편중 완화를 위해 같은 prefix 그룹별 한도를 둘 수도 있음 (TODO)
         return filtered

--- a/tests/test_feature_miner_saliency_rank.py
+++ b/tests/test_feature_miner_saliency_rank.py
@@ -1,0 +1,14 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_normalize_and_rank_prefers_higher_saliency():
+    miner = FeatureMiner(top_k=1)
+    feats = ["call:FuncA", "call:FuncB", "call:FuncB"]
+    sal_map = {"call:FuncA": 5.0, "call:FuncB": 1.0}
+    out = miner._normalize_and_rank(feats, sal_map)
+    assert out[0] == "call:FuncA"
+    assert out[1] == "call:FuncB"


### PR DESCRIPTION
## Summary
- accumulate saliency per token while mining
- sort mined tokens by saliency sum then frequency
- keep non-standard section names
- test saliency ranking logic

## Testing
- `pytest tests/test_feature_miner_* -q`

------
https://chatgpt.com/codex/tasks/task_e_68846b9e810c832e9af812a01a8c8bac