### PR TITLE
Fix classifier eval mode

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -123,6 +123,7 @@ def classify(
 ) -> tuple[int, float, float]:
     device_t = torch.device(device)
     model = RESGCLClassifier.load_from_checkpoint(ckpt, map_location=device_t)
+    model.eval()
     attr = getattr(getattr(model, "encoder", None), "attr_names", None)
 
     ds = SingleGraphDataset(graph, work_dir / "data" / "embeds")


### PR DESCRIPTION
## Summary
- ensure RESGCLClassifier runs in eval mode in `single_sample_classify.py`

## Testing
- `black scripts/single_sample_classify.py`
- `pytest -q` *(fails: ModuleNotFoundError for torch, psutil, gymnasium)*

------
https://chatgpt.com/codex/tasks/task_e_688545572fb4832eb20650783b063884