### PR TITLE
Handle missing sha256 in single sample classify

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -7,6 +7,11 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Sequence
+from uuid import uuid4
+
+from src.common.utils import get_logger
+
+LOGGER = get_logger(__name__)
 
 __all__ = ["classify_from_json", "main"]
 
@@ -75,7 +80,11 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> tuple[Path, str]
     shutil.copy2(json_path, dst)
 
     with dst.open("r", encoding="utf-8") as f:
-        sha = json.load(f).get("get_metadata", {}).get("sha256", dst.stem)
+        js = json.load(f)
+        sha = js.get("get_metadata", {}).get("sha256")
+    if not sha:
+        sha = uuid4().hex
+        LOGGER.warning("sha256 missing in %s; generated %s", dst.name, sha)
 
     common = dict(
         input_dir=str(raw_dir),


### PR DESCRIPTION
## Summary
- generate UUID when JSON lacks `get_metadata.sha256`
- warn about the missing hash

## Testing
- `python -m py_compile scripts/single_sample_classify.py`
- `black --check scripts/single_sample_classify.py`
- `pytest -k single_sample_classify -q` *(fails: Missing torch_geometric build deps)*

------
https://chatgpt.com/codex/tasks/task_e_68854c4a6748832eb5ba4b233035bfb4