### PR TITLE
Fix infer to request logits

### DIFF
--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -146,7 +146,7 @@ def infer(
     for batch in loader:
         batch = batch.to(device, non_blocking=True)
         with scaler_ctx():
-            logits = model(batch)  # shape [B]
+            logits = model(batch, return_logits=True)  # shape [B]
             probs = logits.sigmoid().detach().cpu()
         preds = (probs >= threshold).int()
 


### PR DESCRIPTION
## Summary
- call models with `return_logits=True` when running inference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68855376867c832e93b684cf0c674abc