### PR TITLE
Improve preprocessing logging

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -19,6 +19,10 @@ import torch
 from torch_geometric.loader import DataLoader as GeoDataLoader
 from torch_geometric.data import InMemoryDataset, HeteroData
 
+from src.common.logger import get_logger
+
+logger = get_logger(__name__)
+
 from src.graphs.features.cache import load_tensor
 from src.cli.preprocessing import run_json, run_graphs, run_embeds
 from src.cli.detect import collate_graphs, infer
@@ -47,6 +51,8 @@ class SingleGraphDataset(InMemoryDataset):
                     store.x = torch.cat([store.x, feat], dim=-1)
                 else:
                     store.x = feat
+            else:
+                logger.warning("Embedding file missing: %s", embed_file)
         g.sha256 = sha
         g = GraphDataset._ensure_num_nodes(g)
         g = GraphDataset._ensure_x(g)
@@ -96,7 +102,7 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> tuple[Path, str]
             **common,
         )
     )
-    run_embeds(
+    processed, skipped = run_embeds(
         argparse.Namespace(
             input_dir=None,
             model_name="microsoft/codebert-base",
@@ -104,6 +110,9 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> tuple[Path, str]
             device=device,
             **{k: v for k, v in common.items() if k != "input_dir"},
         )
+    )
+    logger.info(
+        "[PREPROCESS] embed creation: created=%d skipped=%d", processed, skipped
     )
 
     hetero_dir = work_dir / "data" / "hetero"

--- a/src/cli/preprocessing.py
+++ b/src/cli/preprocessing.py
@@ -310,8 +310,11 @@ def run_splits(args: argparse.Namespace) -> None:
 # 4. EMBEDS
 # ────────────────────────────────────────────────────────────────
 @register_stage("embeds")
-def run_embeds(args: argparse.Namespace) -> None:
-    """Stage 4 – Code‑LLM 임베딩 캐시."""
+def run_embeds(args: argparse.Namespace) -> tuple[int, int]:
+    """Stage 4 – Code‑LLM 임베딩 캐시.
+
+    Returns the number of created and skipped embeddings.
+    """
     from src.models.llm_embed import CodeLLMNodeFeat, embed_corpus
 
     logger = _get_logger(args.log_level)
@@ -331,13 +334,15 @@ def run_embeds(args: argparse.Namespace) -> None:
         encoder.to(args.device)
         embeds_dir = Path(args.out_dir, "data", "embeds")
         ensure_dir(embeds_dir)
-        embed_corpus(
+        processed, skipped = embed_corpus(
             encoder,
             hetero_dir=hetero_dir,
             out_dir=embeds_dir,
             batch_size=args.batch_size,
             overwrite=args.overwrite,
         )
+        logger.info("[EMBEDS] created=%d skipped=%d", processed, skipped)
+        return processed, skipped
     except Exception as exc:  # noqa: BLE001
         logger.exception("Embeds stage failed")
         raise StageError from exc

--- a/src/models/llm_embed.py
+++ b/src/models/llm_embed.py
@@ -235,7 +235,7 @@ def embed_corpus(
     out_dir: Path,
     batch_size: int = 32,
     overwrite: bool = False,
-) -> None:
+) -> tuple[int, int]:
     """Encode all ``token`` nodes under ``hetero_dir`` and cache embeddings.
 
     Parameters
@@ -250,6 +250,11 @@ def embed_corpus(
         Mini-batch size for encoding.
     overwrite : bool, default False
         Replace existing feature files.
+
+    Returns
+    -------
+    tuple[int, int]
+        Number of processed and skipped graphs.
     """
 
     import torch
@@ -349,6 +354,9 @@ def embed_corpus(
         save_tensor(out_name, feat, out_dir, overwrite=overwrite)
         processed += 1
 
-    LOGGER.info("embed_corpus completed: processed=%d skipped=%d", processed, skipped)
+    LOGGER.info(
+        "embed_corpus completed: processed=%d skipped=%d", processed, skipped
+    )
     if processed == 0:
         raise RuntimeError("No graphs contained token nodes")
+    return processed, skipped


### PR DESCRIPTION
## Summary
- warn when node embedding files are missing
- report processed/skipped counts in embedding stage

## Testing
- `python -m py_compile scripts/single_sample_classify.py src/models/llm_embed.py src/cli/preprocessing.py`
- `pytest -q` *(fails: missing heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68855586bbe8832eb402e845ec3b8741