### PR TITLE
Improve load_from_checkpoint logging

### DIFF
--- a/src/models/gnn/res_wrapper.py
+++ b/src/models/gnn/res_wrapper.py
@@ -26,14 +26,13 @@ probs = clf(data)                # (batch,)
 """
 from __future__ import annotations
 
-from typing import Union, Optional, List, Dict, Callable
+from typing import Union, Dict
 from pathlib import Path
 try:  # torch<2.3 does not expose add_safe_globals
     from torch.serialization import add_safe_globals
 except Exception:  # pragma: no cover - optional API
     def add_safe_globals(*_args, **_kwargs):
         pass
-import logging
 
 import torch
 from torch import nn, Tensor
@@ -179,8 +178,23 @@ class RESGCLClassifier(nn.Module):
 
     # ------------------------------------------------------------------ #
     @classmethod
-    def load_from_checkpoint(cls, path, *, map_location=None, dtype=None) -> "RESGCLClassifier":
-        """Load classifier from ``torch.save`` checkpoint."""
+    def load_from_checkpoint(
+        cls,
+        path,
+        *,
+        map_location=None,
+        dtype=None,
+        strict: bool = False,
+    ) -> "RESGCLClassifier":
+        """Load classifier from ``torch.save`` checkpoint.
+
+        Parameters
+        ----------
+        strict : bool, default False
+            Whether to enforce that the checkpoint exactly matches the model
+            architecture. If ``False``, missing or unexpected keys are loaded in
+            a non-strict fashion with warnings logged.
+        """
         obj = torch.load(path, map_location=map_location, weights_only=False)
 
         if isinstance(obj, cls):
@@ -218,6 +232,9 @@ class RESGCLClassifier(nn.Module):
             node_types = list(meta.get("node_types", []))
             edge_types = [tuple(e) for e in meta.get("edge_types", [])]
             in_dims = {k: int(v) for k, v in meta.get("in_dims", {}).items()}
+            zero_in = [nt for nt, d in in_dims.items() if d == 0]
+            if zero_in:
+                LOGGER.warning("Input dimension 0 for node types: %s", zero_in)
             num_relations = int(meta.get("num_relations", len(edge_types)))
 
             out_w = enc_state["out_proj.weight"]
@@ -244,12 +261,20 @@ class RESGCLClassifier(nn.Module):
                 num_layers=num_layers,
                 out_dim=out_dim,
             )
-            encoder.load_state_dict(enc_state, strict=False)
+            _res = encoder.load_state_dict(enc_state, strict=strict)
+            if _res.missing_keys:
+                LOGGER.warning("Missing encoder keys: %s", _res.missing_keys)
+            if _res.unexpected_keys:
+                LOGGER.warning("Unexpected encoder keys: %s", _res.unexpected_keys)
         else:
             encoder = RGCNEncoder._from_state_dict(enc_state, attr_names=attr_names)
 
         model = cls(encoder=encoder, dtype=dtype)
-        model.load_state_dict(state, strict=False)
+        res = model.load_state_dict(state, strict=strict)
+        if res.missing_keys:
+            LOGGER.warning("Missing model keys: %s", res.missing_keys)
+        if res.unexpected_keys:
+            LOGGER.warning("Unexpected model keys: %s", res.unexpected_keys)
         return model
 
     # ------------------------------------------------------------------ #
@@ -278,6 +303,18 @@ class RESGCLClassifier(nn.Module):
                     LOGGER.info(f"Re-initialized input projection for node type '{nt}' with new in_dim={in_channels}")
 
     @classmethod
-    def load_pretrained(cls, path, *, map_location=None, dtype=None) -> "RESGCLClassifier":
+    def load_pretrained(
+        cls,
+        path,
+        *,
+        map_location=None,
+        dtype=None,
+        strict: bool = False,
+    ) -> "RESGCLClassifier":
         """Backward-compatible alias for :meth:`load_from_checkpoint`."""
-        return cls.load_from_checkpoint(path, map_location=map_location, dtype=dtype)
+        return cls.load_from_checkpoint(
+            path,
+            map_location=map_location,
+            dtype=dtype,
+            strict=strict,
+        )


### PR DESCRIPTION
## Summary
- warn when loading model with missing or unexpected keys
- alert if any input dimensions are zero in checkpoint metadata
- allow strict flag on load_from_checkpoint and load_pretrained

## Testing
- `ruff check src/models/gnn/res_wrapper.py`
- `pytest tests/test_resgcl_load_meta.py tests/test_encoder_load.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6885557ca60c832e98162af8437c3ad5