### PR TITLE
Ensure classifier moves to device after load

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -123,6 +123,7 @@ def classify(
 ) -> tuple[int, float, float]:
     device_t = torch.device(device)
     model = RESGCLClassifier.load_from_checkpoint(ckpt, map_location=device_t)
+    model.to(device_t)
     model.eval()
     attr = getattr(getattr(model, "encoder", None), "attr_names", None)
 

--- a/src/cli/rulegen_cli.py
+++ b/src/cli/rulegen_cli.py
@@ -303,6 +303,7 @@ def cmd_feature_mine(args: argparse.Namespace) -> None:
             classifier = RESGCLClassifier.load_from_checkpoint(
                 args.classifier_ckpt, map_location="cpu"
             )
+            classifier.to(device).eval()
         except FileNotFoundError:
             logger.error("Classifier checkpoint not found at %s", args.classifier_ckpt)
             raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add missing `model.to(device_t)` in `single_sample_classify.py`
- move rulegen CLI classifier to the selected device

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688555728de0832eac4fcfe63614de1b