### PR TITLE
Sync classification metadata with checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,11 @@ label, prob, _ = classify_from_json(js, Path("models/gnn/res_gcl.pt"))
 print(label, prob)
 ```
 
+모델과 입력 그래프의 메타데이터 차원이 다를 경우 자동으로 재초기화 됩니다.
+분류 정확도를 위해 학습 당시 사용한 임베딩 설정(`attr_dim`, `vocab_size`,
+`model_name`)이 체크포인트와 함께 저장되어야 하며, `classify_from_json`이
+이를 읽어 `run_embeds` 단계에 전달합니다.
+
 `meta.csv`는 다음과 같이 생성합니다.
 ```bash
 python -m cli.preprocessing --input-dir ../maldata/benign --out . labels --label 0 --csv data/meta.csv

--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -54,7 +54,15 @@ class SingleGraphDataset(InMemoryDataset):
         return g
 
 
-def preprocess(json_path: Path, work_dir: Path, device: str) -> tuple[Path, str]:
+def preprocess(
+    json_path: Path,
+    work_dir: Path,
+    device: str,
+    *,
+    model_name: str = "microsoft/codebert-base",
+    attr_dim: int = 32,
+    vocab_size: int = 0,
+) -> tuple[Path, str]:
     """Run preprocessing stages for a single JSON sample."""
     raw_dir = work_dir / "raw"
     views_dir = work_dir / "data" / "views"
@@ -99,9 +107,11 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> tuple[Path, str]
     run_embeds(
         argparse.Namespace(
             input_dir=None,
-            model_name="microsoft/codebert-base",
+            model_name=model_name,
             batch_size=32,
             device=device,
+            attr_dim=attr_dim,
+            vocab_size=vocab_size,
             **{k: v for k, v in common.items() if k != "input_dir"},
         )
     )
@@ -115,14 +125,14 @@ def preprocess(json_path: Path, work_dir: Path, device: str) -> tuple[Path, str]
 
 def classify(
     graph: Path,
-    ckpt: Path,
+    model: RESGCLClassifier,
     work_dir: Path,
     device: str,
     threshold: float,
     amp: bool,
 ) -> tuple[int, float, float]:
     device_t = torch.device(device)
-    model = RESGCLClassifier.load_from_checkpoint(ckpt, map_location=device_t)
+    model = model.to(device_t)
     model.eval()
     attr = getattr(getattr(model, "encoder", None), "attr_names", None)
 
@@ -150,15 +160,54 @@ def classify_from_json(
     amp: bool = False,
 ) -> tuple[int, float, float]:
     """Classify a single JSON object and return (label, prob, cert_radius)."""
+    device_t = torch.device(device)
+    model = RESGCLClassifier.load_from_checkpoint(ckpt, map_location=device_t)
+    meta_path = ckpt.with_suffix(".meta.pkl")
+    meta = {}
+    if meta_path.is_file():
+        try:
+            from torch.serialization import add_safe_globals
+            from src.graphs.normalizers.schema import NodeType
+
+            add_safe_globals([NodeType])
+            meta = torch.load(meta_path, weights_only=False)
+        except Exception:
+            meta = {}
+
     with tempfile.TemporaryDirectory() as tmpdir:
         work_dir = Path(tmpdir)
         json_path = work_dir / "sample.json"
         with json_path.open("w", encoding="utf-8") as f:
             json.dump(json_obj, f)
-        graph, _ = preprocess(json_path, work_dir, device)
+
+        graph, _ = preprocess(
+            json_path,
+            work_dir,
+            device,
+            model_name=meta.get("model_name", "microsoft/codebert-base"),
+            attr_dim=int(meta.get("attr_dim", 32)),
+            vocab_size=int(meta.get("vocab_size", 0)),
+        )
+
+        # Re-init encoder if feature dimensions do not match
+        in_dims = meta.get("in_dims")
+        if in_dims:
+            mismatch = False
+            for nt, dim in in_dims.items():
+                proj = model.encoder.input_proj.get(nt)
+                if proj is None or proj.in_features != int(dim):
+                    mismatch = True
+                    break
+            if mismatch:
+                model.reinit_input_dims(
+                    in_dims,
+                    attr_names=meta.get("attr_names"),
+                    vocab_size=meta.get("vocab_size", 0),
+                )
+
         pred, prob, radius = classify(
             graph,
-            ckpt,
+            model,
             work_dir,
             device,
             threshold,
@@ -208,15 +257,16 @@ def main(argv: Sequence[str] | None = None) -> None:
     with args.out.open("w", encoding="utf-8") as f:
         f.write("sha256,pred,prob,cert_radius\n")
         for json_fp in json_files:
-            graph, sha = preprocess(json_fp, args.work_dir, args.device)
-            pred, prob, radius = classify(
-                graph,
+            with json_fp.open("r", encoding="utf-8") as jf:
+                js = json.load(jf)
+            pred, prob, radius = classify_from_json(
+                js,
                 args.model,
-                args.work_dir,
-                args.device,
-                args.threshold,
-                args.amp,
+                device=args.device,
+                threshold=args.threshold,
+                amp=args.amp,
             )
+            sha = js.get("get_metadata", {}).get("sha256", json_fp.stem)
             f.write(f"{sha},{pred},{prob:.6f},{radius}\n")
             if sha in labels:
                 y_true.append(labels[sha])


### PR DESCRIPTION
## Summary
- update `single_sample_classify` to read checkpoint metadata before preprocessing
- reinitialize encoder input layers when dimensions mismatch
- forward model embedding parameters to `run_embeds`
- document metadata alignment in the README

## Testing
- `pytest -q` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688555c2cb50832eb7740bfd6f9858e0