### PR TITLE
Fix ModuleDict lookup in single-sample classifier

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -203,7 +203,7 @@ def classify_from_json(
         if in_dims:
             mismatch = False
             for nt, dim in in_dims.items():
-                proj = model.encoder.input_proj.get(nt)
+                proj = model.encoder.input_proj[nt] if nt in model.encoder.input_proj else None
                 if proj is None or proj.in_features != int(dim):
                     mismatch = True
                     break


### PR DESCRIPTION
## Summary
- resolve AttributeError when checking input projection in `classify_from_json`

## Testing
- `pytest -q tests/test_auto_reinit_input_dim.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688559795d30832e8ecace9debef5710