### PR TITLE
Add optional embedding usage for single-sample classification

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -31,9 +31,10 @@ from src.models.gnn.res_wrapper import RESGCLClassifier
 
 
 class SingleGraphDataset(InMemoryDataset):
-    def __init__(self, graph_path: Path, embed_dir: Path | None):
+    def __init__(self, graph_path: Path, embed_dir: Path | None, *, load_embeds: bool = True):
         self.graph_path = graph_path
         self.embed_dir = embed_dir
+        self.load_embeds = load_embeds
         super().__init__(None, None, None, None)
 
     def len(self) -> int:  # type: ignore[override]
@@ -42,7 +43,7 @@ class SingleGraphDataset(InMemoryDataset):
     def get(self, idx: int) -> HeteroData:  # type: ignore[override]
         g = torch.load(self.graph_path, map_location="cpu", weights_only=False)
         sha = self.graph_path.stem
-        if self.embed_dir:
+        if self.embed_dir and self.load_embeds:
             embed_file = self.embed_dir / f"{sha}.ftr"
             if embed_file.is_file():
                 feat = load_tensor(sha, self.embed_dir, mmap=False)
@@ -68,6 +69,7 @@ def preprocess(
     model_name: str = "microsoft/codebert-base",
     attr_dim: int = 32,
     vocab_size: int = 0,
+    use_embeds: bool = True,
 ) -> tuple[Path, str]:
     """Run preprocessing stages for a single JSON sample."""
     raw_dir = work_dir / "raw"
@@ -110,20 +112,22 @@ def preprocess(
             **common,
         )
     )
-    processed, skipped = run_embeds(
-        argparse.Namespace(
-            input_dir=None,
-            model_name=model_name,
-            batch_size=32,
-            device=device,
-            attr_dim=attr_dim,
-            vocab_size=vocab_size,
-            **{k: v for k, v in common.items() if k != "input_dir"},
+    processed = skipped = 0
+    if use_embeds:
+        processed, skipped = run_embeds(
+            argparse.Namespace(
+                input_dir=None,
+                model_name=model_name,
+                batch_size=32,
+                device=device,
+                attr_dim=attr_dim,
+                vocab_size=vocab_size,
+                **{k: v for k, v in common.items() if k != "input_dir"},
+            )
         )
-    )
-    logger.info(
-        "[PREPROCESS] embed creation: created=%d skipped=%d", processed, skipped
-    )
+        logger.info(
+            "[PREPROCESS] embed creation: created=%d skipped=%d", processed, skipped
+        )
 
     hetero_dir = work_dir / "data" / "hetero"
     graph_path = hetero_dir / f"{sha}.pt"
@@ -139,13 +143,15 @@ def classify(
     device: str,
     threshold: float,
     amp: bool,
+    *,
+    load_embeds: bool = True,
 ) -> tuple[int, float, float]:
     device_t = torch.device(device)
     model = model.to(device_t)
     model.eval()
     attr = getattr(getattr(model, "encoder", None), "attr_names", None)
 
-    ds = SingleGraphDataset(graph, work_dir / "data" / "embeds")
+    ds = SingleGraphDataset(graph, work_dir / "data" / "embeds", load_embeds=load_embeds)
     loader = GeoDataLoader(
         ds,
         batch_size=1,
@@ -167,6 +173,7 @@ def classify_from_json(
     device: str = "cuda" if torch.cuda.is_available() else "cpu",
     threshold: float = 0.5,
     amp: bool = False,
+    use_embeds: bool = True,
 ) -> tuple[int, float, float]:
     """Classify a single JSON object and return (label, prob, cert_radius)."""
     device_t = torch.device(device)
@@ -196,6 +203,7 @@ def classify_from_json(
             model_name=meta.get("model_name", "microsoft/codebert-base"),
             attr_dim=int(meta.get("attr_dim", 32)),
             vocab_size=int(meta.get("vocab_size", 0)),
+            use_embeds=use_embeds,
         )
 
         # Re-init encoder if feature dimensions do not match
@@ -221,6 +229,7 @@ def classify_from_json(
             device,
             threshold,
             amp,
+            load_embeds=use_embeds,
         )
         return pred, prob, radius
 
@@ -241,6 +250,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     p.add_argument("--threshold", type=float, default=0.5)
     p.add_argument("--amp", action="store_true")
+    p.add_argument(
+        "--no-embeds",
+        action="store_true",
+        help="Skip creating and loading token embeddings",
+    )
     args = p.parse_args(argv)
 
     if not args.json_dir and not args.json:
@@ -263,6 +277,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     args.out.parent.mkdir(parents=True, exist_ok=True)
     y_true = []
     y_pred = []
+    use_embeds = not args.no_embeds
+
     with args.out.open("w", encoding="utf-8") as f:
         f.write("sha256,pred,prob,cert_radius\n")
         for json_fp in json_files:
@@ -274,6 +290,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 device=args.device,
                 threshold=args.threshold,
                 amp=args.amp,
+                use_embeds=use_embeds,
             )
             sha = js.get("get_metadata", {}).get("sha256", json_fp.stem)
             f.write(f"{sha},{pred},{prob:.6f},{radius}\n")


### PR DESCRIPTION
## Summary
- add `use_embeds` switch in preprocessing
- conditionally load embeddings in `SingleGraphDataset`
- propagate the option through `classify` and `classify_from_json`
- expose CLI flag `--no-embeds` for `single_sample_classify.py`

## Testing
- `python -m py_compile scripts/single_sample_classify.py`
- `pytest tests/test_train_res_gcl_no_embeds.py::test_train_res_gcl_no_embeds -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*

------
https://chatgpt.com/codex/tasks/task_e_6885970ecad8832eb0e6d59712c62386