### PR TITLE
Implement auto input dim reinit in detect

### DIFF
--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -204,7 +204,53 @@ def main(argv: list[str] | None = None) -> None:
     model = load_model(args.ckpt, device)
     attr_names = getattr(getattr(model, "encoder", None), "attr_names", None)
 
+    # ------------------------------------------------------------------
+    # Load meta snapshot to obtain original input dimensions
+    # ------------------------------------------------------------------
+    meta_in_dims: dict[str, int] = {}
+    meta_path = args.ckpt.with_suffix(".meta.pkl")
+    if meta_path.is_file():
+        try:
+            from torch.serialization import add_safe_globals  # type: ignore
+            from src.graphs.normalizers.schema import NodeType
+
+            add_safe_globals([NodeType])
+            meta = torch.load(meta_path, map_location="cpu", weights_only=False)
+            if isinstance(meta, dict):
+                meta_in_dims = {k: int(v) for k, v in meta.get("in_dims", {}).items()}
+        except Exception as exc:  # pragma: no cover - optional I/O
+            print(
+                f"[WARN] Failed to load meta snapshot {meta_path}: {exc}",
+                file=sys.stderr,
+            )
+
     ds = GraphFileDataset(graph_files)
+
+    # Inspect the first graph to check for feature dimension mismatches
+    sample_dims: dict[str, int] = {}
+    if len(ds) > 0:
+        try:
+            sample = ds.get(0)
+            for nt in sample.node_types:
+                if hasattr(sample[nt], "x") and sample[nt].x is not None:
+                    sample_dims[nt] = int(sample[nt].x.size(1))
+        except Exception:
+            sample_dims = {}
+
+    if sample_dims and any(
+        meta_in_dims.get(nt) != sample_dims.get(nt) for nt in sample_dims
+    ):
+        vocab_size = (
+            model.encoder.meta_embed.num_embeddings
+            if getattr(getattr(model, "encoder", None), "meta_embed", None) is not None
+            else 0
+        )
+        model.reinit_input_dims(
+            in_dims=sample_dims,
+            attr_names=getattr(getattr(model, "encoder", None), "attr_names", None),
+            vocab_size=vocab_size,
+        )
+
     loader: DataLoader = GeoDataLoader(
         ds,
         batch_size=args.batch_size,


### PR DESCRIPTION
## Summary
- load in_dims metadata when loading a checkpoint in `detect.py`
- compare the first graph's feature dimensions against meta info
- reinit classifier input layers on mismatch

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_688599529ee8832e871b7b319e2c5861