### PR TITLE
Ensure count mode clamps to available features

### DIFF
--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -259,7 +259,10 @@ class YaraBuilder:
             thresh = max(1, math.ceil(n_feats * self.percentage / 100.0))
             cond_line = f"    {thresh} of them"
         elif self.condition_type == "count":
-            cond_line = f"    {self.min_count} of them"
+            required = self.min_count if self.min_count is not None else n_feats
+            required = min(required, n_feats)
+            required = max(1, required)
+            cond_line = f"    {required} of them"
         else:  # combo
             group_count = sum(1 for v in groups.values() if v)
             feat_count = n_feats

--- a/tests/test_yara_builder_count.py
+++ b/tests/test_yara_builder_count.py
@@ -8,3 +8,11 @@ def test_count_condition():
     assert "2 of them" in rule
     ok, err = builder.validate(rule)
     assert ok, err
+
+
+def test_count_caps_at_len():
+    builder = YaraBuilder(condition_type="count", min_count=3)
+    rule = builder.build(["featA", "featB"])
+    assert "2 of them" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err


### PR DESCRIPTION
## Summary
- adjust `count` condition to clamp to the number of generated strings
- add regression test for clamping behaviour

## Testing
- `pytest -q tests/test_yara_builder_count.py`
- `pytest -q tests/test_yara_builder_prefix_strip.py tests/test_yara_builder_percentage.py tests/test_yara_builder_modifiers.py tests/test_yara_builder_combo.py tests/test_yara_builder_count.py`


------
https://chatgpt.com/codex/tasks/task_e_6885cef0d2d4832e858eba0324832c0f