### PR TITLE
Update combo thresholds for small feature sets

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -202,8 +202,10 @@ python -m cli.rulegen_cli ppo-train \
 
 `src.cli.explainer_rule_eval`는 그래프와 샘플을 입력으로 중요 노드를 기반한
 YARA 룰을 생성해 탐지 여부를 확인합니다. 기본 `--condition-type`은 `combo`
-이며 각 그룹의 50% 이상이 매치되어야 합니다. 단, 그룹이 하나이거나 특징이
-2개 이하일 때는 자동으로 `any` 조건으로 전환됩니다.
+이며 각 그룹의 50% 이상이 매치되어야 합니다. 그룹이 하나이거나 특징이
+2개 이하일 경우 별도 설정이 없으면 자동으로 `any` 조건을 사용하지만,
+`--group-min-count`나 `--group-percentage`가 지정된 경우 해당 값에 맞춰
+최소 매치 수가 계산됩니다.
 
 ```bash
 python -m src.cli.explainer_rule_eval \

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -249,7 +249,7 @@ class YaraBuilder:
 
         # 4) condition
         n_feats = len(unique_feats)
-        if n_feats == 1:
+        if n_feats == 1 and self.condition_type != "combo":
             cond_line = "    all of them"
         elif self.condition_type == "any":
             cond_line = "    any of them"
@@ -268,8 +268,21 @@ class YaraBuilder:
             feat_count = n_feats
             if feat_count <= 2:
                 if group_count == 1:
-                    # Require all available features when only a single group exists
-                    cond_line = "    all of them"
+                    tag = next(t for t, v in groups.items() if v)
+                    feats_list = groups[tag]
+                    if tag == "m":
+                        cond_line = f"    {len(feats_list)} of ($m*)"
+                    elif self.group_min_count is not None:
+                        required = min(self.group_min_count, len(feats_list))
+                        cond_line = f"    {required} of (${tag}*)"
+                    elif self.group_percentage is not None:
+                        pct = self.group_percentage
+                        if self.adjust_group_percentage:
+                            pct = self._scaled_group_percentage(len(feats_list))
+                        required = max(1, math.ceil(len(feats_list) * pct / 100.0))
+                        cond_line = f"    {required} of (${tag}*)"
+                    else:
+                        cond_line = "    any of them"
                 else:
                     parts = []
                     for tag, feats_list in groups.items():
@@ -277,8 +290,17 @@ class YaraBuilder:
                             continue
                         if tag == "m":
                             parts.append(f"{len(feats_list)} of ($m*)")
+                            continue
+                        if self.group_min_count is not None:
+                            required = min(self.group_min_count, len(feats_list))
+                        elif self.group_percentage is not None:
+                            pct = self.group_percentage
+                            if self.adjust_group_percentage:
+                                pct = self._scaled_group_percentage(len(feats_list))
+                            required = max(1, math.ceil(len(feats_list) * pct / 100.0))
                         else:
-                            parts.append(f"1 of (${tag}*)")
+                            required = 1
+                        parts.append(f"{required} of (${tag}*)")
                     cond_line = "    " + " and ".join(parts)
             elif group_count <= 1:
                 # Single feature group but more than two features: require all

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -38,7 +38,23 @@ def test_combo_group_min_count_falls_back_any():
 def test_combo_percentage_falls_back_any():
     builder = YaraBuilder(condition_type="combo", group_percentage=50)
     rule = builder.build(["call:A", "call:B"])
-    assert "all of them" in rule
+    assert "1 of ($c*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err
+
+
+def test_combo_group_min_count_small_feat():
+    builder = YaraBuilder(condition_type="combo", group_min_count=2)
+    rule = builder.build(["call:A", "call:B"])
+    assert "2 of ($c*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err
+
+
+def test_combo_percentage_single_feature():
+    builder = YaraBuilder(condition_type="combo", group_percentage=60)
+    rule = builder.build(["call:A"])
+    assert "1 of ($c*)" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 

--- a/tests/test_yara_builder_single_token.py
+++ b/tests/test_yara_builder_single_token.py
@@ -10,6 +10,9 @@ def test_single_token_all_condition(cond):
         kwargs["percentage"] = 50
     builder = YaraBuilder(**kwargs)
     rule = builder.build(["featA"])
-    assert "all of them" in rule
+    if cond == "combo":
+        assert "any of them" in rule
+    else:
+        assert "all of them" in rule
     ok, err = builder.validate(rule)
     assert ok, err


### PR DESCRIPTION
## Summary
- allow combo mode to apply `group_min_count` and `group_percentage` even when only one or two features exist
- default to `any of them` for tiny feature sets
- update quick start docs on rule evaluation
- expand tests for single/grouped small feature scenarios

## Testing
- `pytest tests/test_yara_builder_combo.py tests/test_yara_builder_single_token.py -q`
- `pytest tests/test_yara_builder_count.py tests/test_yara_builder_percentage.py tests/test_yara_builder_combine_rules.py tests/test_yara_builder_prefix_strip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6885cf8ee1d4832e9944d02b4a73c7f6