### PR TITLE
Update combo rule default thresholds

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -227,7 +227,7 @@ def verify_features(
     feat_count = sum(len(v) for v in groups.values())
 
     if group_percentage is not None and (group_count <= 1 or feat_count <= 2):
-        result = bool(matched)
+        result = len(matched) >= 2
         return (result, matched) if return_matched else result
 
     for tag, feats_list in groups.items():

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -282,7 +282,8 @@ class YaraBuilder:
                         required = max(1, math.ceil(len(feats_list) * pct / 100.0))
                         cond_line = f"    {required} of (${tag}*)"
                     else:
-                        cond_line = "    any of them"
+                        required = max(2, len(feats_list))
+                        cond_line = f"    {required} of (${tag}*)"
                 else:
                     parts = []
                     for tag, feats_list in groups.items():


### PR DESCRIPTION
## Summary
- tighten combo mode condition when only one group has <=2 features
- verify feature matcher to require at least two hits in the same case

## Testing
- `python -m src.cli.explainer_rule_eval --help`
- `python` snippet invoking `explainer_rule_eval.main` with dummy graph

------
https://chatgpt.com/codex/tasks/task_e_6885dc7fd110832e92e9e9d4c4413d56