### PR TITLE
Improve feature filtering with malicious frequency stats

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -273,6 +273,8 @@ def evaluate_single(
     min_saliency: float = 1e-3,
     keep_per_type: int = 20,
     benign_freqs: dict[str, int] | None = None,
+    mal_freqs: dict[str, int] | None = None,
+    freq_ratio: float = 1.0,
     freq_threshold: float | int = 10,
     condition_type: str,
     percentage: int,
@@ -375,6 +377,8 @@ def evaluate_single(
             min_saliency=min_saliency,
             keep_per_type=keep_per_type,
             benign_freqs=benign_freqs,
+            mal_freqs=mal_freqs,
+            freq_ratio=freq_ratio,
             freq_threshold=freq_thresh,
         )
 
@@ -862,6 +866,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--benign-freqs", type=Path, help="JSON with benign feature frequencies"
     )
     p.add_argument(
+        "--mal-freqs", type=Path, help="JSON with malicious feature frequencies"
+    )
+    p.add_argument(
+        "--freq-ratio",
+        type=float,
+        default=1.0,
+        help="Filter token when benign >= malicious * ratio",
+    )
+    p.add_argument(
         "--saliency-stats", type=Path, help="JSON with feature saliency stats"
     )
     p.add_argument(
@@ -1004,6 +1017,10 @@ def main(argv: list[str] | None = None) -> None:
     if args.benign_freqs and args.benign_freqs.is_file():
         benign_freqs = json.loads(args.benign_freqs.read_text(encoding="utf-8"))
 
+    mal_freqs = None
+    if args.mal_freqs and args.mal_freqs.is_file():
+        mal_freqs = json.loads(args.mal_freqs.read_text(encoding="utf-8"))
+
     saliency_stats = None
     if args.saliency_stats and args.saliency_stats.is_file():
         saliency_stats = json.loads(args.saliency_stats.read_text(encoding="utf-8"))
@@ -1068,6 +1085,8 @@ def main(argv: list[str] | None = None) -> None:
                 "min_saliency": args.min_saliency,
                 "keep_per_type": args.keep_per_type,
                 "benign_freqs": benign_freqs,
+                "mal_freqs": mal_freqs,
+                "freq_ratio": args.freq_ratio,
                 "freq_threshold": args.freq_threshold,
                 "condition_type": args.condition_type,
                 "percentage": args.percentage,
@@ -1302,6 +1321,8 @@ def main(argv: list[str] | None = None) -> None:
             min_saliency=args.min_saliency,
             keep_per_type=args.keep_per_type,
             benign_freqs=benign_freqs,
+            mal_freqs=mal_freqs,
+            freq_ratio=args.freq_ratio,
             freq_threshold=args.freq_threshold,
             condition_type=args.condition_type,
             percentage=args.percentage,

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -80,6 +80,8 @@ class FeatureMiner:
         min_saliency: float = 1e-3,
         keep_per_type: int = 20,
         benign_freqs: dict[str, int] | None = None,
+        mal_freqs: dict[str, int] | None = None,
+        freq_ratio: float = 1.0,
         freq_threshold: float | int = 0,
     ) -> None:
         """
@@ -91,6 +93,7 @@ class FeatureMiner:
         min_saliency  : 절대 saliency 임계값 (둘 중 하나라도 통과하면 선택).
         keep_per_type : 노드 타입마다 너무 편중되지 않도록 선정 상한.
         saliency_top_percent : 누적 saliency 기준 추가 필터 (0~1 사이).
+        freq_ratio   : benign 빈도와 악성 빈도의 비율 비교시 사용.
         """
         self.top_k = top_k
         self.top_k_percent = top_k_percent
@@ -99,6 +102,8 @@ class FeatureMiner:
         self.min_saliency = min_saliency
         self.keep_per_type = keep_per_type
         self.benign_freqs = benign_freqs
+        self.mal_freqs = mal_freqs
+        self.freq_ratio = float(freq_ratio)
         self.freq_threshold = freq_threshold
 
     # ────────────────────────────────────────── benign freq updates ―
@@ -628,8 +633,12 @@ class FeatureMiner:
         filtered: List[str] = []
         for f in feats:
             freq = self.benign_freqs.get(f)
-            if freq is not None and freq >= threshold:
-                continue
+            mal = self.mal_freqs.get(f) if self.mal_freqs else None
+            if freq is not None:
+                if freq >= threshold:
+                    continue
+                if mal is not None and freq >= mal * self.freq_ratio:
+                    continue
             filtered.append(f)
         if filtered or not feats:
             return filtered

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -75,6 +75,27 @@ def test_build_parser_flush_every():
     assert args.flush_every == 10
 
 
+def test_build_parser_mal_freqs_ratio():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--mal-freqs",
+            "mal.json",
+            "--freq-ratio",
+            "2.0",
+        ]
+    )
+    assert args.mal_freqs == Path("mal.json")
+    assert args.freq_ratio == 2.0
+
+
 def test_cli_runs_and_writes_json(tmp_path, caplog):
     g = HeteroData()
     g["bb"].x = torch.zeros(2, 1)
@@ -1387,3 +1408,97 @@ def test_fp_retry_selects_best_result(tmp_path, monkeypatch):
     assert res["detected"] is False
     assert res["rule_length"] == 0
     assert res["freq_threshold"] == 10
+
+
+def test_mal_freqs_reduce_fp(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["foo", "bar"]
+    g[("func", "cfg", "func")].edge_index = torch.tensor([[0], [1]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"func": torch.tensor([0.9, 0.8])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class FakeMatch:
+        def __init__(self):
+            self.strings = [(0, "$s0", b"x")]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            p = str(path)
+            if "foo" in self.text:
+                return [FakeMatch()]
+            if "bar" in self.text and "sample" in p:
+                return [FakeMatch()]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res_no = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        benign_freqs={"call:foo": 10, "call:bar": 1},
+        freq_threshold=100,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=None,
+        json_match=False,
+        combine_mode="or",
+    )
+
+    res_yes = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        benign_freqs={"call:foo": 10, "call:bar": 1},
+        mal_freqs={"call:foo": 5, "call:bar": 2},
+        freq_ratio=1.0,
+        freq_threshold=100,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=None,
+        json_match=False,
+        combine_mode="or",
+    )
+
+    assert res_no["false_positive"] is True
+    assert res_yes["false_positive"] is False

--- a/tests/test_feature_miner_benign_freq.py
+++ b/tests/test_feature_miner_benign_freq.py
@@ -48,3 +48,21 @@ def test_benign_freq_filter_breaks_tie_with_saliency():
     feats = miner(g, sal)
 
     assert feats == ["call:CreateFileW"]
+
+
+def test_mal_freq_ratio_filters_token(tmp_path):
+    g = HeteroData()
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["CreateFileA", "CreateFileW"]
+
+    sal = torch.tensor([1.0, 0.9])
+    miner = FeatureMiner(
+        top_k=2,
+        benign_freqs={"call:CreateFileA": 10, "call:CreateFileW": 5},
+        mal_freqs={"call:CreateFileA": 5, "call:CreateFileW": 10},
+        freq_threshold=100,
+        freq_ratio=1.0,
+    )
+    feats = miner(g, sal)
+
+    assert feats == ["call:CreateFileW"]


### PR DESCRIPTION
## Summary
- add `mal_freqs` and `freq_ratio` options to `FeatureMiner`
- extend CLI to accept malicious frequency JSON and ratio
- filter features when benign counts exceed malicious counts times ratio
- tests for new parser options, miner filtering and FP reduction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6885dc8ec498832e8e4d21a327461380