### PR TITLE
Update FP retry logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -740,16 +740,18 @@ def evaluate_single(
         comb_ratio = combine_min_ratio
         while retries > 0 and result.get("false_positive"):
             retries -= 1
-            tokens_to_exclude = result.get(
-                "fp_matched_tokens", result.get("matched_tokens", [])
-            )
-            exclude_set.update(t.lower() for t in tokens_to_exclude)
-            if LOGGER.isEnabledFor(logging.DEBUG) and tokens_to_exclude:
-                LOGGER.debug("Excluding tokens due to FP retry: %s", tokens_to_exclude)
-            if group_min_count is not None:
-                group_cnt = (group_cnt or 0) + 1
+            tokens_to_exclude = result.get("fp_matched_tokens", [])
+            if tokens_to_exclude:
+                exclude_set.update(t.lower() for t in tokens_to_exclude)
+                if LOGGER.isEnabledFor(logging.DEBUG):
+                    LOGGER.debug(
+                        "Excluding tokens due to FP retry: %s", tokens_to_exclude
+                    )
             else:
-                comb_ratio = min(1.0, comb_ratio + comb_ratio_step)
+                if group_min_count is not None:
+                    group_cnt = (group_cnt or 0) + 1
+                else:
+                    comb_ratio = min(1.0, comb_ratio + comb_ratio_step)
             if freq_threshold_step > 0:
                 freq_thresh = max(1, freq_thresh - freq_threshold_step)
             result = _build_and_eval(


### PR DESCRIPTION
## Summary
- handle fp retries more carefully in `explainer_rule_eval`

## Testing
- `pytest -k fp_tokens_accumulation -q tests/test_explainer_rule_eval_cli.py` *(fails: skipped due to missing torch_geometric)*

------
https://chatgpt.com/codex/tasks/task_e_6885df8457c4832eb50edc4e42782f12