### PR TITLE
Implement prefix limit in feature miner

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -272,6 +272,7 @@ def evaluate_single(
     dynamic_k: bool = False,
     min_saliency: float = 1e-3,
     keep_per_type: int = 20,
+    max_per_prefix: int | None = None,
     benign_freqs: dict[str, int] | None = None,
     mal_freqs: dict[str, int] | None = None,
     freq_ratio: float = 1.0,
@@ -376,6 +377,7 @@ def evaluate_single(
             dynamic_k=dynamic_k,
             min_saliency=min_saliency,
             keep_per_type=keep_per_type,
+            max_per_prefix=max_per_prefix,
             benign_freqs=benign_freqs,
             mal_freqs=mal_freqs,
             freq_ratio=freq_ratio,
@@ -861,6 +863,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--dynamic-k", action="store_true")
     p.add_argument("--keep-per-type", type=int, default=20)
+    p.add_argument(
+        "--max-per-prefix",
+        type=int,
+        default=3,
+        help="Limit number of features per prefix after ranking",
+    )
     p.add_argument("--min-saliency", type=float, default=1e-3)
     p.add_argument(
         "--benign-freqs", type=Path, help="JSON with benign feature frequencies"
@@ -1084,6 +1092,7 @@ def main(argv: list[str] | None = None) -> None:
                 "dynamic_k": args.dynamic_k,
                 "min_saliency": args.min_saliency,
                 "keep_per_type": args.keep_per_type,
+                "max_per_prefix": args.max_per_prefix,
                 "benign_freqs": benign_freqs,
                 "mal_freqs": mal_freqs,
                 "freq_ratio": args.freq_ratio,
@@ -1320,6 +1329,7 @@ def main(argv: list[str] | None = None) -> None:
             dynamic_k=args.dynamic_k,
             min_saliency=args.min_saliency,
             keep_per_type=args.keep_per_type,
+            max_per_prefix=args.max_per_prefix,
             benign_freqs=benign_freqs,
             mal_freqs=mal_freqs,
             freq_ratio=args.freq_ratio,

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -79,6 +79,7 @@ class FeatureMiner:
         dynamic_k: bool = False,
         min_saliency: float = 1e-3,
         keep_per_type: int = 20,
+        max_per_prefix: int | None = None,
         benign_freqs: dict[str, int] | None = None,
         mal_freqs: dict[str, int] | None = None,
         freq_ratio: float = 1.0,
@@ -92,6 +93,7 @@ class FeatureMiner:
         dynamic_k     : 노드 saliency 분포(평균+표준편차)에 따라 k를 자동 조정한다.
         min_saliency  : 절대 saliency 임계값 (둘 중 하나라도 통과하면 선택).
         keep_per_type : 노드 타입마다 너무 편중되지 않도록 선정 상한.
+        max_per_prefix : 정규화된 후보 토큰을 prefix별로 제한할 최대 개수.
         saliency_top_percent : 누적 saliency 기준 추가 필터 (0~1 사이).
         freq_ratio   : benign 빈도와 악성 빈도의 비율 비교시 사용.
         """
@@ -101,6 +103,7 @@ class FeatureMiner:
         self.dynamic_k = dynamic_k
         self.min_saliency = min_saliency
         self.keep_per_type = keep_per_type
+        self.max_per_prefix = int(max_per_prefix) if max_per_prefix else None
         self.benign_freqs = benign_freqs
         self.mal_freqs = mal_freqs
         self.freq_ratio = float(freq_ratio)
@@ -605,7 +608,25 @@ class FeatureMiner:
                 if token.lower() in {".text", ".data", ".rdata", ".rsrc"}:
                     continue
             filtered.append(feat)
-        # 타입 편중 완화를 위해 같은 prefix 그룹별 한도를 둘 수도 있음 (TODO)
+        if self.max_per_prefix and self.max_per_prefix > 0:
+            result: List[str] = []
+            counts: Dict[str, int] = {}
+
+            def _prefix(s: str) -> str:
+                if s.startswith('"'):
+                    return 'string'
+                if s.startswith("byte["):
+                    return "byte"
+                return s.split(":", 1)[0]
+
+            for f in filtered:
+                pfx = _prefix(f)
+                cnt = counts.get(pfx, 0)
+                if cnt < self.max_per_prefix:
+                    result.append(f)
+                    counts[pfx] = cnt + 1
+            filtered = result
+
         return filtered
 
     def _filter_by_saliency_stats(

--- a/tests/test_feature_miner_prefix_limit.py
+++ b/tests/test_feature_miner_prefix_limit.py
@@ -1,0 +1,31 @@
+import pytest
+pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+from rulegen.feature_miner import FeatureMiner
+
+
+def test_prefix_limit_applied():
+    miner = FeatureMiner(top_k=1, max_per_prefix=3)
+    feats = [
+        "call:FuncA",
+        "call:FuncB",
+        "call:FuncC",
+        "call:FuncD",
+        "import:libA",
+        "import:libB",
+        "import:libC",
+        "import:libD",
+        '"str1" ascii nocase',
+        '"str2" ascii nocase',
+        '"str3" ascii nocase',
+        '"str4" ascii nocase',
+    ]
+    sal_map = {f: 1.0 for f in feats}
+    out = miner._normalize_and_rank(feats, sal_map)
+    call_feats = [f for f in out if f.startswith("call:")]
+    import_feats = [f for f in out if f.startswith("import:")]
+    string_feats = [f for f in out if f.startswith('"')]
+    assert len(call_feats) == 3
+    assert len(import_feats) == 3
+    assert len(string_feats) == 3


### PR DESCRIPTION
## Summary
- limit mined tokens per prefix with `max_per_prefix`
- expose new argument in CLI
- test prefix limit behavior

## Testing
- `pytest -q tests/test_feature_miner_prefix_limit.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_6885df6d287c832eb183ce269307f15c