### PR TITLE
Implement max OR ratio for FP retry

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -293,6 +293,7 @@ def evaluate_single(
     saliency_stats: dict[str, tuple[float, float]] | None = None,
     combine_mode: str = "or",
     combine_min_ratio: float = 0.5,
+    combine_max_ratio: float = 1.0,
     fp_retries: int = 0,
     freq_threshold_step: float = 0.0,
     comb_ratio_step: float = 0.1,
@@ -753,7 +754,7 @@ def evaluate_single(
                 if group_min_count is not None:
                     group_cnt = (group_cnt or 0) + 1
                 else:
-                    comb_ratio = min(1.0, comb_ratio + comb_ratio_step)
+                    comb_ratio = min(combine_max_ratio, comb_ratio + comb_ratio_step)
             if freq_threshold_step > 0:
                 freq_thresh = max(1, freq_thresh - freq_threshold_step)
             result = _build_and_eval(
@@ -952,6 +953,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="When combining rules in OR mode, require this fraction to match",
     )
     p.add_argument(
+        "--combine-max-ratio",
+        type=float,
+        default=1.0,
+        help="Maximum value for combine_min_ratio during FP retries",
+    )
+    p.add_argument(
         "--fp-retries",
         type=int,
         default=0,
@@ -1115,6 +1122,7 @@ def main(argv: list[str] | None = None) -> None:
                 "json_match": args.json_match,
                 "saliency_stats": saliency_stats,
                 "combine_min_ratio": args.combine_min_ratio,
+                "combine_max_ratio": args.combine_max_ratio,
                 "fp_retries": args.fp_retries,
                 "freq_threshold_step": args.freq_threshold_step,
                 "comb_ratio_step": args.comb_ratio_step,
@@ -1356,6 +1364,7 @@ def main(argv: list[str] | None = None) -> None:
             saliency_stats=saliency_stats,
             combine_mode=combine_mode,
             combine_min_ratio=args.combine_min_ratio,
+            combine_max_ratio=args.combine_max_ratio,
             fp_retries=args.fp_retries,
             freq_threshold_step=args.freq_threshold_step,
             comb_ratio_step=args.comb_ratio_step,

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -36,6 +36,24 @@ def test_build_parser_fp_retries():
     assert args.comb_ratio_step == 0.2
 
 
+def test_build_parser_combine_max_ratio():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--combine-max-ratio",
+            "0.8",
+        ]
+    )
+    assert args.combine_max_ratio == 0.8
+
+
 def test_build_parser_exclude_tokens():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()
@@ -1408,6 +1426,107 @@ def test_fp_retry_selects_best_result(tmp_path, monkeypatch):
     assert res["detected"] is False
     assert res["rule_length"] == 0
     assert res["freq_threshold"] == 10
+
+
+def test_fp_retry_increases_ratio(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9, 0.8])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["foo", "bar"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self, ident="$sample"):
+            self.strings = [(0, ident, b"x")]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            p = str(path)
+            if "foo" in self.text:
+                return [FakeMatch()]
+            if "bar" in self.text:
+                return [] if "clean" in p else [FakeMatch()]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res_no = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=2,
+        chunk_size=1,
+        clean_sample=clean,
+        combine_mode="or",
+        combine_min_ratio=0.5,
+        combine_max_ratio=0.5,
+        comb_ratio_step=0.5,
+        fp_retries=1,
+    )
+
+    res_yes = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=2,
+        chunk_size=1,
+        clean_sample=clean,
+        combine_mode="or",
+        combine_min_ratio=0.5,
+        combine_max_ratio=1.0,
+        comb_ratio_step=0.5,
+        fp_retries=1,
+    )
+
+    assert res_no["false_positive"] is True
+    assert res_yes["false_positive"] is False
 
 
 def test_mal_freqs_reduce_fp(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- allow a maximum combine ratio for FP retries
- step FP retries up to that limit when no tokens get excluded
- test parser and ratio retry behaviour

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_combine_max_ratio -q`


------
https://chatgpt.com/codex/tasks/task_e_6885e24a5ef0832eafbae386918ced05