### PR TITLE
Add adjustable FP retry heuristics

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -297,6 +297,8 @@ def evaluate_single(
     fp_retries: int = 0,
     freq_threshold_step: float = 0.0,
     comb_ratio_step: float = 0.1,
+    chunk_size_step: int = 1,
+    num_rules_min: int = 1,
     exclude_tokens: Sequence[str] | None = None,
     clean_json_cache: Dict[Path, Any] | None = None,
 ) -> Dict[str, Any]:
@@ -369,6 +371,9 @@ def evaluate_single(
         group_cnt: int | None,
         comb_ratio: float,
         *,
+        n_rules: int = num_rules,
+        c_size: int | None = chunk_size,
+        mode: str = combine_mode,
         exclude: Sequence[str] | None = None,
     ) -> Dict[str, Any]:
         miner = FeatureMiner(
@@ -428,13 +433,13 @@ def evaluate_single(
 
         LOGGER.debug("Building YARA rule with %d features", len(features))
 
-        csize = chunk_size
+        csize = c_size
         if csize is None or csize <= 0:
-            csize = max(1, math.ceil(len(features) / max(1, num_rules)))
+            csize = max(1, math.ceil(len(features) / max(1, n_rules)))
 
         groups: list[list[str]] = []
         start = 0
-        for _ in range(max(1, num_rules)):
+        for _ in range(max(1, n_rules)):
             if start >= len(features):
                 break
             groups.append(features[start : start + csize])
@@ -631,7 +636,7 @@ def evaluate_single(
             float(1.0 - num_selected / flat.numel()) if flat.numel() > 0 else 0.0
         )
 
-        if combine_mode == "or":
+        if mode == "or":
             required = max(1, math.ceil(len(detections) * comb_ratio))
             combined_det = sum(detections) >= required
             combined_fp = sum(false_positives) >= required
@@ -710,6 +715,9 @@ def evaluate_single(
         freq_threshold,
         group_min_count,
         combine_min_ratio,
+        n_rules=num_rules,
+        c_size=chunk_size,
+        mode=combine_mode,
         exclude=exclude_set,
     )
 
@@ -741,6 +749,10 @@ def evaluate_single(
         freq_thresh = freq_threshold
         group_cnt = group_min_count
         comb_ratio = combine_min_ratio
+        n_rules = num_rules
+        c_size = chunk_size
+        mode = combine_mode
+        first_retry = True
         while retries > 0 and result.get("false_positive"):
             retries -= 1
             tokens_to_exclude = result.get("fp_matched_tokens", [])
@@ -754,17 +766,31 @@ def evaluate_single(
                 if group_min_count is not None:
                     group_cnt = (group_cnt or 0) + 1
                 else:
-                    comb_ratio = min(combine_max_ratio, comb_ratio + comb_ratio_step)
+                    if first_retry and mode == "or":
+                        comb_ratio = min(combine_max_ratio, comb_ratio + comb_ratio_step)
+                        if c_size is not None:
+                            c_size += chunk_size_step
+                        elif n_rules > num_rules_min:
+                            n_rules = max(num_rules_min, n_rules - 1)
+                    else:
+                        mode = "and"
+                        if n_rules > num_rules_min:
+                            n_rules = max(num_rules_min, n_rules - 1)
+                        c_size = None
             if freq_threshold_step > 0:
                 freq_thresh = max(1, freq_thresh - freq_threshold_step)
             result = _build_and_eval(
                 freq_thresh,
                 group_cnt,
                 comb_ratio,
+                n_rules=n_rules,
+                c_size=c_size,
+                mode=mode,
                 exclude=exclude_set,
             )
             if _is_better(result, best_result):
                 best_result = result
+            first_retry = False
             if not result.get("false_positive"):
                 break
 
@@ -977,6 +1003,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Increase combine_min_ratio by this value on each FP retry",
     )
     p.add_argument(
+        "--chunk-size-step",
+        type=int,
+        default=1,
+        help="Increase chunk_size by this amount on first FP retry",
+    )
+    p.add_argument(
+        "--num-rules-min",
+        type=int,
+        default=1,
+        help="Minimum number of rules when adjusting due to FP",
+    )
+    p.add_argument(
         "--clean-sample", type=Path, help="Optional clean sample for FP check"
     )
     p.add_argument("--out", type=Path, help="Save JSON result path")
@@ -1126,6 +1164,8 @@ def main(argv: list[str] | None = None) -> None:
                 "fp_retries": args.fp_retries,
                 "freq_threshold_step": args.freq_threshold_step,
                 "comb_ratio_step": args.comb_ratio_step,
+                "chunk_size_step": args.chunk_size_step,
+                "num_rules_min": args.num_rules_min,
                 "exclude_tokens": args.exclude_tokens,
                 "clean_json_cache": clean_json_cache,
             }
@@ -1368,6 +1408,8 @@ def main(argv: list[str] | None = None) -> None:
             fp_retries=args.fp_retries,
             freq_threshold_step=args.freq_threshold_step,
             comb_ratio_step=args.comb_ratio_step,
+            chunk_size_step=args.chunk_size_step,
+            num_rules_min=args.num_rules_min,
             exclude_tokens=args.exclude_tokens,
         )
 


### PR DESCRIPTION
## Summary
- improve `evaluate_single` FP retry logic
  - track rule count, chunk size, and combine mode
  - adjust parameters when false positives persist
- expose new CLI options `--chunk-size-step` and `--num-rules-min`

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_combine_mode -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_json_match_fp_with_clean_sample -q`


------
https://chatgpt.com/codex/tasks/task_e_6885efb9d364832e892da67269f160b3