### PR TITLE
Add self-detection enforcement option

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,12 @@ python -m src.cli.explainer_rule_eval \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt \
     --fp-retries 2 --freq-threshold-step 1 --comb-ratio-step 0.2
 
+# enforce self-detection by relaxing thresholds
+python -m src.cli.explainer_rule_eval \
+    --graph graph.pt --sample sample.bin \
+    --saliency sal.pt --classifier models/gnn/res_gcl.pt \
+    --enforce-self-detect
+
 # require at least two matches per group
 python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \

--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -215,6 +215,7 @@ python -m src.cli.explainer_rule_eval \
 
 `--freq-threshold-step`과 `--comb-ratio-step`을 사용하면 재시도 과정에서
 빈도 임계값을 낮추거나 병합 비율을 높여가며 규칙을 조정할 수 있습니다.
+`--enforce-self-detect` 옵션을 주면 현재 샘플이 탐지될 때까지 조건을 단계적으로 완화합니다.
 
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -294,6 +294,7 @@ def evaluate_single(
     combine_mode: str = "or",
     combine_min_ratio: float = 0.5,
     combine_max_ratio: float = 1.0,
+    enforce_self_detect: bool = False,
     fp_retries: int = 0,
     freq_threshold_step: float = 0.0,
     comb_ratio_step: float = 0.1,
@@ -721,6 +722,48 @@ def evaluate_single(
         exclude=exclude_set,
     )
 
+    if enforce_self_detect and not result.get("detected"):
+        comb_ratio = combine_min_ratio
+        grp_cnt = group_min_count
+        freq_th = freq_threshold
+        while comb_ratio > 0.0 and not result.get("detected"):
+            comb_ratio = max(0.0, round(comb_ratio - 0.1, 3))
+            result = _build_and_eval(
+                freq_th,
+                grp_cnt,
+                comb_ratio,
+                n_rules=num_rules,
+                c_size=chunk_size,
+                mode=combine_mode,
+                exclude=exclude_set,
+            )
+        if grp_cnt and not result.get("detected"):
+            for cnt in range(grp_cnt - 1, 0, -1):
+                result = _build_and_eval(
+                    freq_th,
+                    cnt,
+                    comb_ratio,
+                    n_rules=num_rules,
+                    c_size=chunk_size,
+                    mode=combine_mode,
+                    exclude=exclude_set,
+                )
+                if result.get("detected"):
+                    grp_cnt = cnt
+                    break
+        if not result.get("detected") and freq_th > 1:
+            while freq_th > 1 and not result.get("detected"):
+                freq_th = max(1, freq_th - 1)
+                result = _build_and_eval(
+                    freq_th,
+                    grp_cnt,
+                    comb_ratio,
+                    n_rules=num_rules,
+                    c_size=chunk_size,
+                    mode=combine_mode,
+                    exclude=exclude_set,
+                )
+
     best_result = result
 
     def _is_better(new: Dict[str, Any], current: Dict[str, Any]) -> bool:
@@ -756,6 +799,15 @@ def evaluate_single(
         while retries > 0 and result.get("false_positive"):
             retries -= 1
             tokens_to_exclude = result.get("fp_matched_tokens", [])
+            prev_state = (
+                freq_thresh,
+                group_cnt,
+                comb_ratio,
+                n_rules,
+                c_size,
+                mode,
+                set(exclude_set),
+            )
             if tokens_to_exclude:
                 exclude_set.update(t.lower() for t in tokens_to_exclude)
                 if LOGGER.isEnabledFor(logging.DEBUG):
@@ -788,6 +840,28 @@ def evaluate_single(
                 mode=mode,
                 exclude=exclude_set,
             )
+            if not result.get("detected"):
+                (
+                    freq_thresh,
+                    group_cnt,
+                    comb_ratio,
+                    n_rules,
+                    c_size,
+                    mode,
+                    exclude_prev,
+                ) = prev_state
+                exclude_set = set(exclude_prev)
+                if exclude_set:
+                    exclude_set.discard(next(iter(exclude_set)))
+                result = _build_and_eval(
+                    freq_thresh,
+                    group_cnt,
+                    comb_ratio,
+                    n_rules=n_rules,
+                    c_size=c_size,
+                    mode=mode,
+                    exclude=exclude_set,
+                )
             if _is_better(result, best_result):
                 best_result = result
             first_retry = False
@@ -1056,6 +1130,11 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="*",
         help="특정 토큰을 제외하고 규칙을 생성",
     )
+    p.add_argument(
+        "--enforce-self-detect",
+        action="store_true",
+        help="relax thresholds until the sample is detected",
+    )
     p.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
     return p
 
@@ -1167,6 +1246,7 @@ def main(argv: list[str] | None = None) -> None:
                 "chunk_size_step": args.chunk_size_step,
                 "num_rules_min": args.num_rules_min,
                 "exclude_tokens": args.exclude_tokens,
+                "enforce_self_detect": args.enforce_self_detect,
                 "clean_json_cache": clean_json_cache,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
@@ -1411,6 +1491,7 @@ def main(argv: list[str] | None = None) -> None:
             chunk_size_step=args.chunk_size_step,
             num_rules_min=args.num_rules_min,
             exclude_tokens=args.exclude_tokens,
+            enforce_self_detect=args.enforce_self_detect,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -93,6 +93,23 @@ def test_build_parser_flush_every():
     assert args.flush_every == 10
 
 
+def test_build_parser_enforce_self_detect():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--enforce-self-detect",
+        ]
+    )
+    assert args.enforce_self_detect is True
+
+
 def test_build_parser_mal_freqs_ratio():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()


### PR DESCRIPTION
## Summary
- add `--enforce-self-detect` CLI flag in explainer_rule_eval
- gradually relax thresholds when self detection fails
- revert last FP retry adjustment if detection is lost
- document the new option in README and quick start
- test parser for the new flag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6885f94b2480832ebf82c0b90f1fff07