### PR TITLE
Improve feature token validation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -11,6 +11,7 @@ import re
 
 import logging
 from src.common.utils import get_logger, tqdm_wrap
+from src.graphs.loaders.common_token_utils import split_name
 
 import torch
 from torch_geometric.data import HeteroData
@@ -117,21 +118,18 @@ def _compute_saliency_with_explainer(
 
 def _extract_tokens(feature: str) -> list[str]:
     """Return plain tokens from mined feature strings."""
-    if feature.startswith("chain:"):
-        parts = feature[len("chain:") :].split("\u2192")
+    if feature.lower().startswith("chain:"):
+        parts = feature.split(":", 1)[1].split("\u2192")
     else:
         parts = [feature]
 
     tokens: list[str] = []
     for part in parts:
-        if part.startswith("call:"):
-            part = part[len("call:") :]
-        if part.startswith("import:"):
-            part = part[len("import:") :]
+        part = part.strip()
+        part = re.sub(r"^(?:call|import)\s*:", "", part, flags=re.I)
         if "!" in part:
             part = part.split("!")[-1]
 
-        part = part.strip()
         m = re.search(r'"([^\"]+)"', part)
         if m:
             part = m.group(1)
@@ -143,7 +141,7 @@ def _extract_tokens(feature: str) -> list[str]:
 
         if not part or part.startswith("{") or part.startswith("/"):
             continue
-        tokens.append(part)
+        tokens.append(part.lower())
     return tokens
 
 
@@ -176,11 +174,20 @@ def verify_features(
     for key in ("c_code", "h_code", "asm_code", "llvm_ir"):
         text_fields.extend(js.get(key, []))
 
-    joined = "\n".join(text_fields).lower()
+    joined = "\n".join(text_fields)
+
+    def _token_regex(tok: str) -> re.Pattern:
+        parts = split_name(tok)
+        if parts:
+            pat = r"[_-]?".join(re.escape(p) for p in parts)
+        else:
+            pat = re.escape(tok)
+        pat = pat.replace(r"\_", "[-_]").replace(r"\-", "[-_]")
+        return re.compile(pat, re.IGNORECASE)
 
     def _feat_present(feat: str) -> bool:
         for tok in _extract_tokens(feat):
-            if tok.lower() in joined:
+            if _token_regex(tok).search(joined):
                 return True
         return False
 


### PR DESCRIPTION
## Summary
- handle `call:` and `import:` prefixes in a case-insensitive way
- allow flexible token matching with underscores and hyphens
- check tokens using regex patterns when verifying features

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_verify_features_return_matched -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f98335cc832e995bc609fd347b32