### PR TITLE
Record last detection result

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -772,6 +772,9 @@ def evaluate_single(
                 )
 
     best_result = result
+    last_detected_result: Dict[str, Any] | None = None
+    if best_result.get("detected"):
+        last_detected_result = best_result
 
     def _is_better(new: Dict[str, Any], current: Dict[str, Any]) -> bool:
         """Return True if ``new`` should replace ``current`` based on prefs."""
@@ -871,10 +874,15 @@ def evaluate_single(
                 )
             if _is_better(result, best_result):
                 best_result = result
+                if best_result.get("detected"):
+                    last_detected_result = best_result
             first_retry = False
             if not result.get("false_positive"):
                 break
 
+    if not best_result.get("detected") and last_detected_result is not None:
+        LOGGER.info("No detection after retries; using last detected result")
+        return last_detected_result
     return best_result
 
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1439,9 +1439,9 @@ def test_fp_retry_selects_best_result(tmp_path, monkeypatch):
         fp_retries=1,
     )
 
-    assert res["false_positive"] is False
-    assert res["detected"] is False
-    assert res["rule_length"] == 0
+    assert res["false_positive"] is True
+    assert res["detected"] is True
+    assert res["rule_length"] == 1
     assert res["freq_threshold"] == 10
 
 


### PR DESCRIPTION
## Summary
- track the last detection result in `evaluate_single`
- rollback to previous detected result when final result isn't detected
- update test expectations

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k fp_retry_selects_best_result -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fcabb014832eb69d05ae8f00a293