### PR TITLE
Fix rule eval comparison order

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -775,15 +775,15 @@ def evaluate_single(
 
     def _is_better(new: Dict[str, Any], current: Dict[str, Any]) -> bool:
         """Return True if ``new`` should replace ``current`` based on prefs."""
-        new_fp = bool(new.get("false_positive"))
-        cur_fp = bool(current.get("false_positive"))
-        if new_fp != cur_fp:
-            return not new_fp
-
         new_det = bool(new.get("detected"))
         cur_det = bool(current.get("detected"))
         if new_det != cur_det:
             return new_det
+
+        new_fp = bool(new.get("false_positive"))
+        cur_fp = bool(current.get("false_positive"))
+        if new_fp != cur_fp:
+            return not new_fp
 
         new_cov = float(new.get("coverage", 0.0))
         cur_cov = float(current.get("coverage", 0.0))


### PR DESCRIPTION
## Summary
- ensure detection status takes precedence over FP status when choosing better rule

## Testing
- `pytest -k explainer_rule_eval -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6885fca07d04832eb2156089b6011207