### PR TITLE
Implement rule evaluation relaxation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -729,6 +729,58 @@ def evaluate_single(
         exclude=exclude_set,
     )
 
+    if not result.get("detected"):
+        relax_ratio = max(0.0, round(combine_min_ratio - 0.1, 3))
+        if relax_ratio != combine_min_ratio:
+            LOGGER.debug(
+                "Detection failed; retrying with combine_min_ratio=%.3f",
+                relax_ratio,
+            )
+            relaxed = _build_and_eval(
+                freq_threshold,
+                group_min_count,
+                relax_ratio,
+                n_rules=num_rules,
+                c_size=chunk_size,
+                mode=combine_mode,
+                exclude=exclude_set,
+            )
+            if relaxed.get("detected"):
+                LOGGER.debug(
+                    "Detection succeeded with combine_min_ratio=%.3f",
+                    relax_ratio,
+                )
+                result = relaxed
+
+        if (
+            not result.get("detected")
+            and group_min_count is not None
+            and group_min_count > 1
+        ):
+            relax_cnt = group_min_count - 1
+            LOGGER.debug(
+                "Detection still failed; retrying with group_min_count=%d",
+                relax_cnt,
+            )
+            relaxed = _build_and_eval(
+                freq_threshold,
+                relax_cnt,
+                relax_ratio,
+                n_rules=num_rules,
+                c_size=chunk_size,
+                mode=combine_mode,
+                exclude=exclude_set,
+            )
+            if relaxed.get("detected"):
+                LOGGER.debug(
+                    "Detection succeeded with combine_min_ratio=%.3f, group_min_count=%d",
+                    relax_ratio,
+                    relax_cnt,
+                )
+                result = relaxed
+            else:
+                LOGGER.debug("Relaxed parameters did not yield detection")
+
     if enforce_self_detect and not result.get("detected"):
         comb_ratio = combine_min_ratio
         grp_cnt = group_min_count

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1638,3 +1638,71 @@ def test_mal_freqs_reduce_fp(tmp_path, monkeypatch):
 
     assert res_no["false_positive"] is True
     assert res_yes["false_positive"] is False
+
+
+def test_evaluate_single_relax_params(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["foo", "bar"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self):
+            self.strings = [(0, "$s0", b"x")]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            if "foo" in self.text:
+                return [FakeMatch()]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=2,
+        chunk_size=1,
+        combine_mode="or",
+        combine_min_ratio=0.6,
+    )
+
+    assert res["detected"] is True


### PR DESCRIPTION
## Summary
- try lower `combine_min_ratio` or decrease `group_min_count` when detection fails
- log debug messages about relaxation attempts
- test relaxation logic in `evaluate_single`

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_relax_params -vv -s` *(fails: found no collectors due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6885fcb92228832eb2c254829c1cc1e1