### PR TITLE
Improve benign frequency fallback

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -34,7 +34,7 @@ import re
 import string
 from collections import Counter
 from pathlib import Path
-from typing import Dict, List, Sequence, Tuple
+from typing import Callable, Dict, List, Sequence, Tuple
 
 import torch
 from torch_geometric.data import HeteroData
@@ -84,6 +84,7 @@ class FeatureMiner:
         mal_freqs: dict[str, int] | None = None,
         freq_ratio: float = 1.0,
         freq_threshold: float | int = 0,
+        verify_func: callable | None = None,
     ) -> None:
         """
         Args
@@ -108,6 +109,7 @@ class FeatureMiner:
         self.mal_freqs = mal_freqs
         self.freq_ratio = float(freq_ratio)
         self.freq_threshold = freq_threshold
+        self.verify_func = verify_func
 
     # ────────────────────────────────────────── benign freq updates ―
     def update_benign_freqs(self, updates: Dict[str, int]) -> None:
@@ -664,20 +666,40 @@ class FeatureMiner:
         if filtered or not feats:
             return filtered
 
-        # 모든 후보가 제거된 경우: benign 빈도 최소 + saliency 최대 토큰 선택
-        best = None
-        best_freq = None
-        best_sal = None
-        for f in feats:
-            freq = self.benign_freqs.get(f, 0)
-            sal = sal_map.get(f, 0.0) if sal_map else 0.0
-            if best is None or freq < best_freq or (
-                freq == best_freq and sal > best_sal
-            ):
-                best = f
-                best_freq = freq
-                best_sal = sal
-        return [best] if best is not None else []
+        # 모든 후보가 제거된 경우
+        cand_order: List[str] = []
+        if self.mal_freqs:
+            high_mal: List[str] = []
+            for f in feats:
+                ben = self.benign_freqs.get(f, 0)
+                mal = self.mal_freqs.get(f, 0)
+                if mal > ben * 2:
+                    high_mal.append(f)
+            if high_mal:
+                cand_order = sorted(
+                    high_mal,
+                    key=lambda x: sal_map.get(x, 0.0) if sal_map else 0.0,
+                    reverse=True,
+                )
+
+        if not cand_order:
+            cand_order = sorted(
+                feats,
+                key=lambda x: (
+                    self.benign_freqs.get(x, float("inf")),
+                    -(sal_map.get(x, 0.0) if sal_map else 0.0),
+                ),
+            )
+
+        if self.verify_func:
+            for c in cand_order:
+                try:
+                    if self.verify_func([c]):
+                        return [c]
+                except Exception:  # pragma: no cover - verifier errors
+                    continue
+
+        return [cand_order[0]] if cand_order else []
 
     # ──────────────────────────────────────────────────────────
 

--- a/tests/test_feature_miner_benign_freq.py
+++ b/tests/test_feature_miner_benign_freq.py
@@ -66,3 +66,26 @@ def test_mal_freq_ratio_filters_token(tmp_path):
     feats = miner(g, sal)
 
     assert feats == ["call:CreateFileW"]
+
+
+def test_select_high_mal_freq_token_with_verification():
+    g = HeteroData()
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["Foo", "Bar"]
+
+    sal = torch.tensor([0.8, 0.6])
+
+    def _verify(feats):
+        return feats[0] == "call:Bar"
+
+    miner = FeatureMiner(
+        top_k=2,
+        benign_freqs={"call:Foo": 30, "call:Bar": 20},
+        mal_freqs={"call:Foo": 90, "call:Bar": 45},
+        freq_threshold=5,
+        verify_func=_verify,
+    )
+
+    feats = miner(g, sal)
+
+    assert feats == ["call:Bar"]


### PR DESCRIPTION
## Summary
- extend `FeatureMiner` to accept optional verification callback
- prefer tokens with much higher malicious frequency when all are filtered
- verify candidate tokens and fallback by saliency
- test new fallback behaviour

## Testing
- `pytest tests/test_feature_miner_benign_freq.py -q` *(fails: 1 skipped due to missing torch)*

------
https://chatgpt.com/codex/tasks/task_e_68860e3e5820832e9991ca54effb2712