### PR TITLE
Implement persistent FP token exclusion

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -22,6 +22,35 @@ from rulegen.yara_builder import YaraBuilder
 
 LOGGER = get_logger(__name__)
 
+# Persistent false positive exclude tokens
+_FP_EXCLUDE_SET: set[str] = set()
+_FP_EXCLUDE_PATH: Path | None = None
+
+
+def _load_fp_exclude(path: Path) -> set[str]:
+    """Load persistent FP exclude tokens from ``path``."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return {str(t).lower() for t in data}
+    except FileNotFoundError:
+        return set()
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Failed to read %s: %s", path, exc)
+    return set()
+
+
+def _save_fp_exclude(path: Path, tokens: set[str]) -> None:
+    """Persist FP exclude ``tokens`` to ``path``."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(sorted(tokens), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Failed to write %s: %s", path, exc)
+
 
 # ---------------------------------------------------------------------------
 # Helper utilities
@@ -308,9 +337,16 @@ def evaluate_single(
     chunk_size_step: int = 1,
     num_rules_min: int = 1,
     exclude_tokens: Sequence[str] | None = None,
+    persist_fp_exclude: Path | None = None,
     clean_json_cache: Dict[Path, Any] | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
+
+    global _FP_EXCLUDE_SET, _FP_EXCLUDE_PATH
+    if persist_fp_exclude is not None:
+        if _FP_EXCLUDE_PATH != persist_fp_exclude:
+            _FP_EXCLUDE_PATH = persist_fp_exclude
+            _FP_EXCLUDE_SET = _load_fp_exclude(persist_fp_exclude)
 
     LOGGER.debug("Loading graph from %s", graph_path)
     graph: HeteroData = torch.load(graph_path, map_location="cpu", weights_only=False)
@@ -718,6 +754,8 @@ def evaluate_single(
         return result
 
     exclude_set: set[str] = set(t.lower() for t in (exclude_tokens or []))
+    if persist_fp_exclude is not None:
+        exclude_set.update(_FP_EXCLUDE_SET)
 
     result = _build_and_eval(
         freq_threshold,
@@ -872,6 +910,9 @@ def evaluate_single(
             )
             if tokens_to_exclude:
                 exclude_set.update(t.lower() for t in tokens_to_exclude)
+                if persist_fp_exclude is not None:
+                    _FP_EXCLUDE_SET.update(t.lower() for t in tokens_to_exclude)
+                    _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
                 if LOGGER.isEnabledFor(logging.DEBUG):
                     LOGGER.debug(
                         "Excluding tokens due to FP retry: %s", tokens_to_exclude
@@ -1198,6 +1239,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="특정 토큰을 제외하고 규칙을 생성",
     )
     p.add_argument(
+        "--persist-fp-exclude",
+        type=Path,
+        help="JSON file to persist tokens excluded due to false positives",
+    )
+    p.add_argument(
         "--enforce-self-detect",
         action="store_true",
         help="relax thresholds until the sample is detected",
@@ -1313,6 +1359,7 @@ def main(argv: list[str] | None = None) -> None:
                 "chunk_size_step": args.chunk_size_step,
                 "num_rules_min": args.num_rules_min,
                 "exclude_tokens": args.exclude_tokens,
+                "persist_fp_exclude": args.persist_fp_exclude,
                 "enforce_self_detect": args.enforce_self_detect,
                 "clean_json_cache": clean_json_cache,
             }
@@ -1558,6 +1605,7 @@ def main(argv: list[str] | None = None) -> None:
             chunk_size_step=args.chunk_size_step,
             num_rules_min=args.num_rules_min,
             exclude_tokens=args.exclude_tokens,
+            persist_fp_exclude=args.persist_fp_exclude,
             enforce_self_detect=args.enforce_self_detect,
         )
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -73,6 +73,24 @@ def test_build_parser_exclude_tokens():
     assert args.exclude_tokens == ["foo", "bar"]
 
 
+def test_build_parser_persist_fp_exclude():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--persist-fp-exclude",
+            "tokens.json",
+        ]
+    )
+    assert args.persist_fp_exclude == Path("tokens.json")
+
+
 def test_build_parser_flush_every():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()


### PR DESCRIPTION
## Summary
- add persistent false-positive token exclude handling in `evaluate_single`
- support `--persist-fp-exclude` CLI option
- update CLI parsing tests for new option

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_persist_fp_exclude -q`

------
https://chatgpt.com/codex/tasks/task_e_68860fda1fd0832e9a782997cca51f5e