### PR TITLE
Improve feature token extraction

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -126,18 +126,31 @@ def _extract_tokens(feature: str) -> list[str]:
     tokens: list[str] = []
     for part in parts:
         part = part.strip()
-        part = re.sub(r"^(?:call|import)\s*:", "", part, flags=re.I)
+        part = re.sub(r"^(?:call|import|syscall|path|reg|url|byte\[[^]]*\])\s*:", "", part, flags=re.I)
         if "!" in part:
             part = part.split("!")[-1]
 
         m = re.search(r'"([^\"]+)"', part)
         if m:
-            part = m.group(1)
-        else:
-            part = part.strip('"')
-            if not part or part.startswith("{") or part.startswith("/"):
-                continue
-            part = part.split()[0]
+            tokens.append(m.group(1).lower())
+            continue
+
+        m = re.search(r"\{([^}]*)\}", part)
+        if m:
+            hx = m.group(1)
+            for h in re.findall(r"[A-Fa-f0-9?]{2}", hx):
+                tokens.append(h.lower())
+            continue
+
+        m = re.search(r"/(.*)/", part)
+        if m:
+            tokens.append(m.group(1).lower())
+            continue
+
+        part = part.strip('"')
+        if not part or part.startswith("{") or part.startswith("/"):
+            continue
+        part = part.split()[0]
 
         if not part or part.startswith("{") or part.startswith("/"):
             continue

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1202,6 +1202,28 @@ def test_verify_features_string_wide_ascii(tmp_path):
     assert mod.verify_features(js, feats) is True
 
 
+def test_verify_features_hex_pattern(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["4D 5A 90 00"]}))
+
+    feats = ["{ 4D 5A 90 00 }"]
+
+    assert mod.verify_features(js, feats) is True
+
+
+def test_verify_features_regex_pattern(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"c_code": ["hello world"]}))
+
+    feats = ["/hello/"]
+
+    assert mod.verify_features(js, feats) is True
+
+
 def test_verify_features_return_matched(tmp_path):
     mod = importlib.import_module("src.cli.explainer_rule_eval")
 


### PR DESCRIPTION
## Summary
- handle hex and regex patterns in `_extract_tokens`
- test token extraction for wide ascii, hex and regex patterns

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_verify_features_hex_pattern tests/test_explainer_rule_eval_cli.py::test_verify_features_regex_pattern tests/test_explainer_rule_eval_cli.py::test_verify_features_string_wide_ascii -q`

------
https://chatgpt.com/codex/tasks/task_e_68860ffb8778832eafaf6e35dddcce55