### PR TITLE
Improve FP retry grid search

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -680,6 +680,7 @@ def evaluate_single(
             "false_positive": combined_fp,
             "group_min_count": group_cnt,
             "freq_threshold": freq_thresh,
+            "combine_min_ratio": comb_ratio,
         }
         result["rule_texts"] = rule_texts
         result["false_positives"] = false_positives
@@ -830,105 +831,75 @@ def evaluate_single(
 
     def _is_better(new: Dict[str, Any], current: Dict[str, Any]) -> bool:
         """Return True if ``new`` should replace ``current`` based on prefs."""
-        new_det = bool(new.get("detected"))
-        cur_det = bool(current.get("detected"))
-        if new_det != cur_det:
-            return new_det
-
-        new_fp = bool(new.get("false_positive"))
-        cur_fp = bool(current.get("false_positive"))
-        if new_fp != cur_fp:
-            return not new_fp
-
-        new_cov = float(new.get("coverage", 0.0))
-        cur_cov = float(current.get("coverage", 0.0))
-        if not math.isclose(new_cov, cur_cov):
-            return new_cov > cur_cov
-
-        new_len = int(new.get("rule_length", 0))
-        cur_len = int(current.get("rule_length", 0))
-        return new_len < cur_len
+        new_key = (
+            bool(new.get("detected")),
+            not bool(new.get("false_positive")),
+            float(new.get("coverage", 0.0)),
+            -int(new.get("rule_length", 0)),
+        )
+        cur_key = (
+            bool(current.get("detected")),
+            not bool(current.get("false_positive")),
+            float(current.get("coverage", 0.0)),
+            -int(current.get("rule_length", 0)),
+        )
+        return new_key > cur_key
 
     if result.get("false_positive") and fp_retries > 0:
-        retries = fp_retries
-        freq_thresh = freq_threshold
-        group_cnt = group_min_count
-        comb_ratio = combine_min_ratio
-        n_rules = num_rules
-        c_size = chunk_size
-        mode = combine_mode
-        first_retry = True
-        while retries > 0 and result.get("false_positive"):
-            retries -= 1
-            tokens_to_exclude = result.get("fp_matched_tokens", [])
-            prev_state = (
-                freq_thresh,
-                group_cnt,
-                comb_ratio,
-                n_rules,
-                c_size,
-                mode,
-                set(exclude_set),
-            )
-            if tokens_to_exclude:
-                exclude_set.update(t.lower() for t in tokens_to_exclude)
-                if LOGGER.isEnabledFor(logging.DEBUG):
-                    LOGGER.debug(
-                        "Excluding tokens due to FP retry: %s", tokens_to_exclude
-                    )
-            else:
-                if group_min_count is not None:
-                    group_cnt = (group_cnt or 0) + 1
-                else:
-                    if first_retry and mode == "or":
-                        comb_ratio = min(combine_max_ratio, comb_ratio + comb_ratio_step)
-                        if c_size is not None:
-                            c_size += chunk_size_step
-                        elif n_rules > num_rules_min:
-                            n_rules = max(num_rules_min, n_rules - 1)
-                    else:
-                        mode = "and"
-                        if n_rules > num_rules_min:
-                            n_rules = max(num_rules_min, n_rules - 1)
-                        c_size = None
+        exclude_set.update(t.lower() for t in result.get("fp_matched_tokens", []))
+
+        freq_vals = [freq_threshold]
+        group_vals = [group_min_count]
+        ratio_vals = [combine_min_ratio]
+        for i in range(1, fp_retries + 1):
             if freq_threshold_step > 0:
-                freq_thresh = max(1, freq_thresh - freq_threshold_step)
-            result = _build_and_eval(
-                freq_thresh,
-                group_cnt,
-                comb_ratio,
-                n_rules=n_rules,
-                c_size=c_size,
-                mode=mode,
-                exclude=exclude_set,
+                freq_vals.append(max(1, freq_threshold - i * freq_threshold_step))
+            if group_min_count is not None:
+                group_vals.append((group_min_count or 0) + i)
+            ratio_vals.append(
+                min(combine_max_ratio, combine_min_ratio + i * comb_ratio_step)
             )
-            if not result.get("detected"):
-                (
-                    freq_thresh,
-                    group_cnt,
-                    comb_ratio,
-                    n_rules,
-                    c_size,
-                    mode,
-                    exclude_prev,
-                ) = prev_state
-                exclude_set = set(exclude_prev)
-                if exclude_set:
-                    exclude_set.discard(next(iter(exclude_set)))
-                result = _build_and_eval(
-                    freq_thresh,
-                    group_cnt,
-                    comb_ratio,
-                    n_rules=n_rules,
-                    c_size=c_size,
-                    mode=mode,
-                    exclude=exclude_set,
-                )
-            if _is_better(result, best_result):
-                best_result = result
-                if best_result.get("detected"):
-                    last_detected_result = best_result
-            first_retry = False
+
+        freq_vals = sorted(set(freq_vals))
+        group_vals = sorted(set(group_vals))
+        ratio_vals = sorted(set(ratio_vals))
+
+        for f in freq_vals:
+            for g in group_vals:
+                for r in ratio_vals:
+                    if (f, g, r) == (
+                        freq_threshold,
+                        group_min_count,
+                        combine_min_ratio,
+                    ):
+                        continue
+                    result = _build_and_eval(
+                        f,
+                        g,
+                        r,
+                        n_rules=num_rules,
+                        c_size=chunk_size,
+                        mode=combine_mode,
+                        exclude=exclude_set,
+                    )
+                    if result.get("fp_matched_tokens"):
+                        exclude_set.update(
+                            t.lower() for t in result.get("fp_matched_tokens", [])
+                        )
+                    if _is_better(result, best_result):
+                        LOGGER.info(
+                            "Improved with freq_threshold=%s group_min_count=%s combine_min_ratio=%.3f",
+                            f,
+                            g,
+                            r,
+                        )
+                        best_result = result
+                        if best_result.get("detected"):
+                            last_detected_result = best_result
+                    if not result.get("false_positive"):
+                        break
+                if not result.get("false_positive"):
+                    break
             if not result.get("false_positive"):
                 break
 
@@ -1356,6 +1327,7 @@ def main(argv: list[str] | None = None) -> None:
                                 "fp_matched_tokens",
                                 "group_min_count",
                                 "freq_threshold",
+                                "combine_min_ratio",
                             ):
                                 if col not in df_flush.columns:
                                     df_flush[col] = [
@@ -1407,6 +1379,7 @@ def main(argv: list[str] | None = None) -> None:
                             "fp_matched_tokens",
                             "group_min_count",
                             "freq_threshold",
+                            "combine_min_ratio",
                         ):
                             if col not in df_flush.columns:
                                 df_flush[col] = [
@@ -1450,6 +1423,7 @@ def main(argv: list[str] | None = None) -> None:
                         "fp_matched_tokens",
                         "group_min_count",
                         "freq_threshold",
+                        "combine_min_ratio",
                     ):
                         if col not in df_flush.columns:
                             df_flush[col] = [
@@ -1469,6 +1443,7 @@ def main(argv: list[str] | None = None) -> None:
                     "fp_matched_tokens",
                     "group_min_count",
                     "freq_threshold",
+                    "combine_min_ratio",
                 ):
                     if col not in df.columns:
                         df[col] = [


### PR DESCRIPTION
## Summary
- explore combinations of freq threshold, group min count, and combine ratio during FP retries
- track combine ratio in results and CSV outputs
- clarify comparison logic in `_is_better`
- log when new parameter combinations improve results

## Testing
- `pytest -q` *(fails: torch missing)*

------
https://chatgpt.com/codex/tasks/task_e_68861009ab80832eb135fd39a8adb9a7