### PR TITLE
Improve FP retry parameter search

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -898,91 +898,61 @@ def evaluate_single(
 
         new_len = int(new.get("rule_length", 0))
         cur_len = int(current.get("rule_length", 0))
-        return new_len < cur_len
+        if new_len != cur_len:
+            return new_len < cur_len
+
+        return False
 
     if result.get("false_positive") and fp_retries > 0:
-        retries = fp_retries
-        freq_thresh = freq_threshold
-        group_cnt = group_min_count
-        comb_ratio = combine_min_ratio
-        n_rules = num_rules
-        c_size = chunk_size
-        mode = combine_mode
-        first_retry = True
-        while retries > 0 and result.get("false_positive"):
-            retries -= 1
-            tokens_to_exclude = result.get("fp_matched_tokens", [])
-            prev_state = (
-                freq_thresh,
-                group_cnt,
-                comb_ratio,
-                n_rules,
-                c_size,
-                mode,
-                set(exclude_set),
-            )
-            if tokens_to_exclude:
-                exclude_set.update(t.lower() for t in tokens_to_exclude)
-                if persist_fp_exclude is not None:
-                    _FP_EXCLUDE_SET.update(t.lower() for t in tokens_to_exclude)
-                    _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
-                if LOGGER.isEnabledFor(logging.DEBUG):
-                    LOGGER.debug(
-                        "Excluding tokens due to FP retry: %s", tokens_to_exclude
+        tokens_to_exclude = result.get("fp_matched_tokens", [])
+        if tokens_to_exclude:
+            exclude_set.update(t.lower() for t in tokens_to_exclude)
+            if persist_fp_exclude is not None:
+                _FP_EXCLUDE_SET.update(t.lower() for t in tokens_to_exclude)
+                _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
+            if LOGGER.isEnabledFor(logging.DEBUG):
+                LOGGER.debug("Excluding tokens due to FP retry: %s", tokens_to_exclude)
+
+        freq_vals = [max(1, round(freq_threshold - i * freq_threshold_step, 3)) for i in range(fp_retries + 1)]
+        freq_vals = sorted(set(freq_vals))
+        comb_vals = [min(combine_max_ratio, round(combine_min_ratio + i * comb_ratio_step, 3)) for i in range(fp_retries + 1)]
+        comb_vals = sorted(set(comb_vals))
+        if group_min_count is not None:
+            group_vals = [group_min_count + i for i in range(fp_retries + 1)]
+        else:
+            group_vals = [None]
+
+        for ft in freq_vals:
+            for gc in group_vals:
+                for cr in comb_vals:
+                    if ft == freq_threshold and gc == group_min_count and cr == combine_min_ratio:
+                        continue
+                    cand = _build_and_eval(
+                        ft,
+                        gc,
+                        cr,
+                        n_rules=num_rules,
+                        c_size=chunk_size,
+                        mode=combine_mode,
+                        exclude=exclude_set,
                     )
-            else:
-                if group_min_count is not None:
-                    group_cnt = (group_cnt or 0) + 1
-                else:
-                    if first_retry and mode == "or":
-                        comb_ratio = min(combine_max_ratio, comb_ratio + comb_ratio_step)
-                        if c_size is not None:
-                            c_size += chunk_size_step
-                        elif n_rules > num_rules_min:
-                            n_rules = max(num_rules_min, n_rules - 1)
-                    else:
-                        mode = "and"
-                        if n_rules > num_rules_min:
-                            n_rules = max(num_rules_min, n_rules - 1)
-                        c_size = None
-            if freq_threshold_step > 0:
-                freq_thresh = max(1, freq_thresh - freq_threshold_step)
-            result = _build_and_eval(
-                freq_thresh,
-                group_cnt,
-                comb_ratio,
-                n_rules=n_rules,
-                c_size=c_size,
-                mode=mode,
-                exclude=exclude_set,
-            )
-            if not result.get("detected"):
-                (
-                    freq_thresh,
-                    group_cnt,
-                    comb_ratio,
-                    n_rules,
-                    c_size,
-                    mode,
-                    exclude_prev,
-                ) = prev_state
-                exclude_set = set(exclude_prev)
-                if exclude_set:
-                    exclude_set.discard(next(iter(exclude_set)))
-                result = _build_and_eval(
-                    freq_thresh,
-                    group_cnt,
-                    comb_ratio,
-                    n_rules=n_rules,
-                    c_size=c_size,
-                    mode=mode,
-                    exclude=exclude_set,
-                )
-            if _is_better(result, best_result):
-                best_result = result
-                if best_result.get("detected"):
-                    last_detected_result = best_result
-            first_retry = False
+                    if _is_better(cand, best_result):
+                        best_result = cand
+                        if best_result.get("detected"):
+                            last_detected_result = best_result
+                        LOGGER.info(
+                            "Improved with freq_threshold=%s group_min_count=%s combine_min_ratio=%.3f (detected=%s FP=%s)",
+                            ft,
+                            gc,
+                            cr,
+                            cand.get("detected"),
+                            cand.get("false_positive"),
+                        )
+                    if not cand.get("false_positive"):
+                        result = cand
+                        break
+                if not result.get("false_positive"):
+                    break
             if not result.get("false_positive"):
                 break
 


### PR DESCRIPTION
## Summary
- refine `_is_better` to clarify detection/FP priority
- evaluate combinations of frequency threshold, group count and ratio when retrying for false positives
- log parameter combinations that improve results

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k test_fp_retry_increases_ratio -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_retry_exclude_tokens -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_retry_selects_best_result -q`

------
https://chatgpt.com/codex/tasks/task_e_688612fa1960832e8a5ed20faf0913cd