### PR TITLE
Improve FP retry combination search

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -880,7 +880,15 @@ def evaluate_single(
         last_detected_result = best_result
 
     def _is_better(new: Dict[str, Any], current: Dict[str, Any]) -> bool:
-        """Return True if ``new`` should replace ``current`` based on prefs."""
+        """Return True if ``new`` should replace ``current``.
+
+        Priority order:
+        1. Detection (prefer detected rules)
+        2. False positives (prefer fewer)
+        3. Coverage (prefer higher)
+        4. Rule length (prefer shorter)
+        """
+
         new_det = bool(new.get("detected"))
         cur_det = bool(current.get("detected"))
         if new_det != cur_det:
@@ -901,90 +909,54 @@ def evaluate_single(
         return new_len < cur_len
 
     if result.get("false_positive") and fp_retries > 0:
-        retries = fp_retries
-        freq_thresh = freq_threshold
-        group_cnt = group_min_count
-        comb_ratio = combine_min_ratio
-        n_rules = num_rules
-        c_size = chunk_size
-        mode = combine_mode
-        first_retry = True
-        while retries > 0 and result.get("false_positive"):
-            retries -= 1
-            tokens_to_exclude = result.get("fp_matched_tokens", [])
-            prev_state = (
-                freq_thresh,
-                group_cnt,
-                comb_ratio,
-                n_rules,
-                c_size,
-                mode,
-                set(exclude_set),
-            )
-            if tokens_to_exclude:
-                exclude_set.update(t.lower() for t in tokens_to_exclude)
-                if persist_fp_exclude is not None:
-                    _FP_EXCLUDE_SET.update(t.lower() for t in tokens_to_exclude)
-                    _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
-                if LOGGER.isEnabledFor(logging.DEBUG):
-                    LOGGER.debug(
-                        "Excluding tokens due to FP retry: %s", tokens_to_exclude
-                    )
-            else:
-                if group_min_count is not None:
-                    group_cnt = (group_cnt or 0) + 1
-                else:
-                    if first_retry and mode == "or":
-                        comb_ratio = min(combine_max_ratio, comb_ratio + comb_ratio_step)
-                        if c_size is not None:
-                            c_size += chunk_size_step
-                        elif n_rules > num_rules_min:
-                            n_rules = max(num_rules_min, n_rules - 1)
-                    else:
-                        mode = "and"
-                        if n_rules > num_rules_min:
-                            n_rules = max(num_rules_min, n_rules - 1)
-                        c_size = None
+        tokens_to_exclude = result.get("fp_matched_tokens", [])
+        if tokens_to_exclude:
+            exclude_set.update(t.lower() for t in tokens_to_exclude)
+            if persist_fp_exclude is not None:
+                _FP_EXCLUDE_SET.update(t.lower() for t in tokens_to_exclude)
+                _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
+            LOGGER.info("Excluding tokens due to FP retry: %s", tokens_to_exclude)
+
+        # Build candidate parameter ranges
+        freq_vals = {freq_threshold}
+        group_vals = {group_min_count} if group_min_count is not None else {None}
+        ratio_vals = {combine_min_ratio}
+
+        for step in range(1, fp_retries + 1):
             if freq_threshold_step > 0:
-                freq_thresh = max(1, freq_thresh - freq_threshold_step)
-            result = _build_and_eval(
-                freq_thresh,
-                group_cnt,
-                comb_ratio,
-                n_rules=n_rules,
-                c_size=c_size,
-                mode=mode,
-                exclude=exclude_set,
-            )
-            if not result.get("detected"):
-                (
-                    freq_thresh,
-                    group_cnt,
-                    comb_ratio,
-                    n_rules,
-                    c_size,
-                    mode,
-                    exclude_prev,
-                ) = prev_state
-                exclude_set = set(exclude_prev)
-                if exclude_set:
-                    exclude_set.discard(next(iter(exclude_set)))
-                result = _build_and_eval(
-                    freq_thresh,
-                    group_cnt,
-                    comb_ratio,
-                    n_rules=n_rules,
-                    c_size=c_size,
-                    mode=mode,
-                    exclude=exclude_set,
-                )
-            if _is_better(result, best_result):
-                best_result = result
-                if best_result.get("detected"):
-                    last_detected_result = best_result
-            first_retry = False
-            if not result.get("false_positive"):
-                break
+                freq_vals.add(max(1, freq_threshold - step * freq_threshold_step))
+            if group_min_count is not None:
+                group_vals.add(group_min_count + step)
+            if comb_ratio_step > 0:
+                ratio_vals.add(min(combine_max_ratio, combine_min_ratio + step * comb_ratio_step))
+
+        for ft in sorted(freq_vals):
+            for gc in sorted(group_vals) if group_vals != {None} else [None]:
+                for cr in sorted(ratio_vals):
+                    trial = _build_and_eval(
+                        ft,
+                        gc,
+                        cr,
+                        n_rules=num_rules,
+                        c_size=chunk_size,
+                        mode=combine_mode,
+                        exclude=exclude_set,
+                    )
+                    if _is_better(trial, best_result):
+                        best_result = trial
+                        if best_result.get("detected"):
+                            last_detected_result = best_result
+                        LOGGER.info(
+                            "Improved with freq_threshold=%s group_min_count=%s combine_min_ratio=%.3f (detected=%s fp=%s)",
+                            ft,
+                            gc,
+                            cr,
+                            best_result.get("detected"),
+                            best_result.get("false_positive"),
+                        )
+                    if not trial.get("false_positive") and trial.get("detected"):
+                        result = trial
+                        break
 
     if not best_result.get("detected") and last_detected_result is not None:
         LOGGER.info("No detection after retries; using last detected result")


### PR DESCRIPTION
## Summary
- iterate through combinations of `freq_threshold`, `group_min_count`, and `combine_min_ratio` during FP retries
- update `_is_better` to clarify priority and improve logging
- log whenever a parameter combination yields better results

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688612fa1960832e8a5ed20faf0913cd