### PR TITLE
Fix preprocess usage in explainer script

### DIFF
--- a/scripts/single_sample_classify.py
+++ b/scripts/single_sample_classify.py
@@ -74,7 +74,11 @@ def preprocess(
     vocab_size: int = 0,
     use_embeds: bool = True,
 ) -> tuple[Path, str]:
-    """Run preprocessing stages for a single JSON sample."""
+    """Run preprocessing stages for a single JSON sample.
+
+    Returns the path to the generated ``.pt`` graph file along with the sample's
+    SHA256 hash.
+    """
     raw_dir = work_dir / "raw"
     views_dir = work_dir / "data" / "views"
     hetero_dir = work_dir / "data" / "hetero"

--- a/scripts/single_sample_explainer_tokens.py
+++ b/scripts/single_sample_explainer_tokens.py
@@ -45,7 +45,9 @@ def extract_top_tokens(
         with json_path.open("w", encoding="utf-8") as f:
             json.dump(json_obj, f)
 
-        graph, _ = preprocess(json_path, work_dir, device)
+        graph_path, _ = preprocess(json_path, work_dir, device)
+        # ``preprocess`` returns the path to the generated graph
+        graph = torch.load(graph_path, map_location="cpu", weights_only=False)
         saliency = _compute_saliency_with_explainer(graph, classifier, explainer, device_t)
 
         miner = FeatureMiner(top_k=threshold * 5)


### PR DESCRIPTION
## Summary
- use returned graph path from `preprocess()` in `single_sample_explainer_tokens`
- document that `preprocess()` returns the graph path

## Testing
- `pytest -k single_sample_explainer_tokens -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68861e1bbf60832e9cd6725426e38661