### PR TITLE
Improve benign freq token fallback

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -228,9 +228,7 @@ class FeatureMiner:
             cursor += s.numel()
         return torch.cat(pieces, dim=0), offsets
 
-    def _infer_offsets_from_data(
-        self, data: HeteroData
-    ) -> Dict[str, Tuple[int, int]]:
+    def _infer_offsets_from_data(self, data: HeteroData) -> Dict[str, Tuple[int, int]]:
         """
         flat saliency가 주어졌을 때 node_type별 offset 계산
         """
@@ -346,7 +344,7 @@ class FeatureMiner:
             "url": ["url", "uri"],
             "reg": ["reg", "key", "registry"],
         }
-        
+
         def _lookup(m, key):
             x = getattr(m, key, None)
             if x is None and hasattr(m, "meta"):
@@ -356,16 +354,24 @@ class FeatureMiner:
             return x
 
         # One-time, very detailed debug log for the first selected node.
-        if not hasattr(self, '_has_logged_detailed_meta'):
-            _LOG.debug("="*50)
+        if not hasattr(self, "_has_logged_detailed_meta"):
+            _LOG.debug("=" * 50)
             _LOG.debug(
                 f"DEBUG: Detailed inspection of first selected node (ntype='{ntype}', local_idx={local_idx})."
             )
-            _LOG.debug(f"DEBUG: All available keys in `meta` object: {list(meta.keys())}")
+            _LOG.debug(
+                f"DEBUG: All available keys in `meta` object: {list(meta.keys())}"
+            )
 
-            meta_content = _lookup(meta, 'meta')
-            if meta_content is not None and isinstance(meta_content, (list, tuple)) and local_idx < len(meta_content):
-                _LOG.debug(f"DEBUG: Content of `meta.meta` field: {meta_content[local_idx]}")
+            meta_content = _lookup(meta, "meta")
+            if (
+                meta_content is not None
+                and isinstance(meta_content, (list, tuple))
+                and local_idx < len(meta_content)
+            ):
+                _LOG.debug(
+                    f"DEBUG: Content of `meta.meta` field: {meta_content[local_idx]}"
+                )
             else:
                 _LOG.debug("DEBUG: `meta.meta` field not found or not accessible.")
 
@@ -374,27 +380,34 @@ class FeatureMiner:
                 keys = alias_map.get(attr, [attr])
                 for key in keys:
                     x = _lookup(meta, key)
-                    if x is None: continue
+                    if x is None:
+                        continue
                     if isinstance(x, (list, tuple)):
-                        if local_idx < len(x): return x[local_idx]
+                        if local_idx < len(x):
+                            return x[local_idx]
                         continue
                     if torch.is_tensor(x):
                         try:
                             arr = x[local_idx]
-                            if arr.ndim == 0: return str(arr.item())
+                            if arr.ndim == 0:
+                                return str(arr.item())
                             return bytes(arr.tolist()).decode(errors="ignore")
-                        except Exception: continue
+                        except Exception:
+                            continue
                     try:
                         return x[local_idx] if hasattr(x, "__getitem__") else x
-                    except Exception: continue
+                    except Exception:
+                        continue
                 return None
 
             for attr_to_test in ["name", "value", "syscall"]:
                 retrieved_val = _get_for_debug(attr_to_test)
-                _LOG.debug(f"DEBUG: _get('{attr_to_test}') returned: {retrieved_val} (type: {type(retrieved_val)})")
-            
+                _LOG.debug(
+                    f"DEBUG: _get('{attr_to_test}') returned: {retrieved_val} (type: {type(retrieved_val)})"
+                )
+
             self._has_logged_detailed_meta = True
-            _LOG.debug("="*50)
+            _LOG.debug("=" * 50)
 
         candidates: List[str] = []
 
@@ -454,7 +467,7 @@ class FeatureMiner:
             s = self._STRING_FILTER.sub("", string_val)
             # 짧거나 null bytes만 있으면 제외
             if len(s) >= 4 and any(c in string.printable for c in s):
-                yara = f"\"{s}\" wide ascii nocase"
+                yara = f'"{s}" wide ascii nocase'
                 candidates.append(yara)
 
         # 3) import library
@@ -493,7 +506,7 @@ class FeatureMiner:
         if isinstance(path_val, str):
             p = self._STRING_FILTER.sub("", path_val)
             if p:
-                candidates.append(f"\"{p}\" wide ascii nocase")
+                candidates.append(f'"{p}" wide ascii nocase')
                 for seg in re.split(r"[\\\\/]+", p):
                     seg = seg.strip()
                     if seg:
@@ -506,7 +519,7 @@ class FeatureMiner:
         if isinstance(reg_val, str):
             r = self._STRING_FILTER.sub("", reg_val)
             if r:
-                candidates.append(f"\"{r}\" wide ascii nocase")
+                candidates.append(f'"{r}" wide ascii nocase')
                 for seg in re.split(r"\\\\+", r):
                     seg = seg.strip()
                     if seg:
@@ -522,12 +535,12 @@ class FeatureMiner:
                 if domain:
                     candidates.append(f"url:{domain}")
                 path_part = m.group(2) or ""
-                for seg in path_part.split('/'):
+                for seg in path_part.split("/"):
                     seg = seg.strip()
                     if seg:
                         candidates.append(f"url:{seg}")
             elif u:
-                candidates.append(f"\"{u}\" wide ascii nocase")
+                candidates.append(f'"{u}" wide ascii nocase')
 
         # 이웃 노드 동시 선택 시 chain 토큰 생성
         if selected_set is not None and chain_label is not None:
@@ -556,15 +569,23 @@ class FeatureMiner:
                                 if arr.ndim == 0:
                                     nbr_name = str(arr.item())
                                 else:
-                                    nbr_name = bytes(arr.tolist()).decode(errors="ignore")
+                                    nbr_name = bytes(arr.tolist()).decode(
+                                        errors="ignore"
+                                    )
                             except Exception:
                                 continue
                         else:
                             try:
-                                nbr_name = val[nbr_local] if hasattr(val, "__getitem__") else val
+                                nbr_name = (
+                                    val[nbr_local]
+                                    if hasattr(val, "__getitem__")
+                                    else val
+                                )
                             except Exception:
                                 continue
-                        if isinstance(nbr_name, str) and self._API_RX.fullmatch(nbr_name):
+                        if isinstance(nbr_name, str) and self._API_RX.fullmatch(
+                            nbr_name
+                        ):
                             candidates.append(f"chain:{chain_label}→{nbr_name}")
                         break
 
@@ -616,7 +637,7 @@ class FeatureMiner:
 
             def _prefix(s: str) -> str:
                 if s.startswith('"'):
-                    return 'string'
+                    return "string"
                 if s.startswith("byte["):
                     return "byte"
                 return s.split(":", 1)[0]
@@ -683,13 +704,29 @@ class FeatureMiner:
                 )
 
         if not cand_order:
-            cand_order = sorted(
-                feats,
-                key=lambda x: (
-                    self.benign_freqs.get(x, float("inf")),
-                    -(sal_map.get(x, 0.0) if sal_map else 0.0),
-                ),
-            )
+            if self.mal_freqs:
+
+                def _ratio(tok: str) -> float:
+                    ben = self.benign_freqs.get(tok, float("inf"))
+                    mal = self.mal_freqs.get(tok, 0)
+                    return ben / mal if mal > 0 else float("inf")
+
+                cand_order = sorted(
+                    feats,
+                    key=lambda x: (
+                        _ratio(x),
+                        self.benign_freqs.get(x, float("inf")),
+                        -(sal_map.get(x, 0.0) if sal_map else 0.0),
+                    ),
+                )
+            else:
+                cand_order = sorted(
+                    feats,
+                    key=lambda x: (
+                        self.benign_freqs.get(x, float("inf")),
+                        -(sal_map.get(x, 0.0) if sal_map else 0.0),
+                    ),
+                )
 
         if self.verify_func:
             for c in cand_order:

--- a/tests/test_feature_miner_benign_freq.py
+++ b/tests/test_feature_miner_benign_freq.py
@@ -1,4 +1,5 @@
 import pytest
+
 pytest.importorskip("torch")
 pytest.importorskip("torch_geometric")
 
@@ -13,7 +14,9 @@ def test_benign_freq_filter_removes_common_token():
     g["func"].x = torch.zeros(1, 1)
     g["func"].name = ["CreateFileW"]
     sal = torch.tensor([1.0])
-    miner = FeatureMiner(top_k=1, benign_freqs={"call:CreateFileW": 10}, freq_threshold=5)
+    miner = FeatureMiner(
+        top_k=1, benign_freqs={"call:CreateFileW": 10}, freq_threshold=5
+    )
     feats = miner(g, sal)
     assert feats == ["call:CreateFileW"]
 
@@ -84,6 +87,25 @@ def test_select_high_mal_freq_token_with_verification():
         mal_freqs={"call:Foo": 90, "call:Bar": 45},
         freq_threshold=5,
         verify_func=_verify,
+    )
+
+    feats = miner(g, sal)
+
+    assert feats == ["call:Bar"]
+
+
+def test_restore_selects_lowest_ratio_when_no_high_mal():
+    g = HeteroData()
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["Foo", "Bar"]
+
+    sal = torch.tensor([0.8, 0.6])
+
+    miner = FeatureMiner(
+        top_k=2,
+        benign_freqs={"call:Foo": 10, "call:Bar": 20},
+        mal_freqs={"call:Foo": 5, "call:Bar": 20},
+        freq_threshold=5,
     )
 
     feats = miner(g, sal)


### PR DESCRIPTION
## Summary
- improve recovery candidate selection when all tokens filtered by benign frequency
- prioritize tokens with the lowest benign/malicious frequency ratio
- test the new fallback logic

## Testing
- `pytest tests/test_feature_miner_benign_freq.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68863b9b7840832ea071582aa56bb14a