### PR TITLE
Refine FP retry exclusion

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1007,11 +1007,36 @@ def evaluate_single(
     if result.get("false_positive") and fp_retries > 0:
         tokens_to_exclude = result.get("fp_matched_tokens", [])
         if tokens_to_exclude:
-            exclude_set.update(t.lower() for t in tokens_to_exclude)
-            if persist_fp_exclude is not None:
-                _FP_EXCLUDE_SET.update(t.lower() for t in tokens_to_exclude)
-                _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
-            LOGGER.debug("Excluding tokens due to FP retry: %s", tokens_to_exclude)
+            LOGGER.debug(
+                "Trying to exclude tokens due to FP retry: %s", tokens_to_exclude
+            )
+            for tok in tokens_to_exclude:
+                ltok = tok.lower()
+                if ltok in exclude_set:
+                    continue
+                exclude_set.add(ltok)
+                trial = _build_and_eval(
+                    freq_threshold,
+                    group_min_count,
+                    combine_min_ratio,
+                    group_ratio=group_min_ratio,
+                    n_rules=num_rules,
+                    c_size=chunk_size,
+                    mode=combine_mode,
+                    exclude=exclude_set,
+                )
+                if trial.get("detected"):
+                    result = trial
+                    if _is_better(trial, best_result):
+                        best_result = trial
+                        if best_result.get("detected"):
+                            last_detected_result = best_result
+                    if persist_fp_exclude is not None:
+                        _FP_EXCLUDE_SET.add(ltok)
+                        _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
+                else:
+                    exclude_set.remove(ltok)
+            LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
 
         # Build candidate parameter ranges
         freq_vals = {freq_threshold}

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1426,6 +1426,106 @@ def test_fp_tokens_accumulation(tmp_path, monkeypatch):
     assert sorted(res.get("fp_matched_tokens", [])) == ["call:bar", "call:foo"]
 
 
+def test_fp_retry_token_exclusion_rollback(tmp_path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    clean = tmp_path / "clean.bin"
+    clean.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["foo", "bar"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self, idents):
+            self.strings = [(0, ident, b"x") for ident in idents]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            p = str(path)
+            have_foo = "foo" in self.text
+            have_bar = "bar" in self.text
+            if "sample" in p:
+                if have_foo and have_bar:
+                    return [FakeMatch(["$s0", "$s1"])]
+                if have_foo:
+                    return [FakeMatch(["$s0"])]
+                if have_bar:
+                    return []
+                return []
+            if "clean" in p:
+                if have_foo and have_bar:
+                    return [FakeMatch(["$s0", "$s1"])]
+                if have_bar:
+                    return [FakeMatch(["$s1"])]
+                if have_foo:
+                    return []
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=clean,
+        clean_paths=None,
+        sample_json=None,
+        json_match=False,
+        combine_mode="or",
+        fp_retries=1,
+    )
+
+    assert res["detected"] is True
+    assert res["false_positive"] is False
+    assert res["rule_length"] == 1
+    assert "foo" in res["rule_texts"][0]
+    assert "bar" not in res["rule_texts"][0]
+    assert not res.get("fp_matched_tokens")
+
+
 def test_fp_retry_selects_best_result(tmp_path, monkeypatch):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)


### PR DESCRIPTION
## Summary
- exclude tokens one-by-one during FP retries so minimal tokens are removed
- add a test that verifies rollback behavior when token removal would break detection

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_retry_token_exclusion_rollback -q`

------
https://chatgpt.com/codex/tasks/task_e_6886404a574c832e98721628e24d834f