### PR TITLE
Allow freq_threshold to reach zero

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -215,6 +215,8 @@ python -m src.cli.explainer_rule_eval \
 
 `--freq-threshold-step`과 `--comb-ratio-step`을 사용하면 재시도 과정에서
 빈도 임계값을 낮추거나 병합 비율을 높여가며 규칙을 조정할 수 있습니다.
+`--freq-threshold`는 0 이상으로 설정할 수 있으며 `--freq-threshold-step`으로
+단계적 완화를 할 수 있습니다.
 `--enforce-self-detect` 옵션을 주면 현재 샘플이 탐지될 때까지 조건을 단계적으로 완화합니다.
 
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1045,7 +1045,7 @@ def evaluate_single(
 
         for step in range(1, fp_retries + 1):
             if freq_threshold_step > 0:
-                freq_vals.add(max(1, freq_threshold - step * freq_threshold_step))
+                freq_vals.add(max(0, freq_threshold - step * freq_threshold_step))
             if group_min_count is not None:
                 group_vals.add(group_min_count + step)
             if comb_ratio_step > 0:


### PR DESCRIPTION
## Summary
- permit frequency threshold search down to zero
- document how to relax frequency threshold in quick start guide

## Testing
- `pytest -k freq_threshold_step -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68864fc4b324832e807c8218a8bb7068