### PR TITLE
Add auto-relax for benign frequency filter

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -44,6 +44,8 @@ miner = FeatureMiner(
     dynamic_k=True,
     keep_per_type=20,
     freq_threshold=10,
+    # disable automatic relaxation if desired
+    auto_relax=True,
 )
 candidates = miner(data, saliency)
 print(candidates[:5])

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -332,6 +332,7 @@ def evaluate_single(
     mal_freqs: dict[str, int] | None = None,
     freq_ratio: float = 1.0,
     freq_threshold: float | int = 10,
+    auto_relax: bool = True,
     condition_type: str,
     percentage: int,
     min_count: int | None = None,
@@ -443,7 +444,7 @@ def evaluate_single(
         c_size: int | None = chunk_size,
         mode: str = combine_mode,
         exclude: Sequence[str] | None = None,
-    ) -> Dict[str, Any]:
+        ) -> Dict[str, Any]:
         miner = FeatureMiner(
             top_k=top_k,
             top_k_percent=top_k_percent,
@@ -456,6 +457,7 @@ def evaluate_single(
             mal_freqs=mal_freqs,
             freq_ratio=freq_ratio,
             freq_threshold=freq_thresh,
+            auto_relax=auto_relax,
         )
 
         if saliency_stats is None:
@@ -1219,6 +1221,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Frequency threshold for filtering",
     )
     p.add_argument(
+        "--no-auto-relax",
+        dest="auto_relax",
+        action="store_false",
+        help="Disable automatic relaxation of frequency thresholds",
+    )
+    p.add_argument(
         "--condition-type",
         choices=["any", "all", "percentage", "count", "combo"],
         default="combo",
@@ -1464,6 +1472,7 @@ def main(argv: list[str] | None = None) -> None:
                 "mal_freqs": mal_freqs,
                 "freq_ratio": args.freq_ratio,
                 "freq_threshold": args.freq_threshold,
+                "auto_relax": args.auto_relax,
                 "condition_type": args.condition_type,
                 "percentage": args.percentage,
                 "min_count": args.min_count,
@@ -1735,6 +1744,7 @@ def main(argv: list[str] | None = None) -> None:
             mal_freqs=mal_freqs,
             freq_ratio=args.freq_ratio,
             freq_threshold=args.freq_threshold,
+            auto_relax=args.auto_relax,
             condition_type=args.condition_type,
             percentage=args.percentage,
             min_count=args.min_count,

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -84,6 +84,7 @@ class FeatureMiner:
         mal_freqs: dict[str, int] | None = None,
         freq_ratio: float = 1.0,
         freq_threshold: float | int = 0,
+        auto_relax: bool = True,
         verify_func: callable | None = None,
     ) -> None:
         """
@@ -109,6 +110,7 @@ class FeatureMiner:
         self.mal_freqs = mal_freqs
         self.freq_ratio = float(freq_ratio)
         self.freq_threshold = freq_threshold
+        self.auto_relax = bool(auto_relax)
         self.verify_func = verify_func
 
     # ────────────────────────────────────────── benign freq updates ―
@@ -674,16 +676,27 @@ class FeatureMiner:
         if not self.benign_freqs:
             return list(feats)
         threshold = float(self.freq_threshold)
+        ratio = float(self.freq_ratio)
         filtered: List[str] = []
-        for f in feats:
-            freq = self.benign_freqs.get(f)
-            mal = self.mal_freqs.get(f) if self.mal_freqs else None
-            if freq is not None:
-                if freq >= threshold:
-                    continue
-                if mal is not None and freq >= mal * self.freq_ratio:
-                    continue
-            filtered.append(f)
+        while True:
+            filtered.clear()
+            for f in feats:
+                freq = self.benign_freqs.get(f)
+                mal = self.mal_freqs.get(f) if self.mal_freqs else None
+                if freq is not None:
+                    if freq >= threshold:
+                        continue
+                    if mal is not None and freq >= mal * ratio:
+                        continue
+                filtered.append(f)
+            if filtered or not feats or not self.auto_relax:
+                break
+            if threshold > 1:
+                threshold /= 2
+            if self.mal_freqs and ratio > 0:
+                ratio /= 2
+            if threshold <= 1 and (not self.mal_freqs or ratio <= 0):
+                break
         if filtered or not feats:
             return filtered
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -128,6 +128,23 @@ def test_build_parser_enforce_self_detect():
     assert args.enforce_self_detect is True
 
 
+def test_build_parser_no_auto_relax():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--no-auto-relax",
+        ]
+    )
+    assert args.auto_relax is False
+
+
 def test_build_parser_mal_freqs_ratio():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()


### PR DESCRIPTION
## Summary
- allow automatic relaxation of benign frequency thresholds in FeatureMiner
- expose the new behaviour via `--no-auto-relax` in the rule eval CLI
- document the option in the quick start guide
- test CLI parser for the new flag

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_no_auto_relax -q`
- `pytest tests/test_feature_miner_benign_freq.py::test_benign_freq_filter_removes_common_token -q`
- `pytest tests/test_feature_miner_benign_freq.py::test_restore_selects_lowest_ratio_when_no_high_mal -q`


------
https://chatgpt.com/codex/tasks/task_e_688651311868832e8cf479b3c448b522