### PR TITLE
Refine FP retry logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any, Dict, Sequence
+from collections import Counter
 import math
 import re
 
@@ -802,6 +803,7 @@ def evaluate_single(
         for toks in fp_tokens_all:
             if toks:
                 fp_tokens_flat.extend(toks)
+        fp_token_counts = Counter(fp_tokens_flat) if fp_tokens_flat else None
         matched_tokens_fp: list[str] | None = (
             sorted(set(fp_tokens_flat)) if fp_tokens_flat else None
         )
@@ -828,6 +830,8 @@ def evaluate_single(
             result["matched_tokens"] = matched_tokens_all_flat
         if matched_tokens_fp:
             result["fp_matched_tokens"] = matched_tokens_fp
+        if fp_token_counts:
+            result["fp_token_counts"] = dict(fp_token_counts)
 
         if sample_json is not None and sample_json.is_file() and first_feats:
             result["feature_verified"] = verify_features(
@@ -855,6 +859,8 @@ def evaluate_single(
             LOGGER.debug("matched_tokens: %s", matched_tokens_all_flat)
         if matched_tokens_fp:
             LOGGER.debug("fp_matched_tokens: %s", matched_tokens_fp)
+        if fp_token_counts:
+            LOGGER.debug("fp_token_counts: %s", fp_token_counts)
 
         return result
 
@@ -1007,16 +1013,23 @@ def evaluate_single(
         return new_len < cur_len
 
     if result.get("false_positive") and fp_retries > 0:
+        counts = result.get("fp_token_counts")
         tokens_to_exclude = result.get("fp_matched_tokens", [])
-        if tokens_to_exclude:
+        if counts:
+            ordered = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+            tokens_sorted = [t for t, _ in ordered]
+        else:
+            tokens_sorted = list(tokens_to_exclude)
+        if tokens_sorted:
             LOGGER.debug(
-                "Trying to exclude tokens due to FP retry: %s", tokens_to_exclude
+                "Trying to exclude tokens due to FP retry: %s", tokens_sorted
             )
-            for tok in tokens_to_exclude:
+            trial_excludes: set[str] = set()
+            for tok in tokens_sorted:
                 ltok = tok.lower()
-                if ltok in exclude_set:
+                if ltok in exclude_set or ltok in trial_excludes:
                     continue
-                exclude_set.add(ltok)
+                trial_excludes.add(ltok)
                 trial = _build_and_eval(
                     freq_threshold,
                     group_min_count,
@@ -1025,19 +1038,28 @@ def evaluate_single(
                     n_rules=num_rules,
                     c_size=chunk_size,
                     mode=combine_mode,
-                    exclude=exclude_set,
+                    exclude=exclude_set.union(trial_excludes),
                 )
-                if trial.get("detected"):
+                LOGGER.info(
+                    "FP retry exclude '%s' -> detected=%s fp=%s",
+                    tok,
+                    trial.get("detected"),
+                    trial.get("false_positive"),
+                )
+                if not trial.get("detected"):
+                    trial_excludes.remove(ltok)
+                    continue
+                if _is_better(trial, best_result):
+                    best_result = trial
+                    if best_result.get("detected"):
+                        last_detected_result = best_result
+                if not trial.get("false_positive"):
+                    exclude_set.update(trial_excludes)
                     result = trial
-                    if _is_better(trial, best_result):
-                        best_result = trial
-                        if best_result.get("detected"):
-                            last_detected_result = best_result
                     if persist_fp_exclude is not None:
-                        _FP_EXCLUDE_SET.add(ltok)
+                        _FP_EXCLUDE_SET.update(trial_excludes)
                         _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
-                else:
-                    exclude_set.remove(ltok)
+                    break
             LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
 
         # Build candidate parameter ranges
@@ -1560,12 +1582,15 @@ def main(argv: list[str] | None = None) -> None:
                             for col in (
                                 "matched_tokens",
                                 "fp_matched_tokens",
+                                "fp_token_counts",
                                 "group_min_count",
                                 "freq_threshold",
                             ):
                                 if col not in df_flush.columns:
                                     df_flush[col] = [
-                                        [] if col == "fp_matched_tokens" else None
+                                        []
+                                        if col in ("fp_matched_tokens", "fp_token_counts")
+                                        else None
                                         for _ in range(len(df_flush))
                                     ]
                             df_flush.to_csv(
@@ -1664,12 +1689,15 @@ def main(argv: list[str] | None = None) -> None:
                     for col in (
                         "matched_tokens",
                         "fp_matched_tokens",
+                        "fp_token_counts",
                         "group_min_count",
                         "freq_threshold",
                     ):
                         if col not in df_flush.columns:
                             df_flush[col] = [
-                                [] if col == "fp_matched_tokens" else None
+                                []
+                                if col in ("fp_matched_tokens", "fp_token_counts")
+                                else None
                                 for _ in range(len(df_flush))
                             ]
                     df_flush.to_csv(
@@ -1683,12 +1711,15 @@ def main(argv: list[str] | None = None) -> None:
                 for col in (
                     "matched_tokens",
                     "fp_matched_tokens",
+                    "fp_token_counts",
                     "group_min_count",
                     "freq_threshold",
                 ):
                     if col not in df.columns:
                         df[col] = [
-                            [] if col == "fp_matched_tokens" else None
+                            []
+                            if col in ("fp_matched_tokens", "fp_token_counts")
+                            else None
                             for _ in range(len(df))
                         ]
                 df.to_csv(args.out_csv, index=False)


### PR DESCRIPTION
## Summary
- refine FP retry loop to drop tokens individually based on frequency
- persist FP token counts in output and include in CSV exports
- log token exclusion attempts and outcomes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688654c16c00832eacd5a69845ed5c86