### PR TITLE
Change FP retry logging level

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1040,7 +1040,7 @@ def evaluate_single(
                     mode=combine_mode,
                     exclude=exclude_set.union(trial_excludes),
                 )
-                LOGGER.info(
+                LOGGER.debug(
                     "FP retry exclude '%s' -> detected=%s fp=%s",
                     tok,
                     trial.get("detected"),


### PR DESCRIPTION
## Summary
- reduce verbosity of FP retry messages by logging at DEBUG

## Testing
- `pytest -k test_explainer_rule_eval_cli -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6886567fcd20832ebc43bb43b9a03958