### PR TITLE
Add persistent FP token counting

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Mapping
 from collections import Counter
 import math
 import re
@@ -24,29 +24,33 @@ from rulegen.yara_builder import YaraBuilder
 LOGGER = get_logger(__name__)
 
 # Persistent false positive exclude tokens
+_FP_EXCLUDE_COUNTS: Counter[str] = Counter()
 _FP_EXCLUDE_SET: set[str] = set()
 _FP_EXCLUDE_PATH: Path | None = None
 
 
-def _load_fp_exclude(path: Path) -> set[str]:
+def _load_fp_exclude(path: Path) -> Counter[str]:
     """Load persistent FP exclude tokens from ``path``."""
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return Counter({str(k).lower(): int(v) for k, v in data.items()})
         if isinstance(data, list):
-            return {str(t).lower() for t in data}
+            return Counter({str(t).lower(): 1 for t in data})
     except FileNotFoundError:
-        return set()
+        return Counter()
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Failed to read %s: %s", path, exc)
-    return set()
+    return Counter()
 
 
-def _save_fp_exclude(path: Path, tokens: set[str]) -> None:
-    """Persist FP exclude ``tokens`` to ``path``."""
+def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
+    """Persist FP exclude ``tokens`` and counts to ``path``."""
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        data = {k: int(v) for k, v in tokens.items()}
         path.write_text(
-            json.dumps(sorted(tokens), ensure_ascii=False, indent=2),
+            json.dumps(data, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
     except Exception as exc:  # noqa: BLE001
@@ -365,11 +369,14 @@ def evaluate_single(
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
-    global _FP_EXCLUDE_SET, _FP_EXCLUDE_PATH
+    global _FP_EXCLUDE_SET, _FP_EXCLUDE_COUNTS, _FP_EXCLUDE_PATH
     if persist_fp_exclude is not None:
         if _FP_EXCLUDE_PATH != persist_fp_exclude:
             _FP_EXCLUDE_PATH = persist_fp_exclude
-            _FP_EXCLUDE_SET = _load_fp_exclude(persist_fp_exclude)
+            _FP_EXCLUDE_COUNTS = _load_fp_exclude(persist_fp_exclude)
+            _FP_EXCLUDE_SET = set(_FP_EXCLUDE_COUNTS.keys())
+
+    fp_token_counter: Counter[str] = Counter()
 
     LOGGER.debug("Loading graph from %s", graph_path)
     graph: HeteroData = torch.load(graph_path, map_location="cpu", weights_only=False)
@@ -864,11 +871,37 @@ def evaluate_single(
 
         return result
 
+    def _eval_with_count(
+        f_thresh: float | int,
+        g_cnt: int | None,
+        c_ratio: float,
+        *,
+        group_ratio: float = 0.0,
+        n_rules: int = num_rules,
+        c_size: int | None = chunk_size,
+        mode: str = combine_mode,
+        exclude: Sequence[str] | None = None,
+    ) -> Dict[str, Any]:
+        res = _build_and_eval(
+            f_thresh,
+            g_cnt,
+            c_ratio,
+            group_ratio=group_ratio,
+            n_rules=n_rules,
+            c_size=c_size,
+            mode=mode,
+            exclude=exclude,
+        )
+        cnts = res.get("fp_token_counts")
+        if cnts:
+            fp_token_counter.update({k.lower(): int(v) for k, v in cnts.items()})
+        return res
+
     exclude_set: set[str] = set(t.lower() for t in (exclude_tokens or []))
     if persist_fp_exclude is not None:
         exclude_set.update(_FP_EXCLUDE_SET)
 
-    result = _build_and_eval(
+    result = _eval_with_count(
         freq_threshold,
         group_min_count,
         combine_min_ratio,
@@ -886,7 +919,7 @@ def evaluate_single(
                 "Detection failed; retrying with combine_min_ratio=%.3f",
                 relax_ratio,
             )
-            relaxed = _build_and_eval(
+            relaxed = _eval_with_count(
                 freq_threshold,
                 group_min_count,
                 relax_ratio,
@@ -913,7 +946,7 @@ def evaluate_single(
                 "Detection still failed; retrying with group_min_count=%d",
                 relax_cnt,
             )
-            relaxed = _build_and_eval(
+            relaxed = _eval_with_count(
                 freq_threshold,
                 relax_cnt,
                 relax_ratio,
@@ -939,7 +972,7 @@ def evaluate_single(
         freq_th = freq_threshold
         while comb_ratio > 0.0 and not result.get("detected"):
             comb_ratio = max(0.0, round(comb_ratio - 0.1, 3))
-            result = _build_and_eval(
+            result = _eval_with_count(
                 freq_th,
                 grp_cnt,
                 comb_ratio,
@@ -951,7 +984,7 @@ def evaluate_single(
             )
         if grp_cnt and not result.get("detected"):
             for cnt in range(grp_cnt - 1, 0, -1):
-                result = _build_and_eval(
+                result = _eval_with_count(
                     freq_th,
                     cnt,
                     comb_ratio,
@@ -967,7 +1000,7 @@ def evaluate_single(
         if not result.get("detected") and freq_th > 1:
             while freq_th > 1 and not result.get("detected"):
                 freq_th = max(1, freq_th - 1)
-                result = _build_and_eval(
+                result = _eval_with_count(
                     freq_th,
                     grp_cnt,
                     comb_ratio,
@@ -1016,7 +1049,10 @@ def evaluate_single(
         counts = result.get("fp_token_counts")
         tokens_to_exclude = result.get("fp_matched_tokens", [])
         if counts:
-            ordered = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+            for t, c in counts.items():
+                fp_token_counter[t.lower()] += int(c)
+        if fp_token_counter:
+            ordered = sorted(fp_token_counter.items(), key=lambda x: (-x[1], x[0]))
             tokens_sorted = [t for t, _ in ordered]
         else:
             tokens_sorted = list(tokens_to_exclude)
@@ -1030,7 +1066,7 @@ def evaluate_single(
                 if ltok in exclude_set or ltok in trial_excludes:
                     continue
                 trial_excludes.add(ltok)
-                trial = _build_and_eval(
+                trial = _eval_with_count(
                     freq_threshold,
                     group_min_count,
                     combine_min_ratio,
@@ -1057,8 +1093,10 @@ def evaluate_single(
                     exclude_set.update(trial_excludes)
                     result = trial
                     if persist_fp_exclude is not None:
+                        for t in trial_excludes:
+                            _FP_EXCLUDE_COUNTS[t] += 1
                         _FP_EXCLUDE_SET.update(trial_excludes)
-                        _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_SET)
+                        _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
                     break
             LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
 
@@ -1080,7 +1118,7 @@ def evaluate_single(
         for ft in sorted(freq_vals):
             for gc in sorted(group_vals) if group_vals != {None} else [None]:
                 for cr in sorted(ratio_vals):
-                    trial = _build_and_eval(
+                    trial = _eval_with_count(
                         ft,
                         gc,
                         cr,
@@ -1106,10 +1144,14 @@ def evaluate_single(
                         result = trial
                         break
 
+    out_result = best_result
     if not best_result.get("detected") and last_detected_result is not None:
         LOGGER.info("No detection after retries; using last detected result")
-        return last_detected_result
-    return best_result
+        out_result = last_detected_result
+    if fp_token_counter:
+        out_result.setdefault("fp_token_counts_total", {})
+        out_result["fp_token_counts_total"] = dict(fp_token_counter)
+    return out_result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- track false positive token counts across evaluation attempts
- sort retry tokens by cumulative frequency
- persist cumulative counts when excluding tokens

## Testing
- `pytest -q` *(fails: missing heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886606ce214832ea8aa583d20ba72fa