### PR TITLE
Improve self-detection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,11 +294,12 @@ python -m src.cli.explainer_rule_eval \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt \
     --fp-retries 2 --freq-threshold-step 1 --comb-ratio-step 0.2
 
-# enforce self-detection by relaxing thresholds
+# enforce self-detection by lowering frequency threshold and
+# expanding chunk size automatically
 python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt \
-    --enforce-self-detect
+    --enforce-self-detect --freq-threshold-step 1 --chunk-size-step 2
 
 # require at least two matches per group
 python -m src.cli.explainer_rule_eval \

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -934,9 +934,18 @@ def evaluate_single(
                 LOGGER.debug("Relaxed parameters did not yield detection")
 
     if enforce_self_detect and not result.get("detected"):
+        # progressively relax parameters in the following order until
+        # the sample is detected:
+        #   1. lower combine_min_ratio
+        #   2. decrease group_min_count
+        #   3. lower freq_threshold step-wise
+        #   4. enlarge chunk_size to include more features
         comb_ratio = combine_min_ratio
         grp_cnt = group_min_count
         freq_th = freq_threshold
+        csize = chunk_size or 0
+
+        # 1) lower combine_min_ratio
         while comb_ratio > 0.0 and not result.get("detected"):
             comb_ratio = max(0.0, round(comb_ratio - 0.1, 3))
             result = _build_and_eval(
@@ -945,10 +954,12 @@ def evaluate_single(
                 comb_ratio,
                 group_ratio=group_min_ratio,
                 n_rules=num_rules,
-                c_size=chunk_size,
+                c_size=csize,
                 mode=combine_mode,
                 exclude=exclude_set,
             )
+
+        # 2) reduce group_min_count
         if grp_cnt and not result.get("detected"):
             for cnt in range(grp_cnt - 1, 0, -1):
                 result = _build_and_eval(
@@ -957,23 +968,44 @@ def evaluate_single(
                     comb_ratio,
                     group_ratio=group_min_ratio,
                     n_rules=num_rules,
-                    c_size=chunk_size,
+                    c_size=csize,
                     mode=combine_mode,
                     exclude=exclude_set,
                 )
                 if result.get("detected"):
                     grp_cnt = cnt
                     break
+
+        # 3) gradually lower frequency threshold
         if not result.get("detected") and freq_th > 1:
+            step = freq_threshold_step if freq_threshold_step > 0 else 1
             while freq_th > 1 and not result.get("detected"):
-                freq_th = max(1, freq_th - 1)
+                freq_th = max(1, freq_th - step)
                 result = _build_and_eval(
                     freq_th,
                     grp_cnt,
                     comb_ratio,
                     group_ratio=group_min_ratio,
                     n_rules=num_rules,
-                    c_size=chunk_size,
+                    c_size=csize,
+                    mode=combine_mode,
+                    exclude=exclude_set,
+                )
+
+        # 4) increase chunk_size to include more features
+        if not result.get("detected"):
+            step = chunk_size_step if chunk_size_step > 0 else 1
+            csize = max(1, csize)
+            limit = top_k if top_k > 0 else 100
+            while csize < limit and not result.get("detected"):
+                csize += step
+                result = _build_and_eval(
+                    freq_th,
+                    grp_cnt,
+                    comb_ratio,
+                    group_ratio=group_min_ratio,
+                    n_rules=num_rules,
+                    c_size=csize,
                     mode=combine_mode,
                     exclude=exclude_set,
                 )


### PR DESCRIPTION
## Summary
- relax parameters sequentially in `evaluate_single`
- document new `--enforce-self-detect` usage in README

## Testing
- `pytest -k test_build_parser_enforce_self_detect tests/test_explainer_rule_eval_cli.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6886604eeaa0832ebe73fe289195063d