### PR TITLE
Improve candidate feature fallback

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -12,7 +12,7 @@ import re
 
 import logging
 from src.common.utils import get_logger, tqdm_wrap
-from src.graphs.loaders.common_token_utils import split_name
+from src.graphs.loaders.common_token_utils import split_name, TOKEN_RE
 
 import torch
 from torch_geometric.data import HeteroData
@@ -502,6 +502,76 @@ def evaluate_single(
                     saliency_stats=saliency_stats,
                 )
             ]
+            if not filtered:
+                LOGGER.debug(
+                    "No mined features present in JSON; relaxing thresholds"
+                )
+                relax_freq = (
+                    max(1, freq_thresh - 1)
+                    if isinstance(freq_thresh, (int, float)) and freq_thresh
+                    else freq_thresh
+                )
+                relax_sal = max(min_saliency * 0.5, 0.0)
+                miner_relax = FeatureMiner(
+                    top_k=top_k,
+                    top_k_percent=top_k_percent,
+                    saliency_top_percent=saliency_top_percent,
+                    dynamic_k=dynamic_k,
+                    min_saliency=relax_sal,
+                    keep_per_type=keep_per_type,
+                    max_per_prefix=max_per_prefix,
+                    benign_freqs=benign_freqs,
+                    mal_freqs=mal_freqs,
+                    freq_ratio=freq_ratio,
+                    freq_threshold=relax_freq,
+                    auto_relax=auto_relax,
+                )
+                if saliency_stats is None:
+                    retry_feats = miner_relax.mine(graph, saliency)
+                else:
+                    retry_feats = miner_relax.mine(graph, saliency, saliency_stats)
+                filtered = [
+                    f
+                    for f in retry_feats
+                    if verify_features(
+                        sample_json,
+                        [f],
+                        condition_type=condition_type,
+                        group_percentage=group_pct,
+                        group_min_count=group_cnt,
+                        adjust_group_percentage=adjust_group_percentage,
+                        saliency_stats=saliency_stats,
+                    )
+                ]
+
+            if not filtered:
+                LOGGER.debug("No features after retry; extracting tokens from JSON")
+                try:
+                    js_obj = json.loads(sample_json.read_text(encoding="utf-8"))
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to read %s: %s", sample_json, exc)
+                    js_obj = {}
+                text_fields = []
+                for key in ("c_code", "h_code", "asm_code", "llvm_ir"):
+                    text_fields.extend(js_obj.get(key, []))
+                joined = "\n".join(text_fields)
+                tokens = sorted(
+                    {m.group(0).lower() for m in TOKEN_RE.finditer(joined)}
+                )
+                filtered = [
+                    t
+                    for t in tokens
+                    if verify_features(
+                        js_obj,
+                        [t],
+                        condition_type=condition_type,
+                        group_percentage=group_pct,
+                        group_min_count=group_cnt,
+                        adjust_group_percentage=adjust_group_percentage,
+                        saliency_stats=saliency_stats,
+                    )
+                ]
+
             if not filtered and features:
                 filtered = [features[0]]
             features = filtered


### PR DESCRIPTION
## Summary
- attempt relaxed mining when mined features have no match in the JSON
- fall back to extracting tokens from JSON when still empty
- import `TOKEN_RE`

## Testing
- `pytest -k explainer_rule_eval_cli -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688662872d0c832ea75a0a8aece5fab0