### PR TITLE
Adjust self-detection tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ python -m src.cli.explainer_rule_eval \
 python -m src.cli.explainer_rule_eval \
     --graph graph.pt --sample sample.bin \
     --saliency sal.pt --classifier models/gnn/res_gcl.pt \
-    --enforce-self-detect
+    --enforce-self-detect --freq-threshold-step 1 --chunk-size-step 2
 
 # require at least two matches per group
 python -m src.cli.explainer_rule_eval \

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -970,6 +970,9 @@ def evaluate_single(
         comb_ratio = combine_min_ratio
         grp_cnt = group_min_count
         freq_th = freq_threshold
+        c_size = chunk_size
+
+        # step 1: loosen combine_min_ratio and group_min_count
         while comb_ratio > 0.0 and not result.get("detected"):
             comb_ratio = max(0.0, round(comb_ratio - 0.1, 3))
             result = _eval_with_count(
@@ -978,10 +981,11 @@ def evaluate_single(
                 comb_ratio,
                 group_ratio=group_min_ratio,
                 n_rules=num_rules,
-                c_size=chunk_size,
+                c_size=c_size,
                 mode=combine_mode,
                 exclude=exclude_set,
             )
+
         if grp_cnt and not result.get("detected"):
             for cnt in range(grp_cnt - 1, 0, -1):
                 result = _eval_with_count(
@@ -990,27 +994,48 @@ def evaluate_single(
                     comb_ratio,
                     group_ratio=group_min_ratio,
                     n_rules=num_rules,
-                    c_size=chunk_size,
+                    c_size=c_size,
                     mode=combine_mode,
                     exclude=exclude_set,
                 )
                 if result.get("detected"):
                     grp_cnt = cnt
                     break
-        if not result.get("detected") and freq_th > 1:
-            while freq_th > 1 and not result.get("detected"):
-                freq_th = max(1, freq_th - 1)
-                result = _eval_with_count(
-                    freq_th,
-                    grp_cnt,
-                    comb_ratio,
-                    group_ratio=group_min_ratio,
-                    n_rules=num_rules,
-                    c_size=chunk_size,
-                    mode=combine_mode,
-                    exclude=exclude_set,
-                )
 
+        # step 2: lower freq_threshold gradually and enlarge chunk_size.
+        # exit early whenever detection succeeds
+        freq_step = freq_threshold_step if freq_threshold_step > 0 else 1
+        chunk_step = chunk_size_step if chunk_size_step > 0 else 1
+        attempts = 0
+        while not result.get("detected") and attempts < 10:
+            if freq_th > 0:
+                freq_th = max(0, freq_th - freq_step)
+            result = _eval_with_count(
+                freq_th,
+                grp_cnt,
+                comb_ratio,
+                group_ratio=group_min_ratio,
+                n_rules=num_rules,
+                c_size=c_size,
+                mode=combine_mode,
+                exclude=exclude_set,
+            )
+            if result.get("detected"):
+                break
+
+            c_size = (c_size or 0) + chunk_step
+            result = _eval_with_count(
+                freq_th,
+                grp_cnt,
+                comb_ratio,
+                group_ratio=group_min_ratio,
+                n_rules=num_rules,
+                c_size=c_size,
+                mode=combine_mode,
+                exclude=exclude_set,
+            )
+            attempts += 1
+            
     best_result = result
     last_detected_result: Dict[str, Any] | None = None
     if best_result.get("detected"):


### PR DESCRIPTION
## Summary
- tweak the fallback loop in `evaluate_single`
- expand self-detect example with new options

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_enforce_self_detect -q`
- `pytest -q` *(fails: FileNotFoundError and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68866281f2e0832e998fe200032cf8df