### PR TITLE
Implement auto group min scaling

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -363,6 +363,7 @@ def evaluate_single(
     chunk_size_step: int = 1,
     num_rules_min: int = 1,
     group_min_ratio: float = 0.0,
+    auto_group_min: bool = True,
     exclude_tokens: Sequence[str] | None = None,
     persist_fp_exclude: Path | None = None,
     clean_json_cache: Dict[Path, Any] | None = None,
@@ -452,6 +453,7 @@ def evaluate_single(
         c_size: int | None = chunk_size,
         mode: str = combine_mode,
         exclude: Sequence[str] | None = None,
+        auto_gmin: bool = auto_group_min,
         ) -> Dict[str, Any]:
         miner = FeatureMiner(
             top_k=top_k,
@@ -608,6 +610,7 @@ def evaluate_single(
                 group_percentage=group_pct,
                 group_min_count=group_cnt,
                 group_min_count_ratio=group_ratio,
+                auto_group_min=auto_gmin,
                 adjust_group_percentage=adjust_group_percentage,
             )
             rule_text, id_map = builder.build(feats, return_map=True)
@@ -951,6 +954,7 @@ def evaluate_single(
         c_size: int | None = chunk_size,
         mode: str = combine_mode,
         exclude: Sequence[str] | None = None,
+        auto_gmin: bool = auto_group_min,
     ) -> Dict[str, Any]:
         res = _build_and_eval(
             f_thresh,
@@ -961,6 +965,7 @@ def evaluate_single(
             c_size=c_size,
             mode=mode,
             exclude=exclude,
+            auto_gmin=auto_gmin,
         )
         cnts = res.get("fp_token_counts")
         if cnts:
@@ -980,6 +985,7 @@ def evaluate_single(
         c_size=chunk_size,
         mode=combine_mode,
         exclude=exclude_set,
+        auto_gmin=auto_group_min,
     )
 
     if not result.get("detected"):
@@ -998,6 +1004,7 @@ def evaluate_single(
                 c_size=chunk_size,
                 mode=combine_mode,
                 exclude=exclude_set,
+                auto_gmin=auto_group_min,
             )
             if relaxed.get("detected"):
                 LOGGER.debug(
@@ -1025,6 +1032,7 @@ def evaluate_single(
                 c_size=chunk_size,
                 mode=combine_mode,
                 exclude=exclude_set,
+                auto_gmin=auto_group_min,
             )
             if relaxed.get("detected"):
                 LOGGER.debug(
@@ -1054,6 +1062,7 @@ def evaluate_single(
                 c_size=c_size,
                 mode=combine_mode,
                 exclude=exclude_set,
+                auto_gmin=auto_group_min,
             )
 
         if grp_cnt and not result.get("detected"):
@@ -1089,6 +1098,7 @@ def evaluate_single(
                 c_size=c_size,
                 mode=combine_mode,
                 exclude=exclude_set,
+                auto_gmin=auto_group_min,
             )
             if result.get("detected"):
                 break
@@ -1170,6 +1180,7 @@ def evaluate_single(
                     c_size=chunk_size,
                     mode=combine_mode,
                     exclude=exclude_set.union(trial_excludes),
+                    auto_gmin=auto_group_min,
                 )
                 LOGGER.debug(
                     "FP retry exclude '%s' -> detected=%s fp=%s",
@@ -1222,6 +1233,7 @@ def evaluate_single(
                         c_size=chunk_size,
                         mode=combine_mode,
                         exclude=exclude_set,
+                        auto_gmin=auto_group_min,
                     )
                     if _is_better(trial, best_result):
                         best_result = trial
@@ -1417,8 +1429,14 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         help="combo mode: minimum matches per group",
     )
+    class _GroupMinRatioAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, float(values))
+            setattr(namespace, "auto_group_min", True)
+
     p.add_argument(
         "--group-min-ratio",
+        action=_GroupMinRatioAction,
         type=float,
         default=0.0,
         help=(
@@ -1426,6 +1444,7 @@ def build_parser() -> argparse.ArgumentParser:
             "--group-min-count so smaller groups are relaxed automatically"
         ),
     )
+    p.set_defaults(auto_group_min=False)
     p.add_argument(
         "--adjust-group-percentage",
         action="store_true",
@@ -1641,6 +1660,7 @@ def main(argv: list[str] | None = None) -> None:
                 "group_percentage": args.group_percentage,
                 "group_min_count": args.group_min_count,
                 "group_min_ratio": args.group_min_ratio,
+                "auto_group_min": args.auto_group_min,
                 "adjust_group_percentage": args.adjust_group_percentage,
                 "num_rules": args.num_rules,
                 "chunk_size": args.chunk_size,
@@ -1922,6 +1942,7 @@ def main(argv: list[str] | None = None) -> None:
             group_percentage=args.group_percentage,
             group_min_count=args.group_min_count,
             group_min_ratio=args.group_min_ratio,
+            auto_group_min=args.auto_group_min,
             adjust_group_percentage=args.adjust_group_percentage,
             num_rules=args.num_rules,
             chunk_size=args.chunk_size,

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -113,6 +113,7 @@ class YaraBuilder:
         group_percentage: int | None = None,
         group_min_count: int | None = None,
         group_min_count_ratio: float = 0.0,
+        auto_group_min: bool = True,
         adjust_group_percentage: bool = False,
         tokenizer: Optional[PreTrainedTokenizer] = None,
         strip_prefix: bool = True,
@@ -130,6 +131,7 @@ class YaraBuilder:
         self.group_percentage = group_percentage
         self.group_min_count = group_min_count
         self.group_min_count_ratio = group_min_count_ratio
+        self.auto_group_min = auto_group_min
         self.adjust_group_percentage = adjust_group_percentage
 
     def _scaled_group_percentage(self, n_feats: int) -> int:
@@ -141,6 +143,29 @@ class YaraBuilder:
         scaled = int(round(self.group_percentage / math.sqrt(n_feats)))
         scaled = max(1, min(self.group_percentage, scaled))
         return scaled
+
+    def _group_required(self, n_feats: int) -> int:
+        """Return minimum required matches for a feature group."""
+        if n_feats <= 0:
+            return 0
+
+        if self.auto_group_min and self.group_min_count_ratio > 0:
+            req = max(1, math.ceil(n_feats * self.group_min_count_ratio))
+            if self.group_min_count is not None:
+                req = max(req, self.group_min_count)
+            if n_feats <= 3:
+                req = min(req, 1 if n_feats <= 2 else 2)
+            return min(req, n_feats)
+
+        if self.group_min_count is not None:
+            req = max(int(n_feats * self.group_min_count_ratio), self.group_min_count or 0)
+            return min(req, n_feats)
+
+        if self.group_min_count_ratio > 0:
+            req = max(1, math.ceil(n_feats * self.group_min_count_ratio))
+            return min(req, n_feats)
+
+        return 1
 
     def _detokenize(self, tokens: Sequence[str]) -> str:
         """
@@ -274,18 +299,14 @@ class YaraBuilder:
                     feats_list = groups[tag]
                     if tag == "m":
                         cond_line = f"    {len(feats_list)} of ($m*)"
-                    elif self.group_min_count is not None:
-                        required = max(
-                            int(len(feats_list) * self.group_min_count_ratio),
-                            self.group_min_count or 0,
-                        )
-                        required = min(required, len(feats_list))
-                        cond_line = f"    {required} of (${tag}*)"
                     elif self.group_percentage is not None:
                         pct = self.group_percentage
                         if self.adjust_group_percentage:
                             pct = self._scaled_group_percentage(len(feats_list))
                         required = max(1, math.ceil(len(feats_list) * pct / 100.0))
+                        cond_line = f"    {required} of (${tag}*)"
+                    elif self.group_min_count is not None or self.group_min_count_ratio > 0:
+                        required = self._group_required(len(feats_list))
                         cond_line = f"    {required} of (${tag}*)"
                     else:
                         required = max(2, len(feats_list))
@@ -298,12 +319,8 @@ class YaraBuilder:
                         if tag == "m":
                             parts.append(f"{len(feats_list)} of ($m*)")
                             continue
-                        if self.group_min_count is not None:
-                            required = max(
-                                int(len(feats_list) * self.group_min_count_ratio),
-                                self.group_min_count or 0,
-                            )
-                            required = min(required, len(feats_list))
+                        if self.group_min_count is not None or self.group_min_count_ratio > 0:
+                            required = self._group_required(len(feats_list))
                         elif self.group_percentage is not None:
                             pct = self.group_percentage
                             if self.adjust_group_percentage:
@@ -319,12 +336,8 @@ class YaraBuilder:
                 feats_list = groups[tag]
                 if tag == "m":
                     cond_line = f"    {len(feats_list)} of ($m*)"
-                elif self.group_min_count is not None:
-                    required = max(
-                        int(len(feats_list) * self.group_min_count_ratio),
-                        self.group_min_count or 0,
-                    )
-                    required = min(required, len(feats_list))
+                elif self.group_min_count is not None or self.group_min_count_ratio > 0:
+                    required = self._group_required(len(feats_list))
                     cond_line = f"    {required} of (${tag}*)"
                 elif self.group_percentage is not None:
                     pct = self.group_percentage
@@ -342,12 +355,8 @@ class YaraBuilder:
                     if tag == "m":
                         parts.append(f"{len(feats_list)} of ($m*)")
                         continue
-                    if self.group_min_count is not None:
-                        required = max(
-                            int(len(feats_list) * self.group_min_count_ratio),
-                            self.group_min_count or 0,
-                        )
-                        required = min(required, len(feats_list))
+                    if self.group_min_count is not None or self.group_min_count_ratio > 0:
+                        required = self._group_required(len(feats_list))
                         parts.append(f"{required} of (${tag}*)")
                     elif self.group_percentage is not None:
                         pct = self.group_percentage

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -182,6 +182,7 @@ def test_build_parser_group_min_ratio():
         ]
     )
     assert args.group_min_ratio == 0.5
+    assert args.auto_group_min is True
 
 
 def test_cli_runs_and_writes_json(tmp_path, caplog):
@@ -300,6 +301,46 @@ def test_cli_condition_type_combo(tmp_path):
 
     data = json.loads(out.read_text())
     assert "detected" in data
+
+
+def test_cli_group_min_ratio_auto(tmp_path):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    out = tmp_path / "res.json"
+    mod.main(
+        [
+            "--graph",
+            str(gpath),
+            "--sample",
+            str(sample),
+            "--saliency",
+            str(salpath),
+            "--classifier",
+            str(sample),
+            "--condition-type",
+            "combo",
+            "--group-min-ratio",
+            "0.5",
+            "--out",
+            str(out),
+        ]
+    )
+
+    data = json.loads(out.read_text())
+    assert data.get("detected") is not None
 
 
 def test_cli_sample_rules_out(tmp_path):

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -84,8 +84,8 @@ def test_combo_marker_group_mandatory():
 def test_combo_group_min_ratio():
     builder = YaraBuilder(
         condition_type="combo",
-        group_min_count=1,
-        group_min_count_ratio=0.75,
+        group_min_count_ratio=0.5,
+        auto_group_min=True,
     )
     rule = builder.build(["call:A", "call:B", "import:X", "import:Y"])
     assert "1 of ($c*)" in rule
@@ -97,8 +97,8 @@ def test_combo_group_min_ratio():
 def test_combo_group_min_ratio_scaling():
     builder = YaraBuilder(
         condition_type="combo",
-        group_min_count=1,
         group_min_count_ratio=0.75,
+        auto_group_min=True,
     )
     rule = builder.build(["call:A", "call:B", "call:C"])
     assert "2 of ($c*)" in rule


### PR DESCRIPTION
## Summary
- add `auto_group_min` option in YaraBuilder
- compute group minimum dynamically based on ratio with scaling
- connect `--group-min-ratio` CLI flag to enable automatic scaling
- update builder and CLI tests
- add test covering group-min-ratio detection

## Testing
- `pip install -q -r requirements.txt` *(fails: WARNING - but installed)*
- `pytest -q` *(fails: FileNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688664d83c24832e817cc001a033c587