### PR TITLE
Add token-based JSON cache for rule evaluator

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -197,8 +197,19 @@ def _extract_tokens(feature: str) -> list[str]:
     return tokens
 
 
+def extract_json_tokens(js_obj: Mapping[str, Any]) -> set[str]:
+    """Return lowercase token set from JSON code fields."""
+    tokens: set[str] = set()
+    for key in ("c_code", "h_code", "asm_code", "llvm_ir"):
+        for txt in js_obj.get(key, []):
+            if not isinstance(txt, str):
+                continue
+            tokens.update(m.group(0).lower() for m in TOKEN_RE.finditer(txt))
+    return tokens
+
+
 def verify_features(
-    json_path: Path | Dict[str, Any],
+    json_path: Path | Mapping[str, Any] | Sequence[str] | set[str],
     features: list[str],
     *,
     condition_type: str = "any",
@@ -213,20 +224,22 @@ def verify_features(
     When ``return_matched`` is ``True`` the function returns a tuple of the
     result and the list of matched feature strings.
     """
+    tokens: set[str] | None = None
+    js: Mapping[str, Any] | None = None
+    joined: str | None = None
+
     try:
         if isinstance(json_path, Path):
             js = json.loads(json_path.read_text(encoding="utf-8"))
-        else:
+            tokens = extract_json_tokens(js)
+        elif isinstance(json_path, Mapping):
             js = json_path
+            tokens = extract_json_tokens(js)
+        else:
+            tokens = {str(t).lower() for t in json_path}
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("failed to read %s: %s", json_path, exc)
         return False
-
-    text_fields = []
-    for key in ("c_code", "h_code", "asm_code", "llvm_ir"):
-        text_fields.extend(js.get(key, []))
-
-    joined = "\n".join(text_fields)
 
     def _token_regex(tok: str) -> re.Pattern:
         parts = split_name(tok)
@@ -238,9 +251,23 @@ def verify_features(
         return re.compile(pat, re.IGNORECASE)
 
     def _feat_present(feat: str) -> bool:
-        for tok in _extract_tokens(feat):
-            if _token_regex(tok).search(joined):
-                return True
+        tks = _extract_tokens(feat)
+        if tokens is not None:
+            for tok in tks:
+                if tok.lower() in tokens:
+                    return True
+            return False
+        if js is not None:
+            if joined is None:
+                text_fields: list[str] = []
+                for key in ("c_code", "h_code", "asm_code", "llvm_ir"):
+                    text_fields.extend(js.get(key, []))
+                joined_local = "\n".join(text_fields)
+            else:
+                joined_local = joined
+            for tok in tks:
+                if _token_regex(tok).search(joined_local):
+                    return True
         return False
 
     def _feat_valid(feat: str) -> bool:
@@ -366,7 +393,7 @@ def evaluate_single(
     auto_group_min: bool = True,
     exclude_tokens: Sequence[str] | None = None,
     persist_fp_exclude: Path | None = None,
-    clean_json_cache: Dict[Path, Any] | None = None,
+    clean_token_cache: Dict[Path, set[str]] | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -408,8 +435,8 @@ def evaluate_single(
             graph, classifier, explainer, device
         )
 
-    if clean_json_cache is None:
-        clean_json_cache = {}
+    if clean_token_cache is None:
+        clean_token_cache = {}
         if clean_dir is not None and clean_dir.is_dir():
             files = [p for p in clean_dir.iterdir() if p.is_file()]
             for p in tqdm_wrap(files, desc="load clean json", unit="file"):
@@ -418,7 +445,8 @@ def evaluate_single(
                     LOGGER.warning("JSON not found for %s", j)
                     continue
                 try:
-                    clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+                    obj = json.loads(j.read_text(encoding="utf-8"))
+                    clean_token_cache[p] = extract_json_tokens(obj)
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
         elif clean_paths is not None:
@@ -428,7 +456,8 @@ def evaluate_single(
                     LOGGER.warning("JSON not found for %s", j)
                     continue
                 try:
-                    clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+                    obj = json.loads(j.read_text(encoding="utf-8"))
+                    clean_token_cache[p] = extract_json_tokens(obj)
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
         elif clean_sample is not None:
@@ -437,9 +466,8 @@ def evaluate_single(
                 LOGGER.warning("JSON not found for %s", j)
             else:
                 try:
-                    clean_json_cache[clean_sample] = json.loads(
-                        j.read_text(encoding="utf-8")
-                    )
+                    obj = json.loads(j.read_text(encoding="utf-8"))
+                    clean_token_cache[clean_sample] = extract_json_tokens(obj)
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
 
@@ -553,18 +581,12 @@ def evaluate_single(
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("Failed to read %s: %s", sample_json, exc)
                     js_obj = {}
-                text_fields = []
-                for key in ("c_code", "h_code", "asm_code", "llvm_ir"):
-                    text_fields.extend(js_obj.get(key, []))
-                joined = "\n".join(text_fields)
-                tokens = sorted(
-                    {m.group(0).lower() for m in TOKEN_RE.finditer(joined)}
-                )
+                token_set = extract_json_tokens(js_obj)
                 filtered = [
                     t
-                    for t in tokens
+                    for t in sorted(token_set)
                     if verify_features(
-                        js_obj,
+                        token_set,
                         [t],
                         condition_type=condition_type,
                         group_percentage=group_pct,
@@ -668,11 +690,11 @@ def evaluate_single(
             if json_match:
 
                 def _check_json(p: Path) -> list[str] | None:
-                    js_obj = clean_json_cache.get(p)
-                    if js_obj is None:
+                    toks_set = clean_token_cache.get(p)
+                    if toks_set is None:
                         return None
                     ok, mt = verify_features(
-                        js_obj,
+                        toks_set,
                         feats,
                         condition_type=condition_type,
                         group_percentage=group_pct,
@@ -1619,14 +1641,15 @@ def main(argv: list[str] | None = None) -> None:
             bname = b_row.get("filename") or b_row.get("name") or f"{bsha}.bin"
             benign_paths.append(Path(args.sample_dir or args.graph_dir) / bname)
 
-        clean_json_cache: dict[Path, Any] = {}
+        clean_token_cache: dict[Path, set[str]] = {}
         if args.clean_dir is None and args.clean_sample is None:
             for p in tqdm_wrap(benign_paths, desc="preload clean json", unit="file"):
                 j = p.with_suffix(".json")
                 if not j.is_file():
                     continue
                 try:
-                    clean_json_cache[p] = json.loads(j.read_text(encoding="utf-8"))
+                    obj = json.loads(j.read_text(encoding="utf-8"))
+                    clean_token_cache[p] = extract_json_tokens(obj)
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
         results: list[dict[str, Any]] = []
@@ -1684,7 +1707,7 @@ def main(argv: list[str] | None = None) -> None:
                 "persist_fp_exclude": args.persist_fp_exclude,
                 "enforce_self_detect": args.enforce_self_detect,
                 "fp_scan_workers": args.fp_scan_workers,
-                "clean_json_cache": clean_json_cache,
+                "clean_token_cache": clean_token_cache,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
 
@@ -1957,6 +1980,7 @@ def main(argv: list[str] | None = None) -> None:
             json_match=args.json_match,
             fp_scan_workers=args.fp_scan_workers,
             saliency_stats=saliency_stats,
+            clean_token_cache=None,
             combine_mode=combine_mode,
             combine_min_ratio=args.combine_min_ratio,
             combine_max_ratio=args.combine_max_ratio,

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -904,7 +904,8 @@ def test_evaluate_single_uses_clean_json_cache(tmp_path, monkeypatch):
 
     monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
 
-    cache = {clean: json.loads(clean_json.read_text())}
+    js_obj = json.loads(clean_json.read_text())
+    cache = {clean: mod.extract_json_tokens(js_obj)}
 
     orig_read = Path.read_text
 
@@ -934,7 +935,7 @@ def test_evaluate_single_uses_clean_json_cache(tmp_path, monkeypatch):
         sample_json=sample_json,
         json_match=True,
         combine_mode="or",
-        clean_json_cache=cache,
+        clean_token_cache=cache,
     )
 
     assert res["false_positive"] is True
@@ -1330,6 +1331,24 @@ def test_verify_features_return_matched(tmp_path):
 
     assert result is True
     assert matched == ["call:foo"]
+
+
+def test_verify_features_token_set_equivalence(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    data = {"c_code": ["foo bar"]}
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps(data))
+
+    feats = ["call:foo", "call:baz"]
+
+    js_obj = json.loads(js.read_text())
+    token_set = mod.extract_json_tokens(js_obj)
+
+    res_dict = mod.verify_features(js_obj, feats)
+    res_tokens = mod.verify_features(token_set, feats)
+
+    assert res_dict == res_tokens
 
 
 def test_fp_retry_exclude_tokens(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- extract tokens from code fields using `TOKEN_RE`
- store token sets for clean samples and verify feature presence using set operations
- allow `verify_features` to accept token sets directly
- update `evaluate_single` and CLI to use token caches
- test token cache usage and equivalence with JSON verification

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k "uses_clean_json_cache or token_set_equivalence" -q`

------
https://chatgpt.com/codex/tasks/task_e_68871615a514832ea886f840b2ebc559