### PR TITLE
Optimize token cache memory

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -12,7 +12,8 @@ import re
 import time
 
 import logging
-from src.common.utils import get_logger, tqdm_wrap
+import sys
+from src.common.utils import get_logger, tqdm_wrap, human_bytes
 from src.graphs.loaders.common_token_utils import split_name, TOKEN_RE
 
 import torch
@@ -207,6 +208,16 @@ def extract_json_tokens(js_obj: Mapping[str, Any]) -> set[str]:
                 continue
             tokens.update(m.group(0).lower() for m in TOKEN_RE.finditer(txt))
     return tokens
+
+
+def estimate_token_cache_size(cache: Mapping[Path, set[str]]) -> int:
+    """Roughly estimate total memory usage of a token cache."""
+    total = 0
+    for token_set in cache.values():
+        total += sys.getsizeof(token_set)
+        for tok in token_set:
+            total += sys.getsizeof(tok)
+    return total
 
 
 def verify_features(
@@ -449,6 +460,7 @@ def evaluate_single(
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     clean_token_cache[p] = extract_json_tokens(obj)
+                    del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
         elif clean_paths is not None:
@@ -460,6 +472,7 @@ def evaluate_single(
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     clean_token_cache[p] = extract_json_tokens(obj)
+                    del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
         elif clean_sample is not None:
@@ -470,8 +483,17 @@ def evaluate_single(
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     clean_token_cache[clean_sample] = extract_json_tokens(obj)
+                    del obj
+
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
+
+        cache_bytes = estimate_token_cache_size(clean_token_cache)
+        LOGGER.info(
+            "Clean token cache loaded: %d samples (%s)",
+            len(clean_token_cache),
+            human_bytes(cache_bytes),
+        )
 
     def _build_and_eval(
         freq_thresh: float | int,
@@ -1680,8 +1702,16 @@ def main(argv: list[str] | None = None) -> None:
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     clean_token_cache[p] = extract_json_tokens(obj)
+                    del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
+
+        cache_bytes = estimate_token_cache_size(clean_token_cache)
+        LOGGER.info(
+            "Preloaded clean token cache: %d samples (%s)",
+            len(clean_token_cache),
+            human_bytes(cache_bytes),
+        )
         results: list[dict[str, Any]] = []
         flush_buffer: list[dict[str, Any]] = []
         first_flush = True

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -889,7 +889,7 @@ def test_evaluate_single_json_match_fp_with_clean_dir(tmp_path, monkeypatch):
     assert res["false_positive"] is True
 
 
-def test_evaluate_single_uses_clean_json_cache(tmp_path, monkeypatch):
+def test_evaluate_single_uses_clean_token_cache(tmp_path, monkeypatch):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)
     g["bb"].num_nodes = 1
@@ -1367,6 +1367,21 @@ def test_verify_features_token_set_equivalence(tmp_path):
     res_tokens = mod.verify_features(token_set, feats)
 
     assert res_dict == res_tokens
+
+
+def test_estimate_token_cache_size(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    cache: dict[Path, set[str]] = {}
+    for i in range(100):
+        p = tmp_path / f"s{i}.bin"
+        p.write_text("dummy")
+        j = tmp_path / f"s{i}.json"
+        j.write_text(json.dumps({"c_code": ["foo bar baz"]}))
+        cache[p] = mod.extract_json_tokens(json.loads(j.read_text()))
+
+    size = mod.estimate_token_cache_size(cache)
+    assert size < 1_000_000  # <1MB
 
 
 def test_fp_retry_exclude_tokens(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- estimate token cache memory via `estimate_token_cache_size`
- drop JSON objects after extracting tokens
- log cache size and estimated memory usage
- rename test to reflect token cache usage
- add test to ensure token cache memory is small

## Testing
- `pytest -q` *(fails: OSError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68871d20547c832e8cd346ba36c2f39a