### PR TITLE
Enable multiprocess rule evaluation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import importlib
 from pathlib import Path
 from typing import Any, Dict, Sequence, Mapping
 from collections import Counter
@@ -364,6 +366,7 @@ def evaluate_single(
     classifier: Any | None = None,
     explainer: Any | None = None,
     saliency_path: Path | None,
+    saliency: Dict[str, torch.Tensor] | torch.Tensor | None = None,
     device: torch.device,
     top_k: int,
     top_k_percent: float | None = None,
@@ -425,28 +428,29 @@ def evaluate_single(
         node_counts = {nt: int(graph[nt].num_nodes) for nt in graph.node_types}
         LOGGER.debug("Node counts: %s", node_counts)
 
-    if saliency_path:
-        LOGGER.info("Loading saliency from %s", saliency_path)
-        saliency = _load_saliency(saliency_path)
-    else:
-        if classifier is None:
-            if classifier_ckpt is None:
-                raise ValueError("classifier or classifier_ckpt must be provided")
-            from src.models.gnn.res_wrapper import RESGCLClassifier
+    if saliency is None:
+        if saliency_path:
+            LOGGER.info("Loading saliency from %s", saliency_path)
+            saliency = _load_saliency(saliency_path)
+        else:
+            if classifier is None:
+                if classifier_ckpt is None:
+                    raise ValueError("classifier or classifier_ckpt must be provided")
+                from src.models.gnn.res_wrapper import RESGCLClassifier
 
-            LOGGER.debug(f"Loading classifier from {classifier_ckpt}")
-            classifier = RESGCLClassifier.load_pretrained(
-                str(classifier_ckpt), map_location=device
-            )
-        if explainer is None and explainer_ckpt is not None:
-            LOGGER.debug(f"Loading explainer from {explainer_ckpt}")
-            explainer = torch.load(
-                explainer_ckpt, map_location=device, weights_only=False
-            )
+                LOGGER.debug(f"Loading classifier from {classifier_ckpt}")
+                classifier = RESGCLClassifier.load_pretrained(
+                    str(classifier_ckpt), map_location=device
+                )
+            if explainer is None and explainer_ckpt is not None:
+                LOGGER.debug(f"Loading explainer from {explainer_ckpt}")
+                explainer = torch.load(
+                    explainer_ckpt, map_location=device, weights_only=False
+                )
 
-        saliency = _compute_saliency_with_explainer(
-            graph, classifier, explainer, device
-        )
+            saliency = _compute_saliency_with_explainer(
+                graph, classifier, explainer, device
+            )
 
     if clean_token_cache is None:
         clean_token_cache = {}
@@ -1358,7 +1362,13 @@ def _init_worker(
 
 def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
-    return evaluate_single(
+    eval_fn = evaluate_single
+    env = os.environ.get("RMG_TEST_EVAL_SINGLE")
+    if env:
+        mod_name, func_name = env.rsplit(":", 1)
+        mod = importlib.import_module(mod_name)
+        eval_fn = getattr(mod, func_name)
+    return eval_fn(
         gpath,
         spath,
         classifier=_WORKER_CLASSIFIER,
@@ -1781,13 +1791,17 @@ def main(argv: list[str] | None = None) -> None:
                 max_workers=args.num_workers,
                 mp_context=ctx,
                 initializer=_init_worker,
-                initargs=(
-                    str(args.classifier),
-                    str(args.explainer) if args.explainer else None,
-                    args.device,
-                ),
+                initargs=(None, None, args.device),
             ) as executor:
-                future_map = {executor.submit(_worker_eval, t): t[0] for t in tasks}
+                future_map = {}
+                for t in tasks:
+                    sha, gpath, spath, jpath, kw = t
+                    graph = torch.load(gpath, map_location=device, weights_only=False)
+                    sal = _compute_saliency_with_explainer(graph, classifier, explainer, device)
+                    kw = kw.copy()
+                    kw["saliency"] = sal
+                    fut = executor.submit(_worker_eval, (sha, gpath, spath, jpath, kw))
+                    future_map[fut] = sha
                 progress = tqdm_wrap(
                     as_completed(future_map),
                     total=len(future_map),
@@ -2007,6 +2021,7 @@ def main(argv: list[str] | None = None) -> None:
             classifier=classifier,
             explainer=explainer,
             saliency_path=args.saliency,
+            saliency=None,
             device=device,
             top_k=args.top_k,
             top_k_percent=args.top_k_percent,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+def fake_eval(*args, **kwargs):
+    return {"detected": True}

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -736,6 +736,7 @@ def test_batch_flush_every(tmp_path, monkeypatch):
     (sdir / "a.bin").write_text("mal")
 
     mod = importlib.import_module("src.cli.explainer_rule_eval")
+    from tests import helpers
 
     class DummyClf(torch.nn.Module):
         def forward(self, x):
@@ -747,10 +748,7 @@ def test_batch_flush_every(tmp_path, monkeypatch):
         classmethod(lambda cls, *a, **k: DummyClf()),
     )
 
-    def fake_eval(*args, **kwargs):
-        return {"detected": True}
-
-    monkeypatch.setattr(mod, "evaluate_single", fake_eval)
+    monkeypatch.setenv("RMG_TEST_EVAL_SINGLE", "tests.helpers:fake_eval")
 
     out_csv = tmp_path / "res.csv"
     mod.main(
@@ -765,6 +763,8 @@ def test_batch_flush_every(tmp_path, monkeypatch):
             str(sdir / "a.bin"),
             "--out-csv",
             str(out_csv),
+            "--num-workers",
+            "2",
             "--flush-every",
             "1",
         ]


### PR DESCRIPTION
## Summary
- compute node saliency in the main process and dispatch FP checks to worker processes
- allow overriding the worker evaluation via `RMG_TEST_EVAL_SINGLE` env var so tests can patch multiprocess behaviour
- extend `evaluate_single` to take precomputed saliency
- add helper for tests and update batch flush test

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k batch_flush_every -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688726616cf0832eb474f4e451b9246a