### PR TITLE
Fix stray break in explainer_rule_eval

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1261,7 +1261,6 @@ def evaluate_single(
                     break
             if timed_out:
                 LOGGER.info("FP retry timed out during token exclusion")
-                break
             LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
 
         if not timed_out:


### PR DESCRIPTION
## Summary
- remove `break` that wasn't in a loop

## Testing
- `python -m py_compile src/cli/explainer_rule_eval.py`
- `python -m src.cli.explainer_rule_eval --help` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68872f958bb8832eb56391a5b1c9af7c