### PR TITLE
Fix invalid break in rule evaluator

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1261,7 +1261,6 @@ def evaluate_single(
                     break
             if timed_out:
                 LOGGER.info("FP retry timed out during token exclusion")
-                break
             LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
 
         if not timed_out:


### PR DESCRIPTION
## Summary
- remove stray `break` that caused syntax error in `explainer_rule_eval.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68873185c0c8832ebe3925479c9ad9f6