### PR TITLE
Fix token exclusion timeout

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1261,7 +1261,7 @@ def evaluate_single(
                     break
             if timed_out:
                 LOGGER.info("FP retry timed out during token exclusion")
-                break
+                return best_result
             LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
 
         if not timed_out:


### PR DESCRIPTION
## Summary
- break early when FP token exclusion hits timeout

## Testing
- `pytest -k fp_timeout -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_688735ffa094832ea0b8804320c3e20e