### PR TITLE
Fix FP retry timeout result behavior

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1261,7 +1261,7 @@ def evaluate_single(
                     break
             if timed_out:
                 LOGGER.info("FP retry timed out during token exclusion")
-                return best_result
+                return last_detected_result or best_result
             LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
 
         if not timed_out:


### PR DESCRIPTION
## Summary
- prefer returning last detected result when FP retries time out
- keep previous logic as fallback

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_timeout_stops_retry -q`

------
https://chatgpt.com/codex/tasks/task_e_68873faf3e30832ea7db5f42a522abd0