### PR TITLE
Add progress bar for FP retries

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1218,7 +1218,7 @@ def evaluate_single(
                 "Trying to exclude tokens due to FP retry: %s", tokens_sorted
             )
             trial_excludes: set[str] = set()
-            for tok in tokens_sorted:
+            for tok in tqdm_wrap(tokens_sorted, desc="fp_retry", unit="tok"):
                 if fp_timeout and time.perf_counter() - start_time > fp_timeout:
                     timed_out = True
                     break
@@ -1243,6 +1243,14 @@ def evaluate_single(
                     trial.get("detected"),
                     trial.get("false_positive"),
                 )
+                try:
+                    from tqdm.auto import tqdm
+
+                    tqdm.write(
+                        f"FP retry exclude '{tok}' -> detected={trial.get('detected')} fp={trial.get('false_positive')}"
+                    )
+                except Exception:  # pragma: no cover - optional dep
+                    pass
                 if not trial.get("detected"):
                     trial_excludes.remove(ltok)
                     continue


### PR DESCRIPTION
## Summary
- visualize exclusion retries in `evaluate_single` with tqdm progress bar
- log each trial using `tqdm.write` so the bar stays visible

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*
- `python - <<'EOF'
from tqdm.auto import tqdm
from src.common.utils import tqdm_wrap
for tok in tqdm_wrap(range(3), desc='fp_retry', unit='tok'):
    tqdm.write(f"trial {tok}")
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688740c89ca0832e9cd5b8f11ea595fb