### PR TITLE
Fix logger to use tqdm stream

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -104,6 +104,19 @@ def _build_colour_formatter() -> logging.Formatter:
     )
 
 
+class _TqdmStreamHandler(logging.StreamHandler):
+    """StreamHandler that delegates writes to ``tqdm.write`` if available."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        try:
+            from tqdm import tqdm  # type: ignore
+
+            msg = self.format(record)
+            tqdm.write(msg, file=self.stream)
+        except Exception:
+            super().emit(record)
+
+
 def get_logger(name: str = "robust‑mg", level: int = logging.INFO) -> logging.Logger:  # noqa: D401
     """Return a *singleton* logger with a colour console handler attached."""
     if name in _LOGGERS:
@@ -112,7 +125,7 @@ def get_logger(name: str = "robust‑mg", level: int = logging.INFO) -> logging.
     logger = logging.getLogger(name)
     logger.setLevel(level)
 
-    handler = logging.StreamHandler(sys.stdout)
+    handler = _TqdmStreamHandler(sys.stderr)
     handler.addFilter(MemoryUsageFilter())
     handler.setFormatter(_build_colour_formatter())
     logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- fix `get_logger()` output stream by using `sys.stderr`
- avoid progress bar overwrite by emitting log records via `tqdm.write`

## Testing
- `pytest -q tests/test_logger_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_688741ceb568832ebec3954284ef58b7