### PR TITLE
Add tqdm progress bars for FP retries

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -16,6 +16,7 @@ import time
 import logging
 import sys
 from src.common.utils import get_logger, tqdm_wrap, human_bytes
+from tqdm.auto import tqdm
 from src.graphs.loaders.common_token_utils import split_name, TOKEN_RE
 
 import torch
@@ -410,6 +411,7 @@ def evaluate_single(
     persist_fp_exclude: Path | None = None,
     clean_token_cache: Dict[Path, set[str]] | None = None,
     fp_timeout: float | None = None,
+    fp_bar: tqdm | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -1218,7 +1220,7 @@ def evaluate_single(
                 "Trying to exclude tokens due to FP retry: %s", tokens_sorted
             )
             trial_excludes: set[str] = set()
-            for tok in tqdm_wrap(tokens_sorted, desc="fp_retry", unit="tok"):
+            for tok in tokens_sorted:
                 if fp_timeout and time.perf_counter() - start_time > fp_timeout:
                     timed_out = True
                     break
@@ -1243,14 +1245,16 @@ def evaluate_single(
                     trial.get("detected"),
                     trial.get("false_positive"),
                 )
-                try:
-                    from tqdm.auto import tqdm
-
-                    tqdm.write(
-                        f"FP retry exclude '{tok}' -> detected={trial.get('detected')} fp={trial.get('false_positive')}"
-                    )
-                except Exception:  # pragma: no cover - optional dep
-                    pass
+                msg = (
+                    f"FP retry exclude '{tok}' -> detected={trial.get('detected')} "
+                    f"fp={trial.get('false_positive')}"
+                )
+                if fp_bar:
+                    fp_bar.write(msg)
+                else:
+                    LOGGER.debug(msg)
+                if fp_bar:
+                    fp_bar.update(1)
                 if not trial.get("detected"):
                     trial_excludes.remove(ltok)
                     continue
@@ -1311,6 +1315,8 @@ def evaluate_single(
                             exclude=exclude_set,
                             auto_gmin=auto_group_min,
                         )
+                        if fp_bar:
+                            fp_bar.update(1)
                         if _is_better(trial, best_result):
                             best_result = trial
                             if best_result.get("detected"):
@@ -1395,6 +1401,7 @@ def _eval_task(
     classifier: Any,
     explainer: Any,
     device: torch.device,
+    fp_bar: tqdm | None = None,
 ) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
     return evaluate_single(
@@ -1407,6 +1414,7 @@ def _eval_task(
         saliency_path=None,
         device=device,
         sample_json=jpath,
+        fp_bar=fp_bar,
         **kwargs,
     )
 
@@ -1789,6 +1797,8 @@ def main(argv: list[str] | None = None) -> None:
                 "fp_timeout": args.fp_timeout,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
+        graph_bar = tqdm(total=len(tasks), desc="graphs", unit="graph", position=0)
+        fp_bar = tqdm(total=args.fp_retries or 1, desc="fp retries", unit="try", position=1, leave=True)
 
         if args.num_workers > 1:
             import multiprocessing as mp
@@ -1810,13 +1820,8 @@ def main(argv: list[str] | None = None) -> None:
                     kw["saliency"] = sal
                     fut = executor.submit(_worker_eval, (sha, gpath, spath, jpath, kw))
                     future_map[fut] = sha
-                progress = tqdm_wrap(
-                    as_completed(future_map),
-                    total=len(future_map),
-                    desc="graphs",
-                    unit="graph",
-                )
-                for fut in progress:
+                for fut in as_completed(future_map):
+                    fp_bar.reset()
                     sha = future_map[fut]
                     try:
                         res = fut.result()
@@ -1834,7 +1839,8 @@ def main(argv: list[str] | None = None) -> None:
                     fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(
                         results
                     )
-                    progress.set_postfix(
+                    graph_bar.update(1)
+                    graph_bar.set_postfix(
                         avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}"
                     )
 
@@ -1887,16 +1893,17 @@ def main(argv: list[str] | None = None) -> None:
                             )
         else:
             for task in tasks:
-                res = _eval_task(task, classifier, explainer, device)
+                fp_bar.reset()
+                res = _eval_task(task, classifier, explainer, device, fp_bar=fp_bar)
                 sha = task[0]
 
                 res["sha256"] = sha
                 results.append(res)
 
                 det_rate = sum(r.get("detected", False) for r in results) / len(results)
-                fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(
-                    results
-                )
+                fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
+                graph_bar.update(1)
+                graph_bar.set_postfix(avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}")
 
                 if args.out_csv and args.flush_every:
                     flush_buffer.append(res)
@@ -1943,6 +1950,8 @@ def main(argv: list[str] | None = None) -> None:
                             rule_txt, encoding="utf-8"
                         )
 
+        graph_bar.close()
+        fp_bar.close()
         df = pd.DataFrame(results)
 
         if args.out_csv:


### PR DESCRIPTION
## Summary
- add optional `fp_bar` argument in `evaluate_single`
- show FP retry progress with a tqdm progress bar
- display graph-level progress in `main`
- avoid breaking bar output by logging messages instead of `tqdm.write`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_688746d1bc60832eabbf68551ee68560