### PR TITLE
Switch certain logs to debug

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1321,7 +1321,7 @@ def evaluate_single(
                             best_result = trial
                             if best_result.get("detected"):
                                 last_detected_result = best_result
-                            LOGGER.info(
+                            LOGGER.debug(
                                 "Improved with freq_threshold=%s group_min_count=%s combine_min_ratio=%.3f (detected=%s fp=%s)",
                                 ft,
                                 gc,
@@ -1733,7 +1733,7 @@ def main(argv: list[str] | None = None) -> None:
                     LOGGER.warning("failed to read %s: %s", j, exc)
 
         cache_bytes = estimate_token_cache_size(clean_token_cache)
-        LOGGER.info(
+        LOGGER.debug(
             "Preloaded clean token cache: %d samples (%s)",
             len(clean_token_cache),
             human_bytes(cache_bytes),


### PR DESCRIPTION
## Summary
- modify logging level for improvement message
- modify logging level for preloaded cache message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentencepiece')*

------
https://chatgpt.com/codex/tasks/task_e_68874c867078832eac34b279dc6258b0