### PR TITLE
Implement token index for rule evaluation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -7,8 +7,8 @@ import json
 import os
 import importlib
 from pathlib import Path
-from typing import Any, Dict, Sequence, Mapping
-from collections import Counter
+from typing import Any, Dict, Sequence, Mapping, Set
+from collections import Counter, defaultdict
 import math
 import re
 import time
@@ -410,6 +410,7 @@ def evaluate_single(
     exclude_tokens: Sequence[str] | None = None,
     persist_fp_exclude: Path | None = None,
     clean_token_cache: Dict[Path, set[str]] | None = None,
+    token_index: Dict[str, Set[Path]] | None = None,
     fp_timeout: float | None = None,
     fp_bar: tqdm | None = None,
 ) -> Dict[str, Any]:
@@ -456,6 +457,13 @@ def evaluate_single(
 
     if clean_token_cache is None:
         clean_token_cache = {}
+    if token_index is None:
+        token_index = defaultdict(set)
+    if clean_token_cache and not token_index:
+        for p, toks in clean_token_cache.items():
+            for t in toks:
+                token_index[t].add(p)
+    if not clean_token_cache:
         if clean_dir is not None and clean_dir.is_dir():
             files = [p for p in clean_dir.iterdir() if p.is_file()]
             for p in tqdm_wrap(files, desc="load clean json", unit="file"):
@@ -465,7 +473,10 @@ def evaluate_single(
                     continue
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
-                    clean_token_cache[p] = extract_json_tokens(obj)
+                    toks = extract_json_tokens(obj)
+                    clean_token_cache[p] = toks
+                    for t in toks:
+                        token_index[t].add(p)
                     del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
@@ -477,7 +488,10 @@ def evaluate_single(
                     continue
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
-                    clean_token_cache[p] = extract_json_tokens(obj)
+                    toks = extract_json_tokens(obj)
+                    clean_token_cache[p] = toks
+                    for t in toks:
+                        token_index[t].add(p)
                     del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
@@ -488,7 +502,10 @@ def evaluate_single(
             else:
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
-                    clean_token_cache[clean_sample] = extract_json_tokens(obj)
+                    toks = extract_json_tokens(obj)
+                    clean_token_cache[clean_sample] = toks
+                    for t in toks:
+                        token_index[t].add(clean_sample)
                     del obj
 
                 except Exception as exc:  # noqa: BLE001
@@ -719,7 +736,22 @@ def evaluate_single(
             fp = False
             if json_match:
 
-                def _check_json(p: Path) -> list[str] | None:
+                def _check_json(p: Path | None) -> list[str] | None:
+                    if token_index:
+                        cand: Set[Path] | None = None
+                        matched: list[str] = []
+                        for feat in feats:
+                            for tok in _extract_tokens(feat):
+                                paths = token_index.get(tok.lower())
+                                if not paths:
+                                    return None
+                                matched.append(tok.lower())
+                                cand = paths if cand is None else cand & paths
+                                if not cand:
+                                    return None
+                        return matched if cand else None
+                    if p is None:
+                        return None
                     toks_set = clean_token_cache.get(p)
                     if toks_set is None:
                         return None
@@ -736,7 +768,12 @@ def evaluate_single(
                     return mt if ok else None
 
                 fp_tokens_set: set[str] = set()
-                if clean_dir is not None and clean_dir.is_dir():
+                if token_index:
+                    toks = _check_json(None)
+                    fp = toks is not None
+                    if fp:
+                        fp_tokens_set.update(toks)
+                elif clean_dir is not None and clean_dir.is_dir():
                     files = [p for p in clean_dir.iterdir() if p.is_file()]
                     if fp_scan_workers > 1 and len(files) > 1:
                         from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -1720,6 +1757,7 @@ def main(argv: list[str] | None = None) -> None:
             benign_paths.append(Path(args.sample_dir or args.graph_dir) / bname)
 
         clean_token_cache: dict[Path, set[str]] = {}
+        token_index: dict[str, set[Path]] = {}
         if args.clean_dir is None and args.clean_sample is None:
             for p in tqdm_wrap(benign_paths, desc="preload clean json", unit="file"):
                 j = p.with_suffix(".json")
@@ -1727,7 +1765,10 @@ def main(argv: list[str] | None = None) -> None:
                     continue
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
-                    clean_token_cache[p] = extract_json_tokens(obj)
+                    toks = extract_json_tokens(obj)
+                    clean_token_cache[p] = toks
+                    for t in toks:
+                        token_index.setdefault(t, set()).add(p)
                     del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
@@ -1794,6 +1835,7 @@ def main(argv: list[str] | None = None) -> None:
                 "enforce_self_detect": args.enforce_self_detect,
                 "fp_scan_workers": args.fp_scan_workers,
                 "clean_token_cache": clean_token_cache,
+                "token_index": token_index,
                 "fp_timeout": args.fp_timeout,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))


### PR DESCRIPTION
## Summary
- create token index alongside token cache
- check false positives via token index intersection
- expose token index through CLI batch execution

## Testing
- `python -m py_compile src/cli/explainer_rule_eval.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887657938a4832e9fccbeff859b340a