### PR TITLE
Add precomputed saliency directory

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -12,6 +12,7 @@ from collections import Counter
 import math
 import re
 import time
+import tempfile
 
 import logging
 import sys
@@ -1355,6 +1356,10 @@ _WORKER_CLASSIFIER = None
 _WORKER_EXPLAINER = None
 _WORKER_DEVICE: torch.device | None = None
 
+_SAL_CLASSIFIER = None
+_SAL_EXPLAINER = None
+_SAL_DEVICE: torch.device | None = None
+
 
 def _init_worker(
     classifier_ckpt: str | None, explainer_ckpt: str | None, device: str
@@ -1374,6 +1379,25 @@ def _init_worker(
         )
 
 
+def _init_saliency_worker(
+    classifier_ckpt: str, explainer_ckpt: str | None, device: str
+) -> None:
+    """Initializer for saliency computation process."""
+    global _SAL_CLASSIFIER, _SAL_EXPLAINER, _SAL_DEVICE
+    _SAL_DEVICE = torch.device(device)
+    from src.models.gnn.res_wrapper import RESGCLClassifier
+
+    _SAL_CLASSIFIER = RESGCLClassifier.load_pretrained(
+        str(classifier_ckpt), map_location=_SAL_DEVICE
+    )
+    if explainer_ckpt and Path(explainer_ckpt).is_file():
+        _SAL_EXPLAINER = torch.load(
+            explainer_ckpt, map_location=_SAL_DEVICE, weights_only=False
+        )
+    else:
+        _SAL_EXPLAINER = None
+
+
 def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
     eval_fn = evaluate_single
@@ -1389,7 +1413,7 @@ def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
         explainer=_WORKER_EXPLAINER,
         classifier_ckpt=None,
         explainer_ckpt=None,
-        saliency_path=None,
+        saliency_path=kwargs.pop("saliency_path", None),
         device=_WORKER_DEVICE or torch.device("cpu"),
         sample_json=jpath,
         **kwargs,
@@ -1411,12 +1435,23 @@ def _eval_task(
         explainer=explainer,
         classifier_ckpt=None,
         explainer_ckpt=None,
-        saliency_path=None,
+        saliency_path=kwargs.pop("saliency_path", None),
         device=device,
         sample_json=jpath,
         fp_bar=fp_bar,
         **kwargs,
     )
+
+
+def _saliency_task(task: tuple[str, Path, Path]) -> Path:
+    """Compute saliency for a graph and save to path."""
+    sha, gpath, out_path = task
+    graph = torch.load(gpath, map_location="cpu", weights_only=False)
+    sal = _compute_saliency_with_explainer(
+        graph, _SAL_CLASSIFIER, _SAL_EXPLAINER, _SAL_DEVICE or torch.device("cpu")
+    )
+    torch.save(sal, out_path)
+    return out_path
 
 
 # ---------------------------------------------------------------------------
@@ -1441,6 +1476,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--saliency", type=Path, help="Precomputed node saliency (.pt or json)"
+    )
+    p.add_argument(
+        "--precomputed-saliency-dir",
+        type=Path,
+        help="Directory with precomputed saliency files",
     )
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
     p.add_argument(
@@ -1800,10 +1840,28 @@ def main(argv: list[str] | None = None) -> None:
         graph_bar = tqdm(total=len(tasks), desc="graphs", unit="graph", position=0)
         fp_bar = tqdm(total=args.fp_retries or 1, desc="fp retries", unit="try", position=1, leave=True)
 
-        if args.num_workers > 1:
-            import multiprocessing as mp
-            from concurrent.futures import ProcessPoolExecutor, as_completed
+        import multiprocessing as mp
+        from concurrent.futures import ProcessPoolExecutor, as_completed
 
+        sal_dir = args.precomputed_saliency_dir or Path(tempfile.mkdtemp(prefix="saliency_"))
+        sal_dir.mkdir(parents=True, exist_ok=True)
+
+        if not args.precomputed_saliency_dir:
+            ctx_sal = mp.get_context("spawn")
+            with ProcessPoolExecutor(
+                max_workers=1,
+                mp_context=ctx_sal,
+                initializer=_init_saliency_worker,
+                initargs=(str(args.classifier), str(args.explainer) if args.explainer else None, args.device),
+            ) as sexec:
+                fut_map = {
+                    sexec.submit(_saliency_task, (sha, gpath, sal_dir / f"{sha}.pt")): sha
+                    for sha, gpath, _, _, _ in tasks
+                }
+                for fut in tqdm(as_completed(fut_map), total=len(fut_map), desc="saliency", unit="graph"):
+                    fut.result()
+
+        if args.num_workers > 1:
             ctx = mp.get_context("forkserver")
             with ProcessPoolExecutor(
                 max_workers=args.num_workers,
@@ -1814,10 +1872,8 @@ def main(argv: list[str] | None = None) -> None:
                 future_map = {}
                 for t in tasks:
                     sha, gpath, spath, jpath, kw = t
-                    graph = torch.load(gpath, map_location=device, weights_only=False)
-                    sal = _compute_saliency_with_explainer(graph, classifier, explainer, device)
                     kw = kw.copy()
-                    kw["saliency"] = sal
+                    kw["saliency_path"] = sal_dir / f"{sha}.pt"
                     fut = executor.submit(_worker_eval, (sha, gpath, spath, jpath, kw))
                     future_map[fut] = sha
                 for fut in as_completed(future_map):
@@ -1894,7 +1950,15 @@ def main(argv: list[str] | None = None) -> None:
         else:
             for task in tasks:
                 fp_bar.reset()
-                res = _eval_task(task, classifier, explainer, device, fp_bar=fp_bar)
+                sha, gpath, spath, jpath, kw = task
+                kw = kw.copy()
+                sal_path = sal_dir / f"{sha}.pt"
+                if not args.precomputed_saliency_dir:
+                    graph = torch.load(gpath, map_location=device, weights_only=False)
+                    sal = _compute_saliency_with_explainer(graph, classifier, explainer, device)
+                    torch.save(sal, sal_path)
+                kw["saliency_path"] = sal_path
+                res = _eval_task((sha, gpath, spath, jpath, kw), classifier, explainer, device, fp_bar=fp_bar)
                 sha = task[0]
 
                 res["sha256"] = sha

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -109,6 +109,24 @@ def test_build_parser_persist_fp_exclude():
     assert args.persist_fp_exclude == Path("tokens.json")
 
 
+def test_build_parser_precomputed_saliency_dir():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--precomputed-saliency-dir",
+            "sal",
+        ]
+    )
+    assert args.precomputed_saliency_dir == Path("sal")
+
+
 def test_build_parser_flush_every():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()


### PR DESCRIPTION
## Summary
- add a `--precomputed-saliency-dir` CLI option for reusing cached saliency
- compute node saliency in a dedicated worker process and pass results via file
- update worker logic to load saliency from file
- cover parser change in tests

## Testing
- `pytest -k precomputed_saliency_dir -vv` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887658a7bc0832eb6503ab5c8bc406e