### PR TITLE
Improve FP retry logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -413,6 +413,7 @@ def evaluate_single(
     clean_token_cache: Dict[Path, set[str]] | None = None,
     token_index: Dict[str, Set[Path]] | None = None,
     fp_timeout: float | None = None,
+    max_exclude_tokens: int = 5,
     fp_bar: tqdm | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
@@ -1243,6 +1244,7 @@ def evaluate_single(
     if result.get("false_positive") and fp_retries > 0:
         start_time = time.perf_counter()
         timed_out = False
+        attempts = 0
         counts = result.get("fp_token_counts")
         tokens_to_exclude = result.get("fp_matched_tokens", [])
         if counts:
@@ -1257,15 +1259,24 @@ def evaluate_single(
             LOGGER.debug(
                 "Trying to exclude tokens due to FP retry: %s", tokens_sorted
             )
-            trial_excludes: set[str] = set()
-            for tok in tokens_sorted:
-                if fp_timeout and time.perf_counter() - start_time > fp_timeout:
+            groups = [
+                tokens_sorted[i : i + max_exclude_tokens]
+                for i in range(0, len(tokens_sorted), max_exclude_tokens)
+            ]
+            for group in groups:
+                if (
+                    fp_retries and attempts >= fp_retries
+                ) or (
+                    fp_timeout and time.perf_counter() - start_time > fp_timeout
+                ):
                     timed_out = True
                     break
-                ltok = tok.lower()
-                if ltok in exclude_set or ltok in trial_excludes:
-                    continue
-                trial_excludes.add(ltok)
+                attempts += 1
+                trial_excludes = {
+                    t.lower()
+                    for t in group
+                    if t.lower() not in exclude_set
+                }
                 trial = _eval_with_count(
                     freq_threshold,
                     group_min_count,
@@ -1278,13 +1289,13 @@ def evaluate_single(
                     auto_gmin=auto_group_min,
                 )
                 LOGGER.debug(
-                    "FP retry exclude '%s' -> detected=%s fp=%s",
-                    tok,
+                    "FP retry exclude %s -> detected=%s fp=%s",
+                    list(group),
                     trial.get("detected"),
                     trial.get("false_positive"),
                 )
                 msg = (
-                    f"FP retry exclude '{tok}' -> detected={trial.get('detected')} "
+                    f"FP retry exclude {group} -> detected={trial.get('detected')} "
                     f"fp={trial.get('false_positive')}"
                 )
                 if fp_bar:
@@ -1294,7 +1305,6 @@ def evaluate_single(
                 if fp_bar:
                     fp_bar.update(1)
                 if not trial.get("detected"):
-                    trial_excludes.remove(ltok)
                     continue
                 if _is_better(trial, best_result):
                     best_result = trial
@@ -1331,17 +1341,30 @@ def evaluate_single(
                     )
 
             for ft in sorted(freq_vals):
-                if fp_timeout and time.perf_counter() - start_time > fp_timeout:
+                if (
+                    fp_retries and attempts >= fp_retries
+                ) or (
+                    fp_timeout and time.perf_counter() - start_time > fp_timeout
+                ):
                     timed_out = True
                     break
                 for gc in sorted(group_vals) if group_vals != {None} else [None]:
-                    if fp_timeout and time.perf_counter() - start_time > fp_timeout:
+                    if (
+                        fp_retries and attempts >= fp_retries
+                    ) or (
+                        fp_timeout and time.perf_counter() - start_time > fp_timeout
+                    ):
                         timed_out = True
                         break
                     for cr in sorted(ratio_vals):
-                        if fp_timeout and time.perf_counter() - start_time > fp_timeout:
+                        if (
+                            fp_retries and attempts >= fp_retries
+                        ) or (
+                            fp_timeout and time.perf_counter() - start_time > fp_timeout
+                        ):
                             timed_out = True
                             break
+                        attempts += 1
                         trial = _eval_with_count(
                             ft,
                             gc,
@@ -1679,6 +1702,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Abort FP retries after this many seconds",
     )
     p.add_argument(
+        "--max-exclude-tokens",
+        type=int,
+        default=5,
+        help="Maximum number of tokens to exclude at once during FP retry",
+    )
+    p.add_argument(
         "--num-rules-min",
         type=int,
         default=1,
@@ -1877,6 +1906,7 @@ def main(argv: list[str] | None = None) -> None:
                 "clean_token_cache": clean_token_cache,
                 "token_index": token_index,
                 "fp_timeout": args.fp_timeout,
+                "max_exclude_tokens": args.max_exclude_tokens,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
         graph_bar = tqdm(total=len(tasks), desc="graphs", unit="graph", position=0)
@@ -2192,6 +2222,7 @@ def main(argv: list[str] | None = None) -> None:
             persist_fp_exclude=args.persist_fp_exclude,
             enforce_self_detect=args.enforce_self_detect,
             fp_timeout=args.fp_timeout,
+            max_exclude_tokens=args.max_exclude_tokens,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -109,6 +109,24 @@ def test_build_parser_persist_fp_exclude():
     assert args.persist_fp_exclude == Path("tokens.json")
 
 
+def test_build_parser_max_exclude_tokens():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--max-exclude-tokens",
+            "7",
+        ]
+    )
+    assert args.max_exclude_tokens == 7
+
+
 def test_build_parser_precomputed_saliency_dir():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()


### PR DESCRIPTION
## Summary
- allow grouped token exclusion attempts with `--max-exclude-tokens`
- stop FP retries when exceeding `fp_retries` or `fp_timeout`
- test parser for new argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688768c8bdf8832eb2775c28b9f8e020