### PR TITLE
Add saliency cache option

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -414,6 +414,7 @@ def evaluate_single(
     token_index: Dict[str, Set[Path]] | None = None,
     fp_timeout: float | None = None,
     fp_bar: tqdm | None = None,
+    cache_saliency: bool = False,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -436,6 +437,34 @@ def evaluate_single(
         if saliency_path:
             LOGGER.info("Loading saliency from %s", saliency_path)
             saliency = _load_saliency(saliency_path)
+        elif cache_saliency:
+            cache_path = graph_path.with_suffix(".sal.pt")
+            if cache_path.is_file():
+                LOGGER.info("Loading saliency from %s", cache_path)
+                saliency = torch.load(cache_path, map_location="cpu", weights_only=False)
+            else:
+                if classifier is None:
+                    if classifier_ckpt is None:
+                        raise ValueError("classifier or classifier_ckpt must be provided")
+                    from src.models.gnn.res_wrapper import RESGCLClassifier
+
+                    LOGGER.debug(f"Loading classifier from {classifier_ckpt}")
+                    classifier = RESGCLClassifier.load_pretrained(
+                        str(classifier_ckpt), map_location=device
+                    )
+                if explainer is None and explainer_ckpt is not None:
+                    LOGGER.debug(f"Loading explainer from {explainer_ckpt}")
+                    explainer = torch.load(
+                        explainer_ckpt, map_location=device, weights_only=False
+                    )
+
+                saliency = _compute_saliency_with_explainer(
+                    graph, classifier, explainer, device
+                )
+                try:
+                    torch.save(saliency, cache_path)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to save saliency cache %s: %s", cache_path, exc)
         else:
             if classifier is None:
                 if classifier_ckpt is None:
@@ -1453,6 +1482,7 @@ def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
         saliency_path=kwargs.pop("saliency_path", None),
         device=_WORKER_DEVICE or torch.device("cpu"),
         sample_json=jpath,
+        cache_saliency=kwargs.pop("cache_saliency", False),
         **kwargs,
     )
 
@@ -1476,6 +1506,7 @@ def _eval_task(
         device=device,
         sample_json=jpath,
         fp_bar=fp_bar,
+        cache_saliency=kwargs.pop("cache_saliency", False),
         **kwargs,
     )
 
@@ -1679,6 +1710,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Abort FP retries after this many seconds",
     )
     p.add_argument(
+        "--cache-saliency",
+        action="store_true",
+        help="Load/save saliency next to graph file",
+    )
+    p.add_argument(
         "--num-rules-min",
         type=int,
         default=1,
@@ -1877,6 +1913,7 @@ def main(argv: list[str] | None = None) -> None:
                 "clean_token_cache": clean_token_cache,
                 "token_index": token_index,
                 "fp_timeout": args.fp_timeout,
+                "cache_saliency": args.cache_saliency,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
         graph_bar = tqdm(total=len(tasks), desc="graphs", unit="graph", position=0)
@@ -2192,6 +2229,7 @@ def main(argv: list[str] | None = None) -> None:
             persist_fp_exclude=args.persist_fp_exclude,
             enforce_self_detect=args.enforce_self_detect,
             fp_timeout=args.fp_timeout,
+            cache_saliency=args.cache_saliency,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -54,6 +54,23 @@ def test_build_parser_fp_timeout():
     assert args.fp_timeout == 3.0
 
 
+def test_build_parser_cache_saliency():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--cache-saliency",
+        ]
+    )
+    assert args.cache_saliency is True
+
+
 def test_build_parser_combine_max_ratio():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()

--- a/tests/test_explainer_rule_eval_saliency.py
+++ b/tests/test_explainer_rule_eval_saliency.py
@@ -68,3 +68,76 @@ def test_compute_saliency_handles_tuple(monkeypatch):
     assert isinstance(sal, dict)
     assert sal["n"].tolist() == [1.0]
     assert isinstance(explainer.last_mask, torch.Tensor)
+
+
+def test_cache_saliency(tmp_path, monkeypatch):
+    import importlib
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    g = HeteroData()
+    g["n"].x = torch.zeros(1, 1)
+    g["n"].num_nodes = 1
+    g[("n", "r", "n")].edge_index = torch.tensor([[0], [0]])
+
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+    sal_cache = {"n": torch.tensor([0.1])}
+    torch.save(sal_cache, gpath.with_suffix(".sal.pt"))
+
+    calls: list[int] = []
+
+    def fake_compute(*args, **kwargs):
+        calls.append(1)
+        return {"n": torch.tensor([0.2])}
+
+    monkeypatch.setattr(mod, "_compute_saliency_with_explainer", fake_compute)
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, *a, **k):
+            return ["foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            class FakeCompiled:
+                def match(self, path):
+                    return []
+
+            return FakeCompiled()
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+
+    mod.evaluate_single(
+        gpath,
+        sample,
+        classifier=DummyClassifier(),
+        explainer=None,
+        classifier_ckpt=None,
+        explainer_ckpt=None,
+        saliency_path=None,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=None,
+        json_match=False,
+        cache_saliency=True,
+        combine_mode="or",
+    )
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- support caching saliency next to graphs via `--cache-saliency`
- load/save precomputed saliency in `evaluate_single`
- test parser for new option
- ensure cached files skip explainer in tests

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -vv | head`
- `pytest tests/test_explainer_rule_eval_saliency.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68876909ce0c832e8f456e2854550923