### PR TITLE
Implement saliency caching

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -369,6 +369,7 @@ def evaluate_single(
     explainer: Any | None = None,
     saliency_path: Path | None,
     saliency: Dict[str, torch.Tensor] | torch.Tensor | None = None,
+    cache_saliency: bool = False,
     device: torch.device,
     top_k: int,
     top_k_percent: float | None = None,
@@ -438,10 +439,15 @@ def evaluate_single(
             LOGGER.info("Loading saliency from %s", saliency_path)
             saliency = _load_saliency(saliency_path)
         else:
-            if classifier is None:
-                if classifier_ckpt is None:
-                    raise ValueError("classifier or classifier_ckpt must be provided")
-                from src.models.gnn.res_wrapper import RESGCLClassifier
+            cache_path = graph_path.with_suffix(".sal.pt") if cache_saliency else None
+            if cache_path is not None and cache_path.is_file():
+                LOGGER.info("Loading saliency from cache %s", cache_path)
+                saliency = torch.load(cache_path, map_location="cpu", weights_only=False)
+            else:
+                if classifier is None:
+                    if classifier_ckpt is None:
+                        raise ValueError("classifier or classifier_ckpt must be provided")
+                    from src.models.gnn.res_wrapper import RESGCLClassifier
 
                 LOGGER.debug(f"Loading classifier from {classifier_ckpt}")
                 classifier = RESGCLClassifier.load_pretrained(
@@ -456,6 +462,11 @@ def evaluate_single(
             saliency = _compute_saliency_with_explainer(
                 graph, classifier, explainer, device
             )
+            if cache_path is not None:
+                try:
+                    torch.save(saliency, cache_path)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to save saliency cache %s: %s", cache_path, exc)
 
     if clean_token_cache is None:
         clean_token_cache = {}
@@ -1474,6 +1485,7 @@ def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
         classifier_ckpt=None,
         explainer_ckpt=None,
         saliency_path=kwargs.pop("saliency_path", None),
+        cache_saliency=kwargs.pop("cache_saliency", False),
         device=_WORKER_DEVICE or torch.device("cpu"),
         sample_json=jpath,
         **kwargs,
@@ -1496,6 +1508,7 @@ def _eval_task(
         classifier_ckpt=None,
         explainer_ckpt=None,
         saliency_path=kwargs.pop("saliency_path", None),
+        cache_saliency=kwargs.pop("cache_saliency", False),
         device=device,
         sample_json=jpath,
         fp_bar=fp_bar,
@@ -1541,6 +1554,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--precomputed-saliency-dir",
         type=Path,
         help="Directory with precomputed saliency files",
+    )
+    p.add_argument(
+        "--cache-saliency",
+        action="store_true",
+        help="Cache computed saliency next to graph",
     )
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
     p.add_argument(
@@ -1907,6 +1925,7 @@ def main(argv: list[str] | None = None) -> None:
                 "token_index": token_index,
                 "fp_timeout": args.fp_timeout,
                 "max_exclude_tokens": args.max_exclude_tokens,
+                "cache_saliency": args.cache_saliency,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
         graph_bar = tqdm(total=len(tasks), desc="graphs", unit="graph", position=0)
@@ -2223,6 +2242,7 @@ def main(argv: list[str] | None = None) -> None:
             enforce_self_detect=args.enforce_self_detect,
             fp_timeout=args.fp_timeout,
             max_exclude_tokens=args.max_exclude_tokens,
+            cache_saliency=args.cache_saliency,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -145,6 +145,23 @@ def test_build_parser_precomputed_saliency_dir():
     assert args.precomputed_saliency_dir == Path("sal")
 
 
+def test_build_parser_cache_saliency():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--cache-saliency",
+        ]
+    )
+    assert args.cache_saliency is True
+
+
 def test_build_parser_flush_every():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()
@@ -2097,4 +2114,105 @@ def test_fp_timeout_stops_retry(tmp_path, monkeypatch):
     )
 
     assert res["false_positive"] is True
+
+
+def test_evaluate_single_saliency_cache(tmp_path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+    import src.models.gnn.res_wrapper as res_wrapper
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyClf(torch.nn.Module):
+        def forward(self, *a, **k):
+            return torch.zeros(1)
+
+    monkeypatch.setattr(
+        res_wrapper.RESGCLClassifier,
+        "load_pretrained",
+        classmethod(lambda cls, *a, **k: DummyClf()),
+    )
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    calls = {"n": 0}
+
+    def fake_compute(graph, classifier, explainer, device):
+        calls["n"] += 1
+        return {"bb": torch.tensor([0.9])}
+
+    monkeypatch.setattr(mod, "_compute_saliency_with_explainer", fake_compute)
+
+    res1 = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=None,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        cache_saliency=True,
+    )
+
+    cache_file = gpath.with_suffix(".sal.pt")
+    assert cache_file.is_file()
+    assert calls["n"] == 1
+
+    calls["n"] = 0
+    res2 = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=None,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        cache_saliency=True,
+    )
+
+    assert calls["n"] == 0
 


### PR DESCRIPTION
## Summary
- add a `--cache-saliency` CLI option
- reuse cached `*.sal.pt` files when computing saliency
- save saliency to cache when enabled
- update evaluate_single workers for caching
- test parser and caching behaviour

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_cache_saliency -q` *(fails: found no collectors because torch is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68876c337204832eb7fa84bb3166c6e8