### PR TITLE
Handle missing saliency files

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1950,7 +1950,12 @@ def main(argv: list[str] | None = None) -> None:
                     for sha, gpath, _, _, _ in tasks
                 }
                 for fut in tqdm(as_completed(fut_map), total=len(fut_map), desc="saliency", unit="graph"):
-                    fut.result()
+                    try:
+                        fut.result()
+                    except FileNotFoundError as exc:
+                        skipped += 1
+                        LOGGER.warning("Skipping %s: %s", fut_map[fut], exc)
+                        continue
 
         if args.num_workers > 1:
             ctx = mp.get_context("forkserver")


### PR DESCRIPTION
## Summary
- log and skip missing saliency files in CLI evaluation

## Testing
- `pytest tests/test_explainer_rule_eval_saliency.py::test_compute_saliency_handles_tuple -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_cli_sample_rules_out -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_688771b50b6c832e961fec5d7c44c75e