### PR TITLE
Adjust logger levels to debug

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -436,12 +436,12 @@ def evaluate_single(
 
     if saliency is None:
         if saliency_path:
-            LOGGER.info("Loading saliency from %s", saliency_path)
+            LOGGER.debug("Loading saliency from %s", saliency_path)
             saliency = _load_saliency(saliency_path)
         else:
             cache_path = graph_path.with_suffix(".sal.pt") if cache_saliency else None
             if cache_path is not None and cache_path.is_file():
-                LOGGER.info("Loading saliency from cache %s", cache_path)
+                LOGGER.debug("Loading saliency from cache %s", cache_path)
                 saliency = torch.load(cache_path, map_location="cpu", weights_only=False)
             else:
                 if classifier is None:
@@ -1954,7 +1954,7 @@ def main(argv: list[str] | None = None) -> None:
                         fut.result()
                     except FileNotFoundError as exc:
                         skipped += 1
-                        LOGGER.warning("Skipping %s: %s", fut_map[fut], exc)
+                        LOGGER.debug("Skipping %s: %s", fut_map[fut], exc)
                         continue
 
         if args.num_workers > 1:
@@ -1979,7 +1979,7 @@ def main(argv: list[str] | None = None) -> None:
                         res = fut.result()
                     except FileNotFoundError as exc:
                         skipped += 1
-                        LOGGER.warning("Skipping %s: %s", sha, exc)
+                        LOGGER.debug("Skipping %s: %s", sha, exc)
                         continue
 
                     res["sha256"] = sha
@@ -2156,12 +2156,12 @@ def main(argv: list[str] | None = None) -> None:
                         ]
                 df.to_csv(args.out_csv, index=False)
 
-        LOGGER.info("Skipped %d graphs due to missing files", skipped)
+        LOGGER.debug("Skipped %d graphs due to missing files", skipped)
 
         if results:
             det_rate = sum(r.get("detected", False) for r in results) / len(results)
             fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
-            LOGGER.info("average detection=%.3f, FP ratio=%.3f", det_rate, fp_ratio)
+            LOGGER.debug("average detection=%.3f, FP ratio=%.3f", det_rate, fp_ratio)
 
             rule_texts = [
                 (r.get("sha256"), r.get("rule_texts", [r.get("rule_text", "")]))


### PR DESCRIPTION
## Summary
- reduce verbosity of explainer rule evaluator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887764ba690832eb1ec7f836c22cf8b