### PR TITLE
Add filter for common tokens in FeatureMiner

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1077,6 +1077,8 @@ def evaluate_single(
     exclude_set: set[str] = set(t.lower() for t in (exclude_tokens or []))
     if persist_fp_exclude is not None:
         exclude_set.update(_FP_EXCLUDE_SET)
+    exclude_set.update(FeatureMiner.COMMON_TYPE_TOKENS)
+    exclude_set.update(FeatureMiner.COMMON_COMPILER_TOKENS)
 
     result = _eval_with_count(
         freq_threshold,

--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -70,6 +70,42 @@ class FeatureMiner:
     _ADDR_RX = re.compile(r"^(?:0x)?[0-9A-Fa-f]{4,}$")
     _SEC_RX = re.compile(r"^\.[A-Za-z0-9$.]{1,8}$")
 
+    # 공통 타입·컴파일러 토큰 (자동 제외 목록)
+    COMMON_TYPE_TOKENS = {
+        "int",
+        "char",
+        "short",
+        "long",
+        "void",
+        "float",
+        "double",
+        "unsigned",
+        "signed",
+        "size_t",
+        "ptr",
+        "byte",
+        "word",
+        "dword",
+        "qword",
+    }
+
+    COMMON_COMPILER_TOKENS = {
+        "memcpy",
+        "memset",
+        "memmove",
+        "memcmp",
+        "strcpy",
+        "strcmp",
+        "strlen",
+        "sprintf",
+        "printf",
+        "scanf",
+        "malloc",
+        "free",
+        "new",
+        "delete",
+    }
+
     def __init__(
         self,
         *,
@@ -621,6 +657,11 @@ class FeatureMiner:
                 if m:
                     token = m.group(1)
             token = token.strip()
+            token_l = token.lower()
+            if token_l in self.COMMON_TYPE_TOKENS:
+                continue
+            if token_l in self.COMMON_COMPILER_TOKENS:
+                continue
             if self._UPPER_RX.fullmatch(token):
                 continue
             if self._LABEL_RX.fullmatch(token):

--- a/tests/test_feature_miner_token_filter.py
+++ b/tests/test_feature_miner_token_filter.py
@@ -23,3 +23,16 @@ def test_normalize_and_rank_filters_tokens():
     assert '".rsrc" ascii nocase' not in out
     assert "call:0x401000" not in out
     assert "\"0123456789ABCDEF0123456789ABCDEF\" wide ascii nocase" not in out
+
+
+def test_common_token_sets_filter():
+    miner = FeatureMiner(top_k=1)
+    feats = [
+        "call:memcpy",
+        '"int" ascii nocase',
+        "call:CreateFileW",
+    ]
+    out = miner._normalize_and_rank(feats)
+    assert "call:CreateFileW" in out
+    assert "call:memcpy" not in out
+    assert '"int" ascii nocase' not in out


### PR DESCRIPTION
## Summary
- define `COMMON_TYPE_TOKENS` and `COMMON_COMPILER_TOKENS`
- skip features containing those tokens in `_normalize_and_rank`
- treat them as built-in excludes for explainer CLI
- test filtering of type/compiler tokens

## Testing
- `pytest tests/test_feature_miner_token_filter.py -q`
- `pytest tests/test_feature_miner_* -q`

------
https://chatgpt.com/codex/tasks/task_e_688785596b84832e925f015318eb7e19