### PR TITLE
Improve combo mode defaults

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -204,7 +204,7 @@ python -m cli.rulegen_cli ppo-train \
 
 `src.cli.explainer_rule_eval`는 그래프와 샘플을 입력으로 중요 노드를 기반한
 YARA 룰을 생성해 탐지 여부를 확인합니다. 기본 `--condition-type`은 `combo`
-이며 각 그룹의 50% 이상이 매치되어야 합니다. 그룹이 하나이거나 특징이
+이며 각 그룹의 70% 이상이 매치되어야 합니다. 그룹이 하나이거나 특징이
 2개 이하일 경우 별도 설정이 없으면 자동으로 `any` 조건을 사용하지만,
 `--group-min-count`나 `--group-percentage`가 지정된 경우 해당 값에 맞춰
 최소 매치 수가 계산됩니다.

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1630,7 +1630,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--group-percentage",
         type=int,
-        default=50,
+        default=70,
         help=(
             "combo mode: percentage of each group; if only one group or two "
             "features are present the condition falls back to 'any'."

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -327,7 +327,7 @@ class YaraBuilder:
                                 pct = self._scaled_group_percentage(len(feats_list))
                             required = max(1, math.ceil(len(feats_list) * pct / 100.0))
                         else:
-                            required = 1
+                            required = 2 if len(feats_list) >= 2 else 1
                         parts.append(f"{required} of (${tag}*)")
                     cond_line = "    " + " and ".join(parts)
             elif group_count <= 1:
@@ -365,7 +365,8 @@ class YaraBuilder:
                         n = max(1, math.ceil(len(feats_list) * pct / 100.0))
                         parts.append(f"{n} of (${tag}*)")
                     else:
-                        parts.append(f"any of (${tag}*)")
+                        required = 2 if len(feats_list) >= 2 else 1
+                        parts.append(f"{required} of (${tag}*)")
                 cond_line = "    " + " and ".join(parts)
 
         # 5) join

--- a/tests/test_yara_builder_combo.py
+++ b/tests/test_yara_builder_combo.py
@@ -13,8 +13,8 @@ def test_combo_basic():
 def test_combo_group_min_count():
     builder = YaraBuilder(condition_type="combo", group_min_count=2)
     rule = builder.build(["call:A", "call:B", "import:X", "import:Y"])
-    assert "1 of ($c*)" in rule
-    assert "1 of ($i*)" in rule
+    assert "2 of ($c*)" in rule
+    assert "2 of ($i*)" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 
@@ -77,6 +77,15 @@ def test_combo_marker_group_mandatory():
     builder = YaraBuilder(condition_type="combo")
     rule = builder.build(["call:A", "import:X", "marker:.foo"])
     assert "1 of ($m*)" in rule
+    ok, err = builder.validate(rule)
+    assert ok, err
+
+
+def test_combo_default_group_requires_two():
+    builder = YaraBuilder(condition_type="combo")
+    rule = builder.build(["call:A", "call:B", "import:X"])
+    assert "2 of ($c*)" in rule
+    assert "1 of ($i*)" in rule
     ok, err = builder.validate(rule)
     assert ok, err
 


### PR DESCRIPTION
## Summary
- tighten combo rule default in `YaraBuilder`
- raise default `--group-percentage` to 70
- adjust docs for new default
- update combo rule tests and add check for 2‑of default

## Testing
- `pytest tests/test_yara_builder_combo.py::test_combo_default_group_requires_two -q`


------
https://chatgpt.com/codex/tasks/task_e_688784272d34832e939b494ccc71d07a