### PR TITLE
Implement benign weight scoring for feature miner

### DIFF
--- a/src/rulegen/feature_miner.py
+++ b/src/rulegen/feature_miner.py
@@ -35,6 +35,7 @@ import string
 from collections import Counter
 from pathlib import Path
 from typing import Callable, Dict, List, Sequence, Tuple
+import math
 
 import torch
 from torch_geometric.data import HeteroData
@@ -120,6 +121,7 @@ class FeatureMiner:
         mal_freqs: dict[str, int] | None = None,
         freq_ratio: float = 1.0,
         freq_threshold: float | int = 0,
+        benign_weight: float = 1.0,
         auto_relax: bool = True,
         verify_func: callable | None = None,
     ) -> None:
@@ -146,6 +148,7 @@ class FeatureMiner:
         self.mal_freqs = mal_freqs
         self.freq_ratio = float(freq_ratio)
         self.freq_threshold = freq_threshold
+        self.benign_weight = float(benign_weight)
         self.auto_relax = bool(auto_relax)
         self.verify_func = verify_func
 
@@ -716,12 +719,23 @@ class FeatureMiner:
         """정상 샘플에서 자주 등장하는 토큰을 제거한다."""
         if not self.benign_freqs:
             return list(feats)
+
+        weight = getattr(self, "benign_weight", 1.0)
+        scored = []
+        for f in feats:
+            sal = sal_map.get(f, 0.0) if sal_map else 0.0
+            freq = self.benign_freqs.get(f, 0)
+            score = sal - weight * math.log(freq + 1)
+            scored.append((f, score))
+        scored.sort(key=lambda t: t[1], reverse=True)
+        ordered = [f for f, _ in scored]
+
         threshold = float(self.freq_threshold)
         ratio = float(self.freq_ratio)
         filtered: List[str] = []
         while True:
             filtered.clear()
-            for f in feats:
+            for f in ordered:
                 freq = self.benign_freqs.get(f)
                 mal = self.mal_freqs.get(f) if self.mal_freqs else None
                 if freq is not None:
@@ -730,7 +744,7 @@ class FeatureMiner:
                     if mal is not None and freq >= mal * ratio:
                         continue
                 filtered.append(f)
-            if filtered or not feats or not self.auto_relax:
+            if filtered or not ordered or not self.auto_relax:
                 break
             if threshold > 1:
                 threshold /= 2
@@ -738,14 +752,14 @@ class FeatureMiner:
                 ratio /= 2
             if threshold <= 1 and (not self.mal_freqs or ratio <= 0):
                 break
-        if filtered or not feats:
+        if filtered or not ordered:
             return filtered
 
         # 모든 후보가 제거된 경우
         cand_order: List[str] = []
         if self.mal_freqs:
             high_mal: List[str] = []
-            for f in feats:
+            for f in ordered:
                 ben = self.benign_freqs.get(f, 0)
                 mal = self.mal_freqs.get(f, 0)
                 if mal > ben * 2:
@@ -766,7 +780,7 @@ class FeatureMiner:
                     return ben / mal if mal > 0 else float("inf")
 
                 cand_order = sorted(
-                    feats,
+                    ordered,
                     key=lambda x: (
                         _ratio(x),
                         self.benign_freqs.get(x, float("inf")),
@@ -774,13 +788,7 @@ class FeatureMiner:
                     ),
                 )
             else:
-                cand_order = sorted(
-                    feats,
-                    key=lambda x: (
-                        self.benign_freqs.get(x, float("inf")),
-                        -(sal_map.get(x, 0.0) if sal_map else 0.0),
-                    ),
-                )
+                cand_order = ordered
 
         if self.verify_func:
             for c in cand_order:

--- a/tests/test_feature_miner_benign_freq.py
+++ b/tests/test_feature_miner_benign_freq.py
@@ -111,3 +111,30 @@ def test_restore_selects_lowest_ratio_when_no_high_mal():
     feats = miner(g, sal)
 
     assert feats == ["call:Bar"]
+
+
+def test_benign_weight_affects_ranking():
+    g = HeteroData()
+    g["func"].x = torch.zeros(2, 1)
+    g["func"].name = ["Foo", "Bar"]
+
+    sal = torch.tensor([0.6, 0.5])
+    freqs = {"call:Foo": 5, "call:Bar": 1}
+
+    miner = FeatureMiner(
+        top_k=2,
+        benign_freqs=freqs,
+        freq_threshold=100,
+        benign_weight=0.0,
+    )
+    feats = miner(g, sal)
+    assert feats[0] == "call:Foo"
+
+    miner_w = FeatureMiner(
+        top_k=2,
+        benign_freqs=freqs,
+        freq_threshold=100,
+        benign_weight=1.0,
+    )
+    feats_w = miner_w(g, sal)
+    assert feats_w[0] == "call:Bar"


### PR DESCRIPTION
## Summary
- add `benign_weight` parameter to `FeatureMiner`
- prioritize score-based filtering in `_filter_by_benign_freq`
- test ranking behaviour with `benign_weight`

## Testing
- `pytest tests/test_feature_miner_benign_freq.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688792c7d53c832e8cc897b9fa86e02d