### PR TITLE
Implement adaptive FP retry

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -224,6 +224,141 @@ def estimate_token_cache_size(cache: Mapping[Path, set[str]]) -> int:
     return total
 
 
+def adaptive_fp_retry(
+    eval_fn,
+    *,
+    result: Dict[str, Any],
+    exclude_set: set[str],
+    fp_token_counter: Counter[str],
+    group_min_count: int | None,
+    combine_min_ratio: float,
+    freq_threshold: float | int,
+    group_min_ratio: float,
+    num_rules: int,
+    chunk_size: int | None,
+    combine_mode: str,
+    auto_group_min: bool,
+    freq_threshold_step: float,
+    comb_ratio_step: float,
+    chunk_size_step: int,
+    combine_max_ratio: float,
+    fp_retries: int,
+    fp_timeout: float | None,
+    max_exclude_tokens: int,
+    persist_fp_exclude: Path | None,
+    fp_bar: tqdm | None,
+    is_better,
+    best_result: Dict[str, Any],
+    last_detected: Dict[str, Any] | None,
+) -> tuple[Dict[str, Any], set[str], Dict[str, Any]]:
+    start_time = time.perf_counter()
+    attempts = 0
+    counts = result.get("fp_token_counts")
+    if counts:
+        for t, c in counts.items():
+            fp_token_counter[t.lower()] += int(c)
+    tokens_sorted = [t for t, _ in sorted(fp_token_counter.items(), key=lambda x: (-x[1], x[0]))]
+    if not tokens_sorted:
+        tokens_sorted = list(result.get("fp_matched_tokens", []))
+
+    def _try(excl: set[str], gmc: int | None, ratio: float) -> Dict[str, Any]:
+        return eval_fn(
+            freq_threshold,
+            gmc,
+            ratio,
+            group_ratio=group_min_ratio,
+            n_rules=num_rules,
+            c_size=chunk_size,
+            mode=combine_mode,
+            exclude=exclude_set.union(excl),
+            auto_gmin=auto_group_min,
+        )
+
+    for tok in tokens_sorted:
+        if attempts >= fp_retries or (
+            fp_timeout and time.perf_counter() - start_time > fp_timeout
+        ):
+            break
+        attempts += 1
+        trial = _try({tok.lower()}, group_min_count, combine_min_ratio)
+        if fp_bar:
+            fp_bar.update(1)
+        if is_better(trial, best_result):
+            best_result = trial
+            if best_result.get("detected"):
+                last_detected = best_result
+        if trial.get("detected") and not trial.get("false_positive"):
+            exclude_set.add(tok.lower())
+            result = trial
+            if persist_fp_exclude is not None:
+                _FP_EXCLUDE_COUNTS[tok.lower()] += 1
+                _FP_EXCLUDE_SET.add(tok.lower())
+                _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
+            break
+
+    if result.get("false_positive"):
+        for i, t1 in enumerate(tokens_sorted):
+            if not result.get("false_positive"):
+                break
+            for t2 in tokens_sorted[i + 1 :]:
+                if attempts >= fp_retries or (
+                    fp_timeout and time.perf_counter() - start_time > fp_timeout
+                ):
+                    break
+                attempts += 1
+                trial = _try({t1.lower(), t2.lower()}, group_min_count, combine_min_ratio)
+                if fp_bar:
+                    fp_bar.update(1)
+                if is_better(trial, best_result):
+                    best_result = trial
+                    if best_result.get("detected"):
+                        last_detected = best_result
+                if trial.get("detected") and not trial.get("false_positive"):
+                    exclude_set.update({t1.lower(), t2.lower()})
+                    result = trial
+                    if persist_fp_exclude is not None:
+                        for t in (t1.lower(), t2.lower()):
+                            _FP_EXCLUDE_COUNTS[t] += 1
+                            _FP_EXCLUDE_SET.add(t)
+                        _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
+                    break
+            if not result.get("false_positive"):
+                break
+
+    if result.get("false_positive"):
+        max_match = int(result.get("fp_max_matches", 0))
+        new_cnt = max(group_min_count or 0, max_match + 1)
+        if new_cnt != group_min_count:
+            trial = _try(set(), new_cnt, combine_min_ratio)
+            attempts += 1
+            if fp_bar:
+                fp_bar.update(1)
+            if is_better(trial, best_result):
+                best_result = trial
+                if best_result.get("detected"):
+                    last_detected = best_result
+            if trial.get("detected"):
+                group_min_count = new_cnt
+                result = trial
+
+    if result.get("false_positive"):
+        new_ratio = min(combine_max_ratio, max(combine_min_ratio, (max_match + 1) / max(1, num_rules)))
+        if new_ratio > combine_min_ratio:
+            trial = _try(set(), group_min_count, new_ratio)
+            attempts += 1
+            if fp_bar:
+                fp_bar.update(1)
+            if is_better(trial, best_result):
+                best_result = trial
+                if best_result.get("detected"):
+                    last_detected = best_result
+            if trial.get("detected"):
+                combine_min_ratio = new_ratio
+                result = trial
+
+    return result, exclude_set, best_result
+
+
 def verify_features(
     json_path: Path | Mapping[str, Any] | Sequence[str] | set[str],
     features: list[str],
@@ -684,7 +819,15 @@ def evaluate_single(
 
         def _eval_group(
             feats: list[str],
-        ) -> tuple[bool, float, bool, str, list[str] | None, list[str] | None]:
+        ) -> tuple[
+            bool,
+            float,
+            bool,
+            str,
+            list[str] | None,
+            list[str] | None,
+            int,
+        ]:
             builder = YaraBuilder(
                 condition_type=condition_type,
                 percentage=percentage,
@@ -781,6 +924,7 @@ def evaluate_single(
                     return mt if ok else None
 
                 fp_tokens_set: set[str] = set()
+                fp_match_counts: list[int] = []
                 if token_index:
                     toks = _check_json(None)
                     fp = toks is not None
@@ -800,20 +944,20 @@ def evaluate_single(
                                 if toks is not None:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    executor.shutdown(cancel_futures=True)
-                                    break
+                                    fp_match_counts.append(len(toks))
                     else:
                         for p in files:
                             toks = _check_json(p)
                             if toks is not None:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                break
+                                fp_match_counts.append(len(toks))
                 elif clean_sample is not None:
                     toks = _check_json(clean_sample)
                     fp = toks is not None
                     if fp:
                         fp_tokens_set.update(toks)
+                        fp_match_counts.append(len(toks))
                 elif clean_paths is not None:
                     paths = list(clean_paths)
                     if fp_scan_workers > 1 and len(paths) > 1:
@@ -828,15 +972,14 @@ def evaluate_single(
                                 if toks is not None:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    executor.shutdown(cancel_futures=True)
-                                    break
+                                    fp_match_counts.append(len(toks))
                     else:
                         for p in paths:
                             toks = _check_json(p)
                             if toks is not None:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                break
+                                fp_match_counts.append(len(toks))
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
@@ -844,8 +987,10 @@ def evaluate_single(
                 ):
                     fp = False
                 fp_tokens = sorted(fp_tokens_set) if fp_tokens_set else None
+                fp_max = max(fp_match_counts) if fp_match_counts else 0
             else:
                 fp_tokens_set: set[str] = set()
+                fp_match_counts: list[int] = []
                 if (
                     clean_dir is not None
                     and clean_dir.is_dir()
@@ -876,15 +1021,14 @@ def evaluate_single(
                                 if toks:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    executor.shutdown(cancel_futures=True)
-                                    break
+                                    fp_match_counts.append(len(toks))
                     else:
                         for fp_path in files:
                             toks = _scan_file(fp_path)
                             if toks:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                break
+                                fp_match_counts.append(len(toks))
                 elif clean_sample is not None and compiled is not None:
                     try:
                         matches = compiled.match(str(clean_sample))
@@ -893,6 +1037,7 @@ def evaluate_single(
                             fp_tokens_set.update(
                                 id_map.get(s[1], s[1]) for s in matches[0].strings
                             )
+                            fp_match_counts.append(len(matches[0].strings))
                     except Exception:
                         fp = False
                 elif clean_paths is not None and compiled is not None:
@@ -921,15 +1066,14 @@ def evaluate_single(
                                 if toks:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    executor.shutdown(cancel_futures=True)
-                                    break
+                                    fp_match_counts.append(len(toks))
                     else:
                         for p in paths:
                             toks = _scan_path(p)
                             if toks:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                break
+                                fp_match_counts.append(len(toks))
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
@@ -938,19 +1082,30 @@ def evaluate_single(
                     fp = False
 
                 fp_tokens = sorted(fp_tokens_set) if fp_tokens_set else None
+                fp_max = max(fp_match_counts) if fp_match_counts else 0
 
-            return detected, coverage, fp, rule_text, fp_tokens, matched_tokens
+            return (
+                detected,
+                coverage,
+                fp,
+                rule_text,
+                fp_tokens,
+                matched_tokens,
+                fp_max,
+            )
 
         fp_tokens_all: list[list[str] | None] = []
         matched_tokens_all: list[list[str] | None] = []
+        fp_match_max_vals: list[int] = []
         for grp in groups:
-            det, cov, fp, rt, fp_tok, match_tok = _eval_group(grp)
+            det, cov, fp, rt, fp_tok, match_tok, fp_mx = _eval_group(grp)
             detections.append(det)
             coverages.append(cov)
             false_positives.append(fp)
             rule_texts.append(rt)
             fp_tokens_all.append(fp_tok)
             matched_tokens_all.append(match_tok)
+            fp_match_max_vals.append(fp_mx)
 
         if isinstance(saliency, dict):
             flat = torch.cat(list(saliency.values()))
@@ -995,6 +1150,8 @@ def evaluate_single(
             if toks:
                 matched_tokens_all_flat.extend(toks)
 
+        fp_max_total = max(fp_match_max_vals) if fp_match_max_vals else 0
+
         result: Dict[str, Any] = {
             "detected": combined_det,
             "rule_length": len(first_feats),
@@ -1014,6 +1171,8 @@ def evaluate_single(
             result["fp_matched_tokens"] = matched_tokens_fp
         if fp_token_counts:
             result["fp_token_counts"] = dict(fp_token_counts)
+        if fp_max_total:
+            result["fp_max_matches"] = fp_max_total
 
         if sample_json is not None and sample_json.is_file() and first_feats:
             result["feature_verified"] = verify_features(
@@ -1043,6 +1202,9 @@ def evaluate_single(
             LOGGER.debug("fp_matched_tokens: %s", matched_tokens_fp)
         if fp_token_counts:
             LOGGER.debug("fp_token_counts: %s", fp_token_counts)
+        if fp_max_total:
+            LOGGER.debug("fp_max_matches: %d", fp_max_total)
+            result["fp_max_matches"] = fp_max_total
 
         return result
 
@@ -1077,8 +1239,8 @@ def evaluate_single(
     exclude_set: set[str] = set(t.lower() for t in (exclude_tokens or []))
     if persist_fp_exclude is not None:
         exclude_set.update(_FP_EXCLUDE_SET)
-    exclude_set.update(FeatureMiner.COMMON_TYPE_TOKENS)
-    exclude_set.update(FeatureMiner.COMMON_COMPILER_TOKENS)
+    exclude_set.update(getattr(FeatureMiner, "COMMON_TYPE_TOKENS", set()))
+    exclude_set.update(getattr(FeatureMiner, "COMMON_COMPILER_TOKENS", set()))
 
     result = _eval_with_count(
         freq_threshold,
@@ -1254,162 +1416,34 @@ def evaluate_single(
         cur_len = int(current.get("rule_length", 0))
         return new_len < cur_len
 
+
     if result.get("false_positive") and fp_retries > 0:
-        start_time = time.perf_counter()
-        timed_out = False
-        attempts = 0
-        counts = result.get("fp_token_counts")
-        tokens_to_exclude = result.get("fp_matched_tokens", [])
-        if counts:
-            for t, c in counts.items():
-                fp_token_counter[t.lower()] += int(c)
-        if fp_token_counter:
-            ordered = sorted(fp_token_counter.items(), key=lambda x: (-x[1], x[0]))
-            tokens_sorted = [t for t, _ in ordered]
-        else:
-            tokens_sorted = list(tokens_to_exclude)
-        if tokens_sorted:
-            LOGGER.debug(
-                "Trying to exclude tokens due to FP retry: %s", tokens_sorted
-            )
-            groups = [
-                tokens_sorted[i : i + max_exclude_tokens]
-                for i in range(0, len(tokens_sorted), max_exclude_tokens)
-            ]
-            for group in groups:
-                if (
-                    fp_retries and attempts >= fp_retries
-                ) or (
-                    fp_timeout and time.perf_counter() - start_time > fp_timeout
-                ):
-                    timed_out = True
-                    break
-                attempts += 1
-                trial_excludes = {
-                    t.lower()
-                    for t in group
-                    if t.lower() not in exclude_set
-                }
-                trial = _eval_with_count(
-                    freq_threshold,
-                    group_min_count,
-                    combine_min_ratio,
-                    group_ratio=group_min_ratio,
-                    n_rules=num_rules,
-                    c_size=chunk_size,
-                    mode=combine_mode,
-                    exclude=exclude_set.union(trial_excludes),
-                    auto_gmin=auto_group_min,
-                )
-                LOGGER.debug(
-                    "FP retry exclude %s -> detected=%s fp=%s",
-                    list(group),
-                    trial.get("detected"),
-                    trial.get("false_positive"),
-                )
-                msg = (
-                    f"FP retry exclude {group} -> detected={trial.get('detected')} "
-                    f"fp={trial.get('false_positive')}"
-                )
-                if fp_bar:
-                    fp_bar.write(msg)
-                else:
-                    LOGGER.debug(msg)
-                if fp_bar:
-                    fp_bar.update(1)
-                if not trial.get("detected"):
-                    continue
-                if _is_better(trial, best_result):
-                    best_result = trial
-                    if best_result.get("detected"):
-                        last_detected_result = best_result
-                if not trial.get("false_positive"):
-                    exclude_set.update(trial_excludes)
-                    result = trial
-                    if persist_fp_exclude is not None:
-                        for t in trial_excludes:
-                            _FP_EXCLUDE_COUNTS[t] += 1
-                        _FP_EXCLUDE_SET.update(trial_excludes)
-                        _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
-                    break
-            if timed_out:
-                LOGGER.info("FP retry timed out during token exclusion")
-                return last_detected_result or best_result
-            LOGGER.debug("Updated exclude set after FP retry: %s", sorted(exclude_set))
-
-        if not timed_out:
-            # Build candidate parameter ranges
-            freq_vals = {freq_threshold}
-            group_vals = {group_min_count} if group_min_count is not None else {None}
-            ratio_vals = {combine_min_ratio}
-
-            for step in range(1, fp_retries + 1):
-                if freq_threshold_step > 0:
-                    freq_vals.add(max(0, freq_threshold - step * freq_threshold_step))
-                if group_min_count is not None:
-                    group_vals.add(group_min_count + step)
-                if comb_ratio_step > 0:
-                    ratio_vals.add(
-                        min(combine_max_ratio, combine_min_ratio + step * comb_ratio_step)
-                    )
-
-            for ft in sorted(freq_vals):
-                if (
-                    fp_retries and attempts >= fp_retries
-                ) or (
-                    fp_timeout and time.perf_counter() - start_time > fp_timeout
-                ):
-                    timed_out = True
-                    break
-                for gc in sorted(group_vals) if group_vals != {None} else [None]:
-                    if (
-                        fp_retries and attempts >= fp_retries
-                    ) or (
-                        fp_timeout and time.perf_counter() - start_time > fp_timeout
-                    ):
-                        timed_out = True
-                        break
-                    for cr in sorted(ratio_vals):
-                        if (
-                            fp_retries and attempts >= fp_retries
-                        ) or (
-                            fp_timeout and time.perf_counter() - start_time > fp_timeout
-                        ):
-                            timed_out = True
-                            break
-                        attempts += 1
-                        trial = _eval_with_count(
-                            ft,
-                            gc,
-                            cr,
-                            group_ratio=group_min_ratio,
-                            n_rules=num_rules,
-                            c_size=chunk_size,
-                            mode=combine_mode,
-                            exclude=exclude_set,
-                            auto_gmin=auto_group_min,
-                        )
-                        if fp_bar:
-                            fp_bar.update(1)
-                        if _is_better(trial, best_result):
-                            best_result = trial
-                            if best_result.get("detected"):
-                                last_detected_result = best_result
-                            LOGGER.debug(
-                                "Improved with freq_threshold=%s group_min_count=%s combine_min_ratio=%.3f (detected=%s fp=%s)",
-                                ft,
-                                gc,
-                                cr,
-                                best_result.get("detected"),
-                                best_result.get("false_positive"),
-                            )
-                        if not trial.get("false_positive") and trial.get("detected"):
-                            result = trial
-                            break
-                    if timed_out or (not trial.get("false_positive") and trial.get("detected")):
-                        break
-                if timed_out or (not trial.get("false_positive") and trial.get("detected")):
-                    break
+        result, exclude_set, best_result = adaptive_fp_retry(
+            _eval_with_count,
+            result=result,
+            exclude_set=exclude_set,
+            fp_token_counter=fp_token_counter,
+            group_min_count=group_min_count,
+            combine_min_ratio=combine_min_ratio,
+            freq_threshold=freq_threshold,
+            group_min_ratio=group_min_ratio,
+            num_rules=num_rules,
+            chunk_size=chunk_size,
+            combine_mode=combine_mode,
+            auto_group_min=auto_group_min,
+            freq_threshold_step=freq_threshold_step,
+            comb_ratio_step=comb_ratio_step,
+            chunk_size_step=chunk_size_step,
+            combine_max_ratio=combine_max_ratio,
+            fp_retries=fp_retries,
+            fp_timeout=fp_timeout,
+            max_exclude_tokens=max_exclude_tokens,
+            persist_fp_exclude=persist_fp_exclude,
+            fp_bar=fp_bar,
+            is_better=_is_better,
+            best_result=best_result,
+            last_detected=last_detected_result,
+        )
 
     out_result = best_result
     if not best_result.get("detected") and last_detected_result is not None:

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1591,6 +1591,92 @@ def test_fp_tokens_accumulation(tmp_path, monkeypatch):
     assert sorted(res.get("fp_matched_tokens", [])) == ["call:bar", "call:foo"]
 
 
+def test_adaptive_fp_retry_token_order(tmp_path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9, 0.8])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    clean1 = tmp_path / "c1.bin"
+    clean1.write_bytes(b"dummy")
+    clean2 = tmp_path / "c2.bin"
+    clean2.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["foo", "bar"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self, id1, id2=None):
+            ids = [id1] if id2 is None else [id1, id2]
+            self.strings = [(0, i, b"x") for i in ids]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            p = str(path)
+            have_foo = "foo" in self.text
+            have_bar = "bar" in self.text
+            if "c1" in p:
+                return [FakeMatch("$s0")] if have_foo else []
+            if "c2" in p:
+                return [FakeMatch("$s1")] if have_bar else []
+            if have_foo and have_bar:
+                return [FakeMatch("$s0", "$s1")]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_paths=[clean1, clean2],
+        combine_mode="or",
+        fp_retries=2,
+    )
+
+    assert res["detected"] is True
+
+
 def test_fp_retry_token_exclusion_rollback(tmp_path, monkeypatch):
     pytest.importorskip("torch")
     pytest.importorskip("torch_geometric")


### PR DESCRIPTION
## Summary
- add `adaptive_fp_retry` function to refine false positive handling
- accumulate match tokens across all clean samples
- call new retry logic in `evaluate_single`
- add regression test for adaptive retry order

## Testing
- `pytest -k fp_retry_exclude_tokens tests/test_explainer_rule_eval_cli.py -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_adaptive_fp_retry_token_order -q`


------
https://chatgpt.com/codex/tasks/task_e_68879484d4c8832e84beb0ca3691539d