### PR TITLE
Improve FP exclude persistence

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -221,6 +221,9 @@ python -m src.cli.explainer_rule_eval \
 단계적 완화를 할 수 있습니다.
 `--enforce-self-detect` 옵션을 주면 현재 샘플이 탐지될 때까지 조건을 단계적으로 완화합니다.
 `--fp-timeout` 옵션을 지정하면 FP 재시도를 해당 시간(초) 이후 중단합니다.
+`--persist-fp-exclude` 옵션에 JSON 파일을 지정하면 재시도 과정에서
+제외된 토큰을 누적 저장하며, 다음 실행에서도 동일 파일을 지정하면
+자동으로 로드되어 동일 토큰을 계속 제외합니다.
 
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -51,10 +51,16 @@ def _load_fp_exclude(path: Path) -> Counter[str]:
 
 
 def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
-    """Persist FP exclude ``tokens`` and counts to ``path``."""
+    """Persist FP exclude ``tokens`` and counts to ``path``.
+
+    Existing values in ``path`` are merged and result is sorted before saving.
+    """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        data = {k: int(v) for k, v in tokens.items()}
+        merged = _load_fp_exclude(path)
+        for k, v in tokens.items():
+            merged[k.lower()] += int(v)
+        data = {k: int(v) for k, v in sorted(merged.items(), key=lambda x: (-x[1], x[0]))}
         path.write_text(
             json.dumps(data, ensure_ascii=False, indent=2),
             encoding="utf-8",
@@ -1239,6 +1245,8 @@ def evaluate_single(
     exclude_set: set[str] = set(t.lower() for t in (exclude_tokens or []))
     if persist_fp_exclude is not None:
         exclude_set.update(_FP_EXCLUDE_SET)
+        for t in _FP_EXCLUDE_SET:
+            _FP_EXCLUDE_COUNTS[t] += 1
     exclude_set.update(getattr(FeatureMiner, "COMMON_TYPE_TOKENS", set()))
     exclude_set.update(getattr(FeatureMiner, "COMMON_COMPILER_TOKENS", set()))
 
@@ -1452,6 +1460,8 @@ def evaluate_single(
     if fp_token_counter:
         out_result.setdefault("fp_token_counts_total", {})
         out_result["fp_token_counts_total"] = dict(fp_token_counter)
+    if persist_fp_exclude is not None:
+        _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
     return out_result
 
 

--- a/tests/test_fp_exclude_persist.py
+++ b/tests/test_fp_exclude_persist.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from src.cli.explainer_rule_eval import _save_fp_exclude, _load_fp_exclude
+
+
+def test_save_and_load_fp_exclude(tmp_path):
+    fp = tmp_path / "tokens.json"
+    _save_fp_exclude(fp, {"b": 1, "a": 2})
+    counts = _load_fp_exclude(fp)
+    assert counts == {"b": 1, "a": 2}
+
+    _save_fp_exclude(fp, {"c": 1, "a": 3})
+    counts = _load_fp_exclude(fp)
+    assert counts == {"a": 5, "b": 1, "c": 1}
+
+    data = json.loads(fp.read_text())
+    assert list(data.keys()) == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
- persist FP exclude tokens across runs by updating counts each run
- merge and sort token file when saving
- document `--persist-fp-exclude` usage
- test persistent FP exclude file behavior

## Testing
- `pytest -q tests/test_fp_exclude_persist.py`

------
https://chatgpt.com/codex/tasks/task_e_688798fdec1c832ea913b395584e4c73