### PR TITLE
Improve FP retry search heuristics

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -333,9 +333,11 @@ def adaptive_fp_retry(
 
     if result.get("false_positive"):
         max_match = int(result.get("fp_max_matches", 0))
-        new_cnt = max(group_min_count or 0, max_match + 1)
-        if new_cnt != group_min_count:
-            trial = _try(set(), new_cnt, combine_min_ratio)
+        low_cnt = max(group_min_count or 0, max_match + 1)
+        high_cnt: int | None = None
+        gmc = low_cnt
+        while attempts < fp_retries and result.get("false_positive"):
+            trial = _try(set(), gmc, combine_min_ratio)
             attempts += 1
             if fp_bar:
                 fp_bar.update(1)
@@ -343,14 +345,28 @@ def adaptive_fp_retry(
                 best_result = trial
                 if best_result.get("detected"):
                     last_detected = best_result
-            if trial.get("detected"):
-                group_min_count = new_cnt
+            if trial.get("detected") and not trial.get("false_positive"):
+                group_min_count = gmc
                 result = trial
+                break
+            if trial.get("false_positive"):
+                low_cnt = gmc + 1
+                gmc = gmc * 2 if high_cnt is None else (gmc + high_cnt) // 2
+            else:
+                high_cnt = gmc - 1
+                if high_cnt < low_cnt:
+                    break
+                gmc = (low_cnt + high_cnt) // 2
 
     if result.get("false_positive"):
-        new_ratio = min(combine_max_ratio, max(combine_min_ratio, (max_match + 1) / max(1, num_rules)))
-        if new_ratio > combine_min_ratio:
-            trial = _try(set(), group_min_count, new_ratio)
+        max_match = int(result.get("fp_max_matches", 0))
+        low_ratio = combine_min_ratio
+        high_ratio = combine_max_ratio
+        ratio = min(high_ratio, max(low_ratio, (max_match + 1) / max(1, num_rules)))
+        if math.isclose(ratio, combine_min_ratio):
+            ratio = (low_ratio + high_ratio) / 2.0
+        while attempts < fp_retries and result.get("false_positive") and high_ratio - low_ratio > 0.001:
+            trial = _try(set(), group_min_count, ratio)
             attempts += 1
             if fp_bar:
                 fp_bar.update(1)
@@ -358,9 +374,16 @@ def adaptive_fp_retry(
                 best_result = trial
                 if best_result.get("detected"):
                     last_detected = best_result
-            if trial.get("detected"):
-                combine_min_ratio = new_ratio
+            if trial.get("detected") and not trial.get("false_positive"):
+                combine_min_ratio = ratio
                 result = trial
+                high_ratio = ratio
+                break
+            if trial.get("false_positive"):
+                low_ratio = ratio
+            else:
+                high_ratio = ratio
+            ratio = (low_ratio + high_ratio) / 2.0
 
     return result, exclude_set, best_result
 
@@ -896,6 +919,20 @@ def evaluate_single(
                     LOGGER.debug("Matched tokens: %s", matched_tokens)
 
             fp = False
+
+            def _max_group_count(toks: Sequence[str]) -> int:
+                """Return highest match count among feature groups."""
+                prefix_map = {"call:": "c", "import:": "i"}
+                counts: dict[str, int] = {}
+                for t in toks:
+                    tag = "o"
+                    for p, tg in prefix_map.items():
+                        if t.startswith(p):
+                            tag = tg
+                            break
+                    counts[tag] = counts.get(tag, 0) + 1
+                return max(counts.values(), default=0)
+
             if json_match:
 
                 def _check_json(p: Path | None) -> list[str] | None:
@@ -950,20 +987,20 @@ def evaluate_single(
                                 if toks is not None:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    fp_match_counts.append(len(toks))
+                                    fp_match_counts.append(_max_group_count(toks))
                     else:
                         for p in files:
                             toks = _check_json(p)
                             if toks is not None:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                fp_match_counts.append(len(toks))
+                                fp_match_counts.append(_max_group_count(toks))
                 elif clean_sample is not None:
                     toks = _check_json(clean_sample)
                     fp = toks is not None
                     if fp:
                         fp_tokens_set.update(toks)
-                        fp_match_counts.append(len(toks))
+                        fp_match_counts.append(_max_group_count(toks))
                 elif clean_paths is not None:
                     paths = list(clean_paths)
                     if fp_scan_workers > 1 and len(paths) > 1:
@@ -978,14 +1015,14 @@ def evaluate_single(
                                 if toks is not None:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    fp_match_counts.append(len(toks))
+                                    fp_match_counts.append(_max_group_count(toks))
                     else:
                         for p in paths:
                             toks = _check_json(p)
                             if toks is not None:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                fp_match_counts.append(len(toks))
+                                fp_match_counts.append(_max_group_count(toks))
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
@@ -1027,14 +1064,14 @@ def evaluate_single(
                                 if toks:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    fp_match_counts.append(len(toks))
+                                    fp_match_counts.append(_max_group_count(toks))
                     else:
                         for fp_path in files:
                             toks = _scan_file(fp_path)
                             if toks:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                fp_match_counts.append(len(toks))
+                                fp_match_counts.append(_max_group_count(toks))
                 elif clean_sample is not None and compiled is not None:
                     try:
                         matches = compiled.match(str(clean_sample))
@@ -1043,7 +1080,11 @@ def evaluate_single(
                             fp_tokens_set.update(
                                 id_map.get(s[1], s[1]) for s in matches[0].strings
                             )
-                            fp_match_counts.append(len(matches[0].strings))
+                        fp_match_counts.append(
+                            _max_group_count(
+                                [id_map.get(s[1], s[1]) for s in matches[0].strings]
+                            )
+                        )
                     except Exception:
                         fp = False
                 elif clean_paths is not None and compiled is not None:
@@ -1072,14 +1113,14 @@ def evaluate_single(
                                 if toks:
                                     fp = True
                                     fp_tokens_set.update(toks)
-                                    fp_match_counts.append(len(toks))
+                                    fp_match_counts.append(_max_group_count(toks))
                     else:
                         for p in paths:
                             toks = _scan_path(p)
                             if toks:
                                 fp = True
                                 fp_tokens_set.update(toks)
-                                fp_match_counts.append(len(toks))
+                                fp_match_counts.append(_max_group_count(toks))
                 elif (
                     clean_dir is not None
                     or clean_sample is not None


### PR DESCRIPTION
## Summary
- calculate FP match counts per feature group
- binary search `group_min_count` when FP persists
- tune `combine_min_ratio` with similar binary search

## Testing
- `python -m py_compile src/cli/explainer_rule_eval.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68879b572524832e846b49b9b8fb9bae