### PR TITLE
Implement cumulative FP token retry logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -280,13 +280,17 @@ def adaptive_fp_retry(
             auto_gmin=auto_group_min,
         )
 
+    excl_tokens: set[str] = set()
     for tok in tokens_sorted:
-        if attempts >= fp_retries or (
-            fp_timeout and time.perf_counter() - start_time > fp_timeout
+        if (
+            attempts >= fp_retries
+            or (fp_timeout and time.perf_counter() - start_time > fp_timeout)
+            or len(excl_tokens) >= max_exclude_tokens
         ):
             break
+        excl_tokens.add(tok.lower())
         attempts += 1
-        trial = _try({tok.lower()}, group_min_count, combine_min_ratio)
+        trial = _try(excl_tokens, group_min_count, combine_min_ratio)
         if fp_bar:
             fp_bar.update(1)
         if is_better(trial, best_result):
@@ -294,42 +298,16 @@ def adaptive_fp_retry(
             if best_result.get("detected"):
                 last_detected = best_result
         if trial.get("detected") and not trial.get("false_positive"):
-            exclude_set.add(tok.lower())
+            exclude_set.update(excl_tokens)
             result = trial
             if persist_fp_exclude is not None:
-                _FP_EXCLUDE_COUNTS[tok.lower()] += 1
-                _FP_EXCLUDE_SET.add(tok.lower())
+                for t in excl_tokens:
+                    _FP_EXCLUDE_COUNTS[t] += 1
+                    _FP_EXCLUDE_SET.add(t)
                 _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
             break
 
-    if result.get("false_positive"):
-        for i, t1 in enumerate(tokens_sorted):
-            if not result.get("false_positive"):
-                break
-            for t2 in tokens_sorted[i + 1 :]:
-                if attempts >= fp_retries or (
-                    fp_timeout and time.perf_counter() - start_time > fp_timeout
-                ):
-                    break
-                attempts += 1
-                trial = _try({t1.lower(), t2.lower()}, group_min_count, combine_min_ratio)
-                if fp_bar:
-                    fp_bar.update(1)
-                if is_better(trial, best_result):
-                    best_result = trial
-                    if best_result.get("detected"):
-                        last_detected = best_result
-                if trial.get("detected") and not trial.get("false_positive"):
-                    exclude_set.update({t1.lower(), t2.lower()})
-                    result = trial
-                    if persist_fp_exclude is not None:
-                        for t in (t1.lower(), t2.lower()):
-                            _FP_EXCLUDE_COUNTS[t] += 1
-                            _FP_EXCLUDE_SET.add(t)
-                        _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
-                    break
-            if not result.get("false_positive"):
-                break
+
 
     if result.get("false_positive"):
         max_match = int(result.get("fp_max_matches", 0))
@@ -1913,6 +1891,7 @@ def main(argv: list[str] | None = None) -> None:
             human_bytes(cache_bytes),
         )
         results: list[dict[str, Any]] = []
+        fp_token_counter_all: Counter[str] = Counter()
         flush_buffer: list[dict[str, Any]] = []
         first_flush = True
         skipped = 0
@@ -2030,6 +2009,9 @@ def main(argv: list[str] | None = None) -> None:
 
                     res["sha256"] = sha
                     results.append(res)
+                    cnts = res.get("fp_token_counts_total")
+                    if cnts:
+                        fp_token_counter_all.update({k.lower(): int(v) for k, v in cnts.items()})
 
                     det_rate = sum(r.get("detected", False) for r in results) / len(
                         results
@@ -2105,6 +2087,9 @@ def main(argv: list[str] | None = None) -> None:
 
                 res["sha256"] = sha
                 results.append(res)
+                cnts = res.get("fp_token_counts_total")
+                if cnts:
+                    fp_token_counter_all.update({k.lower(): int(v) for k, v in cnts.items()})
 
                 det_rate = sum(r.get("detected", False) for r in results) / len(results)
                 fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
@@ -2208,6 +2193,9 @@ def main(argv: list[str] | None = None) -> None:
             det_rate = sum(r.get("detected", False) for r in results) / len(results)
             fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
             LOGGER.info("average detection=%.3f, FP ratio=%.3f", det_rate, fp_ratio)
+            if fp_token_counter_all:
+                top_tokens = sorted(fp_token_counter_all.items(), key=lambda x: (-x[1], x[0]))[:10]
+                LOGGER.info("Top FP tokens: %s", top_tokens)
 
             rule_texts = [
                 (r.get("sha256"), r.get("rule_texts", [r.get("rule_text", "")]))


### PR DESCRIPTION
## Summary
- implement progressive token exclusion strategy in `adaptive_fp_retry`
- aggregate FP tokens across batch evaluation and log top tokens

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_adaptive_fp_retry_token_order -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_retry_token_exclusion_rollback -q`


------
https://chatgpt.com/codex/tasks/task_e_68879b691ba8832e9adc5810b722b239