### PR TITLE
Improve FP token exclusion strategy

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -280,17 +280,16 @@ def adaptive_fp_retry(
             auto_gmin=auto_group_min,
         )
 
-    excl_tokens: set[str] = set()
-    for tok in tokens_sorted:
+    for i, tok in enumerate(tokens_sorted):
         if (
             attempts >= fp_retries
             or (fp_timeout and time.perf_counter() - start_time > fp_timeout)
-            or len(excl_tokens) >= max_exclude_tokens
+            or i >= max_exclude_tokens
         ):
             break
-        excl_tokens.add(tok.lower())
+        tok_l = tok.lower()
         attempts += 1
-        trial = _try(excl_tokens, group_min_count, combine_min_ratio)
+        trial = _try({tok_l}, group_min_count, combine_min_ratio)
         if fp_bar:
             fp_bar.update(1)
         if is_better(trial, best_result):
@@ -298,12 +297,11 @@ def adaptive_fp_retry(
             if best_result.get("detected"):
                 last_detected = best_result
         if trial.get("detected") and not trial.get("false_positive"):
-            exclude_set.update(excl_tokens)
+            exclude_set.add(tok_l)
             result = trial
             if persist_fp_exclude is not None:
-                for t in excl_tokens:
-                    _FP_EXCLUDE_COUNTS[t] += 1
-                    _FP_EXCLUDE_SET.add(t)
+                _FP_EXCLUDE_COUNTS[tok_l] += 1
+                _FP_EXCLUDE_SET.add(tok_l)
                 _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
             break
 
@@ -1788,7 +1786,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-exclude-tokens",
         type=int,
         default=5,
-        help="Maximum number of tokens to exclude at once during FP retry",
+        help="Maximum number of tokens to try excluding individually during FP retry",
     )
     p.add_argument(
         "--num-rules-min",


### PR DESCRIPTION
## Summary
- refine adaptive FP retry to test tokens individually
- update CLI help for `--max-exclude-tokens`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887adc14e64832e94ec44b91eff59c6