### PR TITLE
Enable dynamic group min count

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -228,6 +228,7 @@ python -m src.cli.explainer_rule_eval \
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로
 낮춰집니다.
+`--group-min-ratio`를 지정하면 그룹 후보 수에 비례하여 최소 매치 수가 자동으로 계산됩니다.
 배치 모드에서 `--flush-every`를 지정하면 중간 결과를 주기적으로 CSV에 저장할 수 있습니다.
 
 ### Building YARA rules

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -833,14 +833,21 @@ def evaluate_single(
             list[str] | None,
             int,
         ]:
+            dyn_cnt = compute_dynamic_group_min_count(
+                feats,
+                base=group_cnt,
+                ratio=group_ratio,
+                auto=auto_gmin,
+            )
+            pct = None if dyn_cnt is not None else group_pct
             builder = YaraBuilder(
                 condition_type=condition_type,
                 percentage=percentage,
                 min_count=min_count,
-                group_percentage=group_pct,
-                group_min_count=group_cnt,
-                group_min_count_ratio=group_ratio,
-                auto_group_min=auto_gmin,
+                group_percentage=pct,
+                group_min_count=dyn_cnt,
+                group_min_count_ratio=0.0,
+                auto_group_min=False,
                 adjust_group_percentage=adjust_group_percentage,
             )
             rule_text, id_map = builder.build(feats, return_map=True)
@@ -1854,6 +1861,27 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
     return p
+
+
+def compute_dynamic_group_min_count(
+    features: Sequence[str],
+    *,
+    base: int | None = None,
+    ratio: float = 0.0,
+    auto: bool = False,
+) -> int | None:
+    """Return group_min_count adjusted for feature count."""
+    if base is not None:
+        return max(1, min(base, len(features)))
+
+    if ratio <= 0:
+        return None
+
+    required = max(1, math.ceil(len(features) * ratio))
+    if auto and len(features) <= 3:
+        required = min(required, 1 if len(features) <= 2 else 2)
+
+    return min(required, len(features))
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- add `compute_dynamic_group_min_count` and use it before building rules
- document how to use `--group-min-ratio`
- fix handling of group percentage when dynamic count is used

## Testing
- `python -m src.cli.explainer_rule_eval --help`
- `pytest tests/test_yara_builder_combo.py::test_combo_group_min_count -q` *(fails: `yara` module not available)*

------
https://chatgpt.com/codex/tasks/task_e_6887b1e48dc0832ea988145567b0864b