### PR TITLE
Add optimizer for explainer_rule_eval

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -224,6 +224,9 @@ python -m src.cli.explainer_rule_eval \
 `--persist-fp-exclude` 옵션에 JSON 파일을 지정하면 재시도 과정에서
 제외된 토큰을 누적 저장하며, 다음 실행에서도 동일 파일을 지정하면
 자동으로 로드되어 동일 토큰을 계속 제외합니다.
+`--optimize` 플래그를 사용하면 재시도 과정에서 하이퍼파라미터를 온라인으로
+조정합니다. `--optimizer-pkl` 로 이전 상태를 불러오거나
+`--save-optimizer` 로 실행 후 상태를 저장할 수 있습니다.
 
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로

--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import torch
+
+
+class CategoricalOptimizer:
+    """Simple optimizer for discrete rule parameters."""
+
+    CONDITION_TYPES = ["any", "all", "percentage", "count", "combo"]
+    COMBINE_MODES = ["or", "and"]
+
+    def __init__(self, lr: float = 0.1) -> None:
+        self.condition_type_logits = torch.nn.Parameter(torch.zeros(len(self.CONDITION_TYPES)))
+        self.combine_mode_logits = torch.nn.Parameter(torch.zeros(len(self.COMBINE_MODES)))
+        self.dynamic_k_logit = torch.nn.Parameter(torch.tensor(0.0))
+        self.auto_relax_logit = torch.nn.Parameter(torch.tensor(0.0))
+        self.adjust_group_percentage_logit = torch.nn.Parameter(torch.tensor(0.0))
+        self.group_min_ratio_logit = torch.nn.Parameter(torch.tensor(0.0))
+        self.combine_min_ratio_logit = torch.nn.Parameter(torch.tensor(0.0))
+
+        self._params = [
+            self.condition_type_logits,
+            self.combine_mode_logits,
+            self.dynamic_k_logit,
+            self.auto_relax_logit,
+            self.adjust_group_percentage_logit,
+            self.group_min_ratio_logit,
+            self.combine_min_ratio_logit,
+        ]
+        self.optimizer = torch.optim.AdamW(self._params, lr=lr)
+
+    # ------------------------------------------------------------------
+    def state_dict(self) -> dict:
+        return {
+            "logits": {k: p.detach().cpu() for k, p in self._logit_map().items()},
+            "optimizer": self.optimizer.state_dict(),
+        }
+
+    def load_state_dict(self, state: dict) -> None:
+        logits = state.get("logits", {})
+        for name, param in self._logit_map().items():
+            if name in logits:
+                param.data.copy_(torch.tensor(logits[name]))
+        if "optimizer" in state:
+            self.optimizer.load_state_dict(state["optimizer"])
+
+    def _logit_map(self) -> dict[str, torch.nn.Parameter]:
+        return {
+            "condition_type": self.condition_type_logits,
+            "combine_mode": self.combine_mode_logits,
+            "dynamic_k": self.dynamic_k_logit,
+            "auto_relax": self.auto_relax_logit,
+            "adjust_group_percentage": self.adjust_group_percentage_logit,
+            "group_min_ratio": self.group_min_ratio_logit,
+            "combine_min_ratio": self.combine_min_ratio_logit,
+        }
+
+    # ------------------------------------------------------------------
+    def discrete_params(self) -> dict[str, object]:
+        cond = self.CONDITION_TYPES[int(torch.argmax(self.condition_type_logits).item())]
+        comb = self.COMBINE_MODES[int(torch.argmax(self.combine_mode_logits).item())]
+        dynamic_k = torch.sigmoid(self.dynamic_k_logit).item() > 0.5
+        auto_relax = torch.sigmoid(self.auto_relax_logit).item() > 0.5
+        adjust_gp = torch.sigmoid(self.adjust_group_percentage_logit).item() > 0.5
+        g_ratio = torch.sigmoid(self.group_min_ratio_logit).item()
+        c_ratio = torch.sigmoid(self.combine_min_ratio_logit).item()
+        return {
+            "condition_type": cond,
+            "combine_mode": comb,
+            "dynamic_k": dynamic_k,
+            "auto_relax": auto_relax,
+            "adjust_group_percentage": adjust_gp,
+            "group_min_ratio": g_ratio,
+            "combine_min_ratio": c_ratio,
+        }
+
+    # ------------------------------------------------------------------
+    def step(self, loss: torch.Tensor | float) -> None:
+        self.optimizer.zero_grad()
+        if not isinstance(loss, torch.Tensor):
+            loss = torch.tensor(float(loss))
+        for p in self._params:
+            p.grad = torch.full_like(p, loss.item())
+        self.optimizer.step()
+

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -23,6 +23,7 @@ from src.graphs.loaders.common_token_utils import split_name, TOKEN_RE
 import torch
 from torch_geometric.data import HeteroData
 from src.graphs.dataset.graph_dataset import GraphDataset
+from src.cli.categorical_optimizer import CategoricalOptimizer
 
 from rulegen.feature_miner import FeatureMiner
 from rulegen.yara_builder import YaraBuilder
@@ -256,6 +257,8 @@ def adaptive_fp_retry(
     is_better,
     best_result: Dict[str, Any],
     last_detected: Dict[str, Any] | None,
+    optimizer: CategoricalOptimizer | None = None,
+    param_update=None,
 ) -> tuple[Dict[str, Any], set[str], Dict[str, Any]]:
     start_time = time.perf_counter()
     attempts = 0
@@ -266,6 +269,9 @@ def adaptive_fp_retry(
     tokens_sorted = [t for t, _ in sorted(fp_token_counter.items(), key=lambda x: (-x[1], x[0]))]
     if not tokens_sorted:
         tokens_sorted = list(result.get("fp_matched_tokens", []))
+
+    if optimizer is not None and param_update is not None:
+        param_update(optimizer.discrete_params())
 
     def _try(excl: set[str], gmc: int | None, ratio: float) -> Dict[str, Any]:
         return eval_fn(
@@ -290,6 +296,17 @@ def adaptive_fp_retry(
         tok_l = tok.lower()
         attempts += 1
         trial = _try({tok_l}, group_min_count, combine_min_ratio)
+        if optimizer is not None:
+            fp_val = float(trial.get("false_positive", False))
+            tp_val = float(trial.get("detected", False))
+            loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
+            optimizer.step(torch.tensor(loss))
+            params = optimizer.discrete_params()
+            combine_min_ratio = params["combine_min_ratio"]
+            combine_mode = params["combine_mode"]
+            group_min_ratio = params["group_min_ratio"]
+            if param_update:
+                param_update(params)
         if fp_bar:
             fp_bar.update(1)
         if is_better(trial, best_result):
@@ -314,6 +331,17 @@ def adaptive_fp_retry(
         gmc = low_cnt
         while attempts < fp_retries and result.get("false_positive"):
             trial = _try(set(), gmc, combine_min_ratio)
+            if optimizer is not None:
+                fp_val = float(trial.get("false_positive", False))
+                tp_val = float(trial.get("detected", False))
+                loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
+                optimizer.step(torch.tensor(loss))
+                params = optimizer.discrete_params()
+                combine_min_ratio = params["combine_min_ratio"]
+                combine_mode = params["combine_mode"]
+                group_min_ratio = params["group_min_ratio"]
+                if param_update:
+                    param_update(params)
             attempts += 1
             if fp_bar:
                 fp_bar.update(1)
@@ -343,6 +371,17 @@ def adaptive_fp_retry(
             ratio = (low_ratio + high_ratio) / 2.0
         while attempts < fp_retries and result.get("false_positive") and high_ratio - low_ratio > 0.001:
             trial = _try(set(), group_min_count, ratio)
+            if optimizer is not None:
+                fp_val = float(trial.get("false_positive", False))
+                tp_val = float(trial.get("detected", False))
+                loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
+                optimizer.step(torch.tensor(loss))
+                params = optimizer.discrete_params()
+                ratio = params["combine_min_ratio"]
+                combine_mode = params["combine_mode"]
+                group_min_ratio = params["group_min_ratio"]
+                if param_update:
+                    param_update(params)
             attempts += 1
             if fp_bar:
                 fp_bar.update(1)
@@ -556,6 +595,7 @@ def evaluate_single(
     fp_timeout: float | None = None,
     max_exclude_tokens: int = 5,
     fp_bar: tqdm | None = None,
+    optimizer: CategoricalOptimizer | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -670,6 +710,21 @@ def evaluate_single(
             len(clean_token_cache),
             human_bytes(cache_bytes),
         )
+
+    def _apply_params(params: dict[str, object]) -> None:
+        nonlocal condition_type, combine_mode, dynamic_k, auto_relax, adjust_group_percentage, group_min_ratio, combine_min_ratio
+        condition_type = params.get("condition_type", condition_type)
+        combine_mode = params.get("combine_mode", combine_mode)
+        dynamic_k = params.get("dynamic_k", dynamic_k)
+        auto_relax = params.get("auto_relax", auto_relax)
+        adjust_group_percentage = params.get(
+            "adjust_group_percentage", adjust_group_percentage
+        )
+        group_min_ratio = params.get("group_min_ratio", group_min_ratio)
+        combine_min_ratio = params.get("combine_min_ratio", combine_min_ratio)
+
+    if optimizer is not None:
+        _apply_params(optimizer.discrete_params())
 
     def _build_and_eval(
         freq_thresh: float | int,
@@ -1285,6 +1340,16 @@ def evaluate_single(
         exclude=exclude_set,
         auto_gmin=auto_group_min,
     )
+    if optimizer is not None:
+        fp_val = float(result.get("false_positive", False))
+        tp_val = float(result.get("detected", False))
+        loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
+        optimizer.step(torch.tensor(loss))
+        params_init = optimizer.discrete_params()
+        _apply_params(params_init)
+        combine_min_ratio = params_init["combine_min_ratio"]
+        group_min_ratio = params_init["group_min_ratio"]
+        combine_mode = params_init["combine_mode"]
 
     if not result.get("detected"):
         relax_ratio = max(0.0, round(combine_min_ratio - 0.1, 3))
@@ -1475,6 +1540,8 @@ def evaluate_single(
             is_better=_is_better,
             best_result=best_result,
             last_detected=last_detected_result,
+            optimizer=optimizer,
+            param_update=_apply_params,
         )
 
     out_result = best_result
@@ -1568,6 +1635,7 @@ def _eval_task(
     explainer: Any,
     device: torch.device,
     fp_bar: tqdm | None = None,
+    optimizer: CategoricalOptimizer | None = None,
 ) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
     return evaluate_single(
@@ -1582,6 +1650,7 @@ def _eval_task(
         device=device,
         sample_json=jpath,
         fp_bar=fp_bar,
+        optimizer=optimizer,
         **kwargs,
     )
 
@@ -1629,6 +1698,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--cache-saliency",
         action="store_true",
         help="Cache computed saliency next to graph",
+    )
+    p.add_argument(
+        "--optimize",
+        action="store_true",
+        help="Enable online optimization of rule parameters",
+    )
+    p.add_argument(
+        "--optimizer-pkl",
+        type=Path,
+        help="Load optimizer state from this path",
+    )
+    p.add_argument(
+        "--save-optimizer",
+        type=Path,
+        help="Save optimizer state to this path after execution",
     )
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
     p.add_argument(
@@ -1906,6 +1990,16 @@ def main(argv: list[str] | None = None) -> None:
 
     device = torch.device(args.device)
 
+    optimizer: CategoricalOptimizer | None = None
+    if args.optimize:
+        optimizer = CategoricalOptimizer()
+        if args.optimizer_pkl and args.optimizer_pkl.is_file():
+            try:
+                state = torch.load(args.optimizer_pkl, map_location="cpu")
+                optimizer.load_state_dict(state)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Failed to load optimizer state %s: %s", args.optimizer_pkl, exc)
+
     classifier = None
     explainer = None
     need_model = args.saliency is None or (args.graph_dir and args.meta_csv)
@@ -2149,7 +2243,14 @@ def main(argv: list[str] | None = None) -> None:
                     sal = _compute_saliency_with_explainer(graph, classifier, explainer, device)
                     torch.save(sal, sal_path)
                 kw["saliency_path"] = sal_path
-                res = _eval_task((sha, gpath, spath, jpath, kw), classifier, explainer, device, fp_bar=fp_bar)
+                res = _eval_task(
+                    (sha, gpath, spath, jpath, kw),
+                    classifier,
+                    explainer,
+                    device,
+                    fp_bar=fp_bar,
+                    optimizer=optimizer,
+                )
                 sha = task[0]
 
                 res["sha256"] = sha
@@ -2349,6 +2450,7 @@ def main(argv: list[str] | None = None) -> None:
             fp_timeout=args.fp_timeout,
             max_exclude_tokens=args.max_exclude_tokens,
             cache_saliency=args.cache_saliency,
+            optimizer=optimizer,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)
@@ -2384,6 +2486,12 @@ def main(argv: list[str] | None = None) -> None:
             (args.fp_rules_out / f"{args.sample.stem}.yar").write_text(
                 rule_txt, encoding="utf-8"
             )
+
+        if optimizer and args.save_optimizer:
+            try:
+                torch.save(optimizer.state_dict(), args.save_optimizer)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Failed to save optimizer to %s: %s", args.save_optimizer, exc)
 
 
 __all__ = ["main"]

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -1,0 +1,76 @@
+import importlib
+import json
+from pathlib import Path
+
+import torch
+from torch_geometric.data import HeteroData
+
+from src.cli.categorical_optimizer import CategoricalOptimizer
+
+
+def test_build_parser_optimize_args():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args([
+        "--graph",
+        "g.pt",
+        "--sample",
+        "s.bin",
+        "--classifier",
+        "c.pt",
+        "--optimize",
+        "--optimizer-pkl",
+        "opt.pkl",
+        "--save-optimizer",
+        "out.pkl",
+    ])
+    assert args.optimize is True
+    assert args.optimizer_pkl == Path("opt.pkl")
+    assert args.save_optimizer == Path("out.pkl")
+
+
+def test_optimizer_state_roundtrip(tmp_path):
+    opt = CategoricalOptimizer()
+    opt.condition_type_logits.data[1] = 1.0
+    state = opt.state_dict()
+    p = tmp_path / "opt.pkl"
+    torch.save(state, p)
+    new_opt = CategoricalOptimizer()
+    new_opt.load_state_dict(torch.load(p))
+    assert new_opt.discrete_params()["condition_type"] == opt.discrete_params()["condition_type"]
+
+
+def test_cli_optimize_saves_state(tmp_path):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    opt_out = tmp_path / "state.pkl"
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--json-match",
+        "--optimize",
+        "--save-optimizer",
+        str(opt_out),
+    ])
+    assert opt_out.is_file()


### PR DESCRIPTION
## Summary
- add optimization flags to explainer_rule_eval CLI
- implement `CategoricalOptimizer` to train rule parameters
- integrate optimizer with adaptive FP retry loop
- document new flags
- test optimizer load/save and CLI integration

## Testing
- `pytest tests/test_categorical_optimizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c08e0594832eadf69b09103815fd