### PR TITLE
Refactor CategoricalOptimizer to use autograd

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -78,8 +78,7 @@ class CategoricalOptimizer:
     def step(self, loss: torch.Tensor | float) -> None:
         self.optimizer.zero_grad()
         if not isinstance(loss, torch.Tensor):
-            loss = torch.tensor(float(loss))
-        for p in self._params:
-            p.grad = torch.full_like(p, loss.item())
+            loss = torch.tensor(float(loss), device=self.condition_type_logits.device)
+        loss.backward()
         self.optimizer.step()
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -300,7 +300,7 @@ def adaptive_fp_retry(
             fp_val = float(trial.get("false_positive", False))
             tp_val = float(trial.get("detected", False))
             loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-            optimizer.step(torch.tensor(loss))
+            optimizer.step(torch.tensor(loss, requires_grad=True))
             params = optimizer.discrete_params()
             combine_min_ratio = params["combine_min_ratio"]
             combine_mode = params["combine_mode"]
@@ -335,7 +335,7 @@ def adaptive_fp_retry(
                 fp_val = float(trial.get("false_positive", False))
                 tp_val = float(trial.get("detected", False))
                 loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-                optimizer.step(torch.tensor(loss))
+                optimizer.step(torch.tensor(loss, requires_grad=True))
                 params = optimizer.discrete_params()
                 combine_min_ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
@@ -375,7 +375,7 @@ def adaptive_fp_retry(
                 fp_val = float(trial.get("false_positive", False))
                 tp_val = float(trial.get("detected", False))
                 loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-                optimizer.step(torch.tensor(loss))
+                optimizer.step(torch.tensor(loss, requires_grad=True))
                 params = optimizer.discrete_params()
                 ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
@@ -1344,7 +1344,7 @@ def evaluate_single(
         fp_val = float(result.get("false_positive", False))
         tp_val = float(result.get("detected", False))
         loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-        optimizer.step(torch.tensor(loss))
+        optimizer.step(torch.tensor(loss, requires_grad=True))
         params_init = optimizer.discrete_params()
         _apply_params(params_init)
         combine_min_ratio = params_init["combine_min_ratio"]

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -74,3 +74,33 @@ def test_cli_optimize_saves_state(tmp_path):
         str(opt_out),
     ])
     assert opt_out.is_file()
+
+
+def test_step_updates_params():
+    opt = CategoricalOptimizer()
+    init_vals = [p.detach().clone() for p in opt._params]
+
+    cond_prob = torch.nn.functional.gumbel_softmax(
+        opt.condition_type_logits, tau=1.0, hard=False
+    )
+    comb_prob = torch.nn.functional.gumbel_softmax(
+        opt.combine_mode_logits, tau=1.0, hard=False
+    )
+    bool_probs = torch.sigmoid(
+        torch.stack([
+            opt.dynamic_k_logit,
+            opt.auto_relax_logit,
+            opt.adjust_group_percentage_logit,
+            opt.group_min_ratio_logit,
+            opt.combine_min_ratio_logit,
+        ])
+    )
+
+    fp_val = cond_prob[0] * bool_probs.mean()
+    tp_val = comb_prob[1] * bool_probs.mean()
+    loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
+
+    opt.step(loss)
+
+    for p0, p1 in zip(init_vals, opt._params):
+        assert not torch.allclose(p0, p1)


### PR DESCRIPTION
## Summary
- compute gradients for individual logits using autograd
- use requires_grad tensors when calling optimizer in rule evaluation script
- ensure optimizer.step updates parameters in tests

## Testing
- `pytest tests/test_categorical_optimizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cb50c974832eac175508cd7841ed