### PR TITLE
Add num-workers warning for optimize mode

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1974,6 +1974,12 @@ def main(argv: list[str] | None = None) -> None:
     if args.verbose:
         LOGGER.setLevel(logging.DEBUG)
 
+    if args.optimize and args.num_workers > 1:
+        LOGGER.warning(
+            "--num-workers > 1 is not supported with --optimize; using 1"
+        )
+        args.num_workers = 1
+
     combine_mode = args.combine_mode
 
     benign_freqs = None

--- a/tests/test_optimize_num_workers.py
+++ b/tests/test_optimize_num_workers.py
@@ -1,0 +1,89 @@
+import importlib
+import types
+import sys
+
+import pytest
+
+import torch
+
+
+class DummyHeteroData:
+    def __init__(self):
+        self.x = torch.zeros(1, 1)
+        self.num_nodes = 1
+        self.edge_index = torch.tensor([[0], [0]])
+
+
+
+
+def test_optimize_limits_num_workers(tmp_path, caplog):
+    tg = types.ModuleType("torch_geometric")
+    data = types.ModuleType("torch_geometric.data")
+    data.HeteroData = DummyHeteroData
+    tg.data = data
+    sys.modules["torch_geometric"] = tg
+    sys.modules["torch_geometric.data"] = data
+    sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+    dummy_tqdm = types.ModuleType("tqdm")
+    dummy_tqdm_auto = types.ModuleType("tqdm.auto")
+    def _tqdm(iterable=None, **k):
+        return list(iterable) if iterable is not None else []
+    dummy_tqdm.tqdm = _tqdm
+    dummy_tqdm_auto.tqdm = _tqdm
+    sys.modules.setdefault("tqdm", dummy_tqdm)
+    sys.modules.setdefault("tqdm.auto", dummy_tqdm_auto)
+    ct_utils = types.ModuleType("src.graphs.loaders.common_token_utils")
+    ct_utils.split_name = lambda s: [s]
+    ct_utils.TOKEN_RE = None
+    sys.modules.setdefault("src.graphs.loaders.common_token_utils", ct_utils)
+    gd = types.ModuleType("src.graphs.dataset.graph_dataset")
+    class GraphDataset:
+        pass
+    gd.GraphDataset = GraphDataset
+    sys.modules.setdefault("src.graphs.dataset.graph_dataset", gd)
+    fm = types.ModuleType("rulegen.feature_miner")
+    class FeatureMiner:
+        def __init__(self, *a, **k):
+            pass
+    fm.FeatureMiner = FeatureMiner
+    sys.modules.setdefault("rulegen.feature_miner", fm)
+    yb = types.ModuleType("rulegen.yara_builder")
+    class YaraBuilder:
+        def combine_rules(self, texts, mode="or", min_match_ratio=0.0):
+            return "".join(texts)
+    yb.YaraBuilder = YaraBuilder
+    sys.modules.setdefault("rulegen.yara_builder", yb)
+
+    g = DummyHeteroData()
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    def dummy_eval(*args, **kwargs):
+        return {"detected": True}
+
+    mod.evaluate_single = dummy_eval
+    caplog.set_level("WARNING", logger=mod.LOGGER.name)
+    mod.main([
+        "--graph",
+        str(gpath),
+        "--sample",
+        str(sample),
+        "--saliency",
+        str(salpath),
+        "--classifier",
+        str(sample),
+        "--optimize",
+        "--num-workers",
+        "4",
+    ])
+
+    assert any("num-workers" in rec.message for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- warn and force `--num-workers` to 1 when `--optimize` is used
- cover this behaviour with a regression test

## Testing
- `pytest -q tests/test_optimize_num_workers.py`

------
https://chatgpt.com/codex/tasks/task_e_6887cd1b6528832e8936956b132a6133