### PR TITLE
Save batch optimizer state

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -228,6 +228,8 @@ python -m src.cli.explainer_rule_eval \
 조정합니다. `--optimizer-pkl` 로 이전 상태를 불러오거나
 `--save-optimizer` 로 실행 후 상태를 저장할 수 있습니다.
 
+배치 모드에서도 `--save-optimizer` 를 사용하면 종료 시점에 상태가 지정한 경로에 저장됩니다.
+
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로
 낮춰집니다.

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -2388,6 +2388,16 @@ def main(argv: list[str] | None = None) -> None:
         else:
             LOGGER.warning("No samples evaluated")
 
+        if optimizer and args.save_optimizer:
+            try:
+                torch.save(optimizer.state_dict(), args.save_optimizer)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning(
+                    "Failed to save optimizer to %s: %s",
+                    args.save_optimizer,
+                    exc,
+                )
+
     else:
         if args.graph is None or args.sample is None:
             raise SystemExit("--graph and --sample are required for single evaluation")

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -827,6 +827,61 @@ def test_batch_flush_every(tmp_path, monkeypatch):
     assert len(df) == 1
 
 
+def test_batch_optimize_saves_state(tmp_path, monkeypatch):
+    import pandas as pd
+    import torch
+    import src.models.gnn.res_wrapper as res_wrapper
+
+    csv = tmp_path / "meta.csv"
+    pd.DataFrame({"sha256": ["a"], "label": [1], "filename": ["a.bin"]}).to_csv(
+        csv, index=False
+    )
+
+    gdir = tmp_path / "graphs"
+    gdir.mkdir()
+    (gdir / "a.pt").write_text("stub")
+
+    sdir = tmp_path / "samples"
+    sdir.mkdir()
+    (sdir / "a.bin").write_text("mal")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    from tests import helpers
+
+    class DummyClf(torch.nn.Module):
+        def forward(self, x):
+            return torch.zeros(1)
+
+    monkeypatch.setattr(
+        res_wrapper.RESGCLClassifier,
+        "load_pretrained",
+        classmethod(lambda cls, *a, **k: DummyClf()),
+    )
+
+    monkeypatch.setenv("RMG_TEST_EVAL_SINGLE", "tests.helpers:fake_eval")
+
+    opt_out = tmp_path / "state.pkl"
+    mod.main(
+        [
+            "--graph-dir",
+            str(gdir),
+            "--sample-dir",
+            str(sdir),
+            "--meta-csv",
+            str(csv),
+            "--classifier",
+            str(sdir / "a.bin"),
+            "--num-workers",
+            "2",
+            "--optimize",
+            "--save-optimizer",
+            str(opt_out),
+        ]
+    )
+
+    assert opt_out.is_file()
+
+
 def test_evaluate_single_json_match_fp_with_clean_sample(tmp_path, monkeypatch):
     g = HeteroData()
     g["bb"].x = torch.zeros(1, 1)


### PR DESCRIPTION
## Summary
- save optimizer state when running batch evaluation
- document saving optimizer in batch mode
- test batch optimizer save capability

## Testing
- `pytest -k test_batch_optimize_saves_state -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887d0042180832eb16d6a5b9221c448