### PR TITLE
Enable differentiable rule optimization

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -24,6 +24,7 @@ import torch
 from torch_geometric.data import HeteroData
 from src.graphs.dataset.graph_dataset import GraphDataset
 from src.cli.categorical_optimizer import CategoricalOptimizer
+import torch.nn.functional as F
 
 from rulegen.feature_miner import FeatureMiner
 from rulegen.yara_builder import YaraBuilder
@@ -68,6 +69,36 @@ def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
         )
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Failed to write %s: %s", path, exc)
+
+
+# ---------------------------------------------------------------------------
+# Optimization utilities
+# ---------------------------------------------------------------------------
+
+def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torch.Tensor:
+    """Return differentiable loss for optimizer step."""
+    fp = torch.tensor(float(trial.get("false_positive", False)), device=opt.condition_type_logits.device)
+    tp = torch.tensor(float(trial.get("detected", False)), device=opt.condition_type_logits.device)
+
+    cond_prob = F.gumbel_softmax(opt.condition_type_logits, tau=1.0, hard=False)
+    comb_prob = F.gumbel_softmax(opt.combine_mode_logits, tau=1.0, hard=False)
+    bool_probs = torch.sigmoid(
+        torch.stack(
+            [
+                opt.dynamic_k_logit,
+                opt.auto_relax_logit,
+                opt.adjust_group_percentage_logit,
+                opt.group_min_ratio_logit,
+                opt.combine_min_ratio_logit,
+            ]
+        )
+    )
+
+    mix = bool_probs.mean()
+    fp_val = fp * cond_prob[0] * mix
+    tp_val = tp * comb_prob[1] * mix
+    loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
+    return loss
 
 
 # ---------------------------------------------------------------------------
@@ -297,10 +328,8 @@ def adaptive_fp_retry(
         attempts += 1
         trial = _try({tok_l}, group_min_count, combine_min_ratio)
         if optimizer is not None:
-            fp_val = float(trial.get("false_positive", False))
-            tp_val = float(trial.get("detected", False))
-            loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-            optimizer.step(torch.tensor(loss, requires_grad=True))
+            loss = _optimizer_loss(trial, optimizer)
+            optimizer.step(loss)
             params = optimizer.discrete_params()
             combine_min_ratio = params["combine_min_ratio"]
             combine_mode = params["combine_mode"]
@@ -332,10 +361,8 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive"):
             trial = _try(set(), gmc, combine_min_ratio)
             if optimizer is not None:
-                fp_val = float(trial.get("false_positive", False))
-                tp_val = float(trial.get("detected", False))
-                loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-                optimizer.step(torch.tensor(loss, requires_grad=True))
+                loss = _optimizer_loss(trial, optimizer)
+                optimizer.step(loss)
                 params = optimizer.discrete_params()
                 combine_min_ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
@@ -372,10 +399,8 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive") and high_ratio - low_ratio > 0.001:
             trial = _try(set(), group_min_count, ratio)
             if optimizer is not None:
-                fp_val = float(trial.get("false_positive", False))
-                tp_val = float(trial.get("detected", False))
-                loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-                optimizer.step(torch.tensor(loss, requires_grad=True))
+                loss = _optimizer_loss(trial, optimizer)
+                optimizer.step(loss)
                 params = optimizer.discrete_params()
                 ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
@@ -1341,10 +1366,8 @@ def evaluate_single(
         auto_gmin=auto_group_min,
     )
     if optimizer is not None:
-        fp_val = float(result.get("false_positive", False))
-        tp_val = float(result.get("detected", False))
-        loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-        optimizer.step(torch.tensor(loss, requires_grad=True))
+        loss = _optimizer_loss(result, optimizer)
+        optimizer.step(loss)
         params_init = optimizer.discrete_params()
         _apply_params(params_init)
         combine_min_ratio = params_init["combine_min_ratio"]

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -104,3 +104,59 @@ def test_step_updates_params():
 
     for p0, p1 in zip(init_vals, opt._params):
         assert not torch.allclose(p0, p1)
+
+
+def test_evaluate_single_updates_optimizer(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    opt = mod.CategoricalOptimizer()
+    init_vals = [p.detach().clone() for p in opt._params]
+
+    mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        optimizer=opt,
+    )
+
+    assert any(not torch.allclose(p0, p1) for p0, p1 in zip(init_vals, opt._params))


### PR DESCRIPTION
## Summary
- compute optimizer loss via differentiable logits in `evaluate_single`
- expose `_optimizer_loss` helper
- test that optimizer parameters update after calling `evaluate_single`

## Testing
- `pytest tests/test_categorical_optimizer.py::test_evaluate_single_updates_optimizer -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887d4e0f930832ea91bd56b19136011