### PR TITLE
Implement optimizer loss queue

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import torch
 
 
@@ -81,4 +82,36 @@ class CategoricalOptimizer:
             loss = torch.tensor(float(loss), device=self.condition_type_logits.device)
         loss.backward()
         self.optimizer.step()
+
+
+class LossQueue:
+    """Accumulate losses and update optimizer in batches."""
+
+    def __init__(self, optimizer: CategoricalOptimizer, batch_size: int = 1) -> None:
+        self.optimizer = optimizer
+        self.batch_size = max(1, batch_size)
+        self._losses: list[float] = []
+        self._lock = threading.Lock()
+
+    def add(self, loss: float | torch.Tensor) -> bool:
+        """Add ``loss`` and run optimizer step when threshold reached.
+
+        Returns ``True`` if ``optimizer.step`` was executed.
+        """
+        if isinstance(loss, torch.Tensor):
+            loss = float(loss.detach().cpu().item())
+        self._losses.append(loss)
+        if len(self._losses) >= self.batch_size:
+            self.flush()
+            return True
+        return False
+
+    def flush(self) -> None:
+        """Perform optimizer step on the aggregated loss."""
+        if not self._losses:
+            return
+        avg_loss = sum(self._losses) / len(self._losses)
+        with self._lock:
+            self.optimizer.step(torch.tensor(avg_loss, requires_grad=True))
+        self._losses.clear()
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -23,7 +23,7 @@ from src.graphs.loaders.common_token_utils import split_name, TOKEN_RE
 import torch
 from torch_geometric.data import HeteroData
 from src.graphs.dataset.graph_dataset import GraphDataset
-from src.cli.categorical_optimizer import CategoricalOptimizer
+from src.cli.categorical_optimizer import CategoricalOptimizer, LossQueue
 
 from rulegen.feature_miner import FeatureMiner
 from rulegen.yara_builder import YaraBuilder
@@ -259,6 +259,7 @@ def adaptive_fp_retry(
     last_detected: Dict[str, Any] | None,
     optimizer: CategoricalOptimizer | None = None,
     param_update=None,
+    loss_queue: LossQueue | None = None,
 ) -> tuple[Dict[str, Any], set[str], Dict[str, Any]]:
     start_time = time.perf_counter()
     attempts = 0
@@ -300,13 +301,19 @@ def adaptive_fp_retry(
             fp_val = float(trial.get("false_positive", False))
             tp_val = float(trial.get("detected", False))
             loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-            optimizer.step(torch.tensor(loss, requires_grad=True))
-            params = optimizer.discrete_params()
-            combine_min_ratio = params["combine_min_ratio"]
-            combine_mode = params["combine_mode"]
-            group_min_ratio = params["group_min_ratio"]
-            if param_update:
-                param_update(params)
+            stepped = False
+            if loss_queue is not None:
+                stepped = loss_queue.add(loss)
+            else:
+                optimizer.step(torch.tensor(loss, requires_grad=True))
+                stepped = True
+            if stepped:
+                params = optimizer.discrete_params()
+                combine_min_ratio = params["combine_min_ratio"]
+                combine_mode = params["combine_mode"]
+                group_min_ratio = params["group_min_ratio"]
+                if param_update:
+                    param_update(params)
         if fp_bar:
             fp_bar.update(1)
         if is_better(trial, best_result):
@@ -335,13 +342,19 @@ def adaptive_fp_retry(
                 fp_val = float(trial.get("false_positive", False))
                 tp_val = float(trial.get("detected", False))
                 loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-                optimizer.step(torch.tensor(loss, requires_grad=True))
-                params = optimizer.discrete_params()
-                combine_min_ratio = params["combine_min_ratio"]
-                combine_mode = params["combine_mode"]
-                group_min_ratio = params["group_min_ratio"]
-                if param_update:
-                    param_update(params)
+                stepped = False
+                if loss_queue is not None:
+                    stepped = loss_queue.add(loss)
+                else:
+                    optimizer.step(torch.tensor(loss, requires_grad=True))
+                    stepped = True
+                if stepped:
+                    params = optimizer.discrete_params()
+                    combine_min_ratio = params["combine_min_ratio"]
+                    combine_mode = params["combine_mode"]
+                    group_min_ratio = params["group_min_ratio"]
+                    if param_update:
+                        param_update(params)
             attempts += 1
             if fp_bar:
                 fp_bar.update(1)
@@ -375,13 +388,19 @@ def adaptive_fp_retry(
                 fp_val = float(trial.get("false_positive", False))
                 tp_val = float(trial.get("detected", False))
                 loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-                optimizer.step(torch.tensor(loss, requires_grad=True))
-                params = optimizer.discrete_params()
-                ratio = params["combine_min_ratio"]
-                combine_mode = params["combine_mode"]
-                group_min_ratio = params["group_min_ratio"]
-                if param_update:
-                    param_update(params)
+                stepped = False
+                if loss_queue is not None:
+                    stepped = loss_queue.add(loss)
+                else:
+                    optimizer.step(torch.tensor(loss, requires_grad=True))
+                    stepped = True
+                if stepped:
+                    params = optimizer.discrete_params()
+                    ratio = params["combine_min_ratio"]
+                    combine_mode = params["combine_mode"]
+                    group_min_ratio = params["group_min_ratio"]
+                    if param_update:
+                        param_update(params)
             attempts += 1
             if fp_bar:
                 fp_bar.update(1)
@@ -596,6 +615,7 @@ def evaluate_single(
     max_exclude_tokens: int = 5,
     fp_bar: tqdm | None = None,
     optimizer: CategoricalOptimizer | None = None,
+    loss_queue: LossQueue | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -1344,12 +1364,18 @@ def evaluate_single(
         fp_val = float(result.get("false_positive", False))
         tp_val = float(result.get("detected", False))
         loss = fp_val + 0.5 * max(0.0, 1.0 - tp_val)
-        optimizer.step(torch.tensor(loss, requires_grad=True))
-        params_init = optimizer.discrete_params()
-        _apply_params(params_init)
-        combine_min_ratio = params_init["combine_min_ratio"]
-        group_min_ratio = params_init["group_min_ratio"]
-        combine_mode = params_init["combine_mode"]
+        stepped = False
+        if loss_queue is not None:
+            stepped = loss_queue.add(loss)
+        else:
+            optimizer.step(torch.tensor(loss, requires_grad=True))
+            stepped = True
+        if stepped:
+            params_init = optimizer.discrete_params()
+            _apply_params(params_init)
+            combine_min_ratio = params_init["combine_min_ratio"]
+            group_min_ratio = params_init["group_min_ratio"]
+            combine_mode = params_init["combine_mode"]
 
     if not result.get("detected"):
         relax_ratio = max(0.0, round(combine_min_ratio - 0.1, 3))
@@ -1542,6 +1568,7 @@ def evaluate_single(
             last_detected=last_detected_result,
             optimizer=optimizer,
             param_update=_apply_params,
+            loss_queue=loss_queue,
         )
 
     out_result = best_result
@@ -1636,6 +1663,7 @@ def _eval_task(
     device: torch.device,
     fp_bar: tqdm | None = None,
     optimizer: CategoricalOptimizer | None = None,
+    loss_queue: LossQueue | None = None,
 ) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
     return evaluate_single(
@@ -1651,6 +1679,7 @@ def _eval_task(
         sample_json=jpath,
         fp_bar=fp_bar,
         optimizer=optimizer,
+        loss_queue=loss_queue,
         **kwargs,
     )
 
@@ -1713,6 +1742,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--save-optimizer",
         type=Path,
         help="Save optimizer state to this path after execution",
+    )
+    p.add_argument(
+        "--opt-batch-size",
+        type=int,
+        default=1,
+        help="Accumulate this many losses before optimizer step",
     )
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
     p.add_argument(
@@ -2006,6 +2041,10 @@ def main(argv: list[str] | None = None) -> None:
             except Exception as exc:  # noqa: BLE001
                 LOGGER.warning("Failed to load optimizer state %s: %s", args.optimizer_pkl, exc)
 
+    loss_queue: LossQueue | None = None
+    if optimizer is not None:
+        loss_queue = LossQueue(optimizer, batch_size=int(args.opt_batch_size))
+
     classifier = None
     explainer = None
     need_model = args.saliency is None or (args.graph_dir and args.meta_csv)
@@ -2168,17 +2207,22 @@ def main(argv: list[str] | None = None) -> None:
                     fp_bar.reset()
                     sha = future_map[fut]
                     try:
-                        res = fut.result()
-                    except FileNotFoundError as exc:
-                        skipped += 1
-                        LOGGER.debug("Skipping %s: %s", sha, exc)
-                        continue
+                    res = fut.result()
+                except FileNotFoundError as exc:
+                    skipped += 1
+                    LOGGER.debug("Skipping %s: %s", sha, exc)
+                    continue
 
                     res["sha256"] = sha
                     results.append(res)
                     cnts = res.get("fp_token_counts_total")
                     if cnts:
                         fp_token_counter_all.update({k.lower(): int(v) for k, v in cnts.items()})
+
+                    if optimizer is not None and loss_queue is not None:
+                        fp_val = float(res.get("false_positive", False))
+                        tp_val = float(res.get("detected", False))
+                        loss_queue.add(fp_val + 0.5 * max(0.0, 1.0 - tp_val))
 
                     det_rate = sum(r.get("detected", False) for r in results) / len(
                         results
@@ -2256,6 +2300,7 @@ def main(argv: list[str] | None = None) -> None:
                     device,
                     fp_bar=fp_bar,
                     optimizer=optimizer,
+                    loss_queue=loss_queue,
                 )
                 sha = task[0]
 
@@ -2394,6 +2439,9 @@ def main(argv: list[str] | None = None) -> None:
         else:
             LOGGER.warning("No samples evaluated")
 
+        if loss_queue is not None:
+            loss_queue.flush()
+
         if optimizer and args.save_optimizer:
             try:
                 torch.save(optimizer.state_dict(), args.save_optimizer)
@@ -2467,6 +2515,7 @@ def main(argv: list[str] | None = None) -> None:
             max_exclude_tokens=args.max_exclude_tokens,
             cache_saliency=args.cache_saliency,
             optimizer=optimizer,
+            loss_queue=loss_queue,
         )
 
         text = json.dumps(result, ensure_ascii=False, indent=2)
@@ -2502,6 +2551,9 @@ def main(argv: list[str] | None = None) -> None:
             (args.fp_rules_out / f"{args.sample.stem}.yar").write_text(
                 rule_txt, encoding="utf-8"
             )
+
+        if loss_queue is not None:
+            loss_queue.flush()
 
         if optimizer and args.save_optimizer:
             try:


### PR DESCRIPTION
## Summary
- add `LossQueue` helper for batched optimizer updates
- expose `--opt-batch-size` option in rule evaluation CLI
- update `adaptive_fp_retry` and evaluation loops to push losses to `LossQueue`
- flush queued losses before saving optimizer state

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887d5000034832e95b097b7bed4298f