### PR TITLE
Enable optimizer with multiprocessing

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -75,8 +75,8 @@ def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
 # Optimization utilities
 # ---------------------------------------------------------------------------
 
-def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torch.Tensor:
-    """Return differentiable loss for optimizer step."""
+def _optimizer_values(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return FP/TP values used for loss computation."""
     fp = torch.tensor(float(trial.get("false_positive", False)), device=opt.condition_type_logits.device)
     tp = torch.tensor(float(trial.get("detected", False)), device=opt.condition_type_logits.device)
 
@@ -97,8 +97,39 @@ def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torc
     mix = bool_probs.mean()
     fp_val = fp * cond_prob[0] * mix
     tp_val = tp * comb_prob[1] * mix
+    return fp_val, tp_val
+
+
+def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torch.Tensor:
+    """Return differentiable loss for optimizer step."""
+    fp_val, tp_val = _optimizer_values(trial, opt)
     loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
     return loss
+
+
+def _batch_optimizer_loss(fp_vals: list[float], tp_vals: list[float], opt: CategoricalOptimizer) -> torch.Tensor:
+    """Compute loss from accumulated FP/TP values."""
+    if not fp_vals:
+        return torch.tensor(0.0, device=opt.condition_type_logits.device)
+    fp = torch.tensor(fp_vals, device=opt.condition_type_logits.device).mean()
+    tp = torch.tensor(tp_vals, device=opt.condition_type_logits.device).mean()
+    cond_prob = F.gumbel_softmax(opt.condition_type_logits, tau=1.0, hard=False)
+    comb_prob = F.gumbel_softmax(opt.combine_mode_logits, tau=1.0, hard=False)
+    bool_probs = torch.sigmoid(
+        torch.stack(
+            [
+                opt.dynamic_k_logit,
+                opt.auto_relax_logit,
+                opt.adjust_group_percentage_logit,
+                opt.group_min_ratio_logit,
+                opt.combine_min_ratio_logit,
+            ]
+        )
+    )
+    mix = bool_probs.mean()
+    fp_val = fp * cond_prob[0] * mix
+    tp_val = tp * comb_prob[1] * mix
+    return fp_val + 0.5 * torch.relu(1.0 - tp_val)
 
 
 # ---------------------------------------------------------------------------
@@ -1629,7 +1660,7 @@ def _init_saliency_worker(
         _SAL_EXPLAINER = None
 
 
-def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
+def _worker_eval(task: tuple[str, Path, Path, Path, dict], opt_queue=None) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
     eval_fn = evaluate_single
     env = os.environ.get("RMG_TEST_EVAL_SINGLE")
@@ -1637,7 +1668,7 @@ def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
         mod_name, func_name = env.rsplit(":", 1)
         mod = importlib.import_module(mod_name)
         eval_fn = getattr(mod, func_name)
-    return eval_fn(
+    result = eval_fn(
         gpath,
         spath,
         classifier=_WORKER_CLASSIFIER,
@@ -1650,6 +1681,14 @@ def _worker_eval(task: tuple[str, Path, Path, Path, dict]) -> Dict[str, Any]:
         sample_json=jpath,
         **kwargs,
     )
+    if opt_queue is not None:
+        opt_queue.put(
+            (
+                float(result.get("false_positive", False)),
+                float(result.get("detected", False)),
+            )
+        )
+    return result
 
 
 def _eval_task(
@@ -1659,9 +1698,10 @@ def _eval_task(
     device: torch.device,
     fp_bar: tqdm | None = None,
     optimizer: CategoricalOptimizer | None = None,
+    opt_queue=None,
 ) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
-    return evaluate_single(
+    result = evaluate_single(
         gpath,
         spath,
         classifier=classifier,
@@ -1676,6 +1716,14 @@ def _eval_task(
         optimizer=optimizer,
         **kwargs,
     )
+    if opt_queue is not None:
+        opt_queue.put(
+            (
+                float(result.get("false_positive", False)),
+                float(result.get("detected", False)),
+            )
+        )
+    return result
 
 
 def _saliency_task(task: tuple[str, Path, Path]) -> Path:
@@ -1736,6 +1784,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--save-optimizer",
         type=Path,
         help="Save optimizer state to this path after execution",
+    )
+    p.add_argument(
+        "--opt-batch-size",
+        type=int,
+        default=1,
+        help="Accumulate optimizer gradients over this many samples",
     )
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
     p.add_argument(
@@ -1997,11 +2051,6 @@ def main(argv: list[str] | None = None) -> None:
     if args.verbose:
         LOGGER.setLevel(logging.DEBUG)
 
-    if args.optimize and args.num_workers > 1:
-        LOGGER.warning(
-            "--num-workers > 1 is not supported with --optimize; using 1"
-        )
-        args.num_workers = 1
 
     combine_mode = args.combine_mode
 
@@ -2149,6 +2198,28 @@ def main(argv: list[str] | None = None) -> None:
         import multiprocessing as mp
         from concurrent.futures import ProcessPoolExecutor, as_completed
 
+        opt_queue = mp.get_context("forkserver").Queue() if args.optimize else None
+        fp_vals_batch: list[float] = []
+        tp_vals_batch: list[float] = []
+
+        def _drain_queue(flush: bool = False) -> None:
+            if not opt_queue:
+                return
+            while not opt_queue.empty():
+                fpv, tpv = opt_queue.get()
+                fp_vals_batch.append(fpv)
+                tp_vals_batch.append(tpv)
+                if len(fp_vals_batch) >= args.opt_batch_size:
+                    loss = _batch_optimizer_loss(fp_vals_batch, tp_vals_batch, optimizer)
+                    optimizer.step(loss)
+                    fp_vals_batch.clear()
+                    tp_vals_batch.clear()
+            if flush and fp_vals_batch:
+                loss = _batch_optimizer_loss(fp_vals_batch, tp_vals_batch, optimizer)
+                optimizer.step(loss)
+                fp_vals_batch.clear()
+                tp_vals_batch.clear()
+
         sal_dir = args.precomputed_saliency_dir or Path(tempfile.mkdtemp(prefix="saliency_"))
         sal_dir.mkdir(parents=True, exist_ok=True)
 
@@ -2185,10 +2256,11 @@ def main(argv: list[str] | None = None) -> None:
                     sha, gpath, spath, jpath, kw = t
                     kw = kw.copy()
                     kw["saliency_path"] = sal_dir / f"{sha}.pt"
-                    fut = executor.submit(_worker_eval, (sha, gpath, spath, jpath, kw))
+                    fut = executor.submit(_worker_eval, (sha, gpath, spath, jpath, kw), opt_queue)
                     future_map[fut] = sha
                 for fut in as_completed(future_map):
                     fp_bar.reset()
+                    _drain_queue()
                     sha = future_map[fut]
                     try:
                         res = fut.result()
@@ -2264,6 +2336,7 @@ def main(argv: list[str] | None = None) -> None:
         else:
             for task in tasks:
                 fp_bar.reset()
+                _drain_queue()
                 sha, gpath, spath, jpath, kw = task
                 kw = kw.copy()
                 sal_path = sal_dir / f"{sha}.pt"
@@ -2279,7 +2352,9 @@ def main(argv: list[str] | None = None) -> None:
                     device,
                     fp_bar=fp_bar,
                     optimizer=optimizer,
+                    opt_queue=opt_queue,
                 )
+                _drain_queue()
                 sha = task[0]
 
                 res["sha256"] = sha
@@ -2338,6 +2413,7 @@ def main(argv: list[str] | None = None) -> None:
                             rule_txt, encoding="utf-8"
                         )
 
+        _drain_queue(flush=True)
         graph_bar.close()
         fp_bar.close()
         df = pd.DataFrame(results)

--- a/tests/test_optimize_num_workers.py
+++ b/tests/test_optimize_num_workers.py
@@ -85,5 +85,5 @@ def test_optimize_limits_num_workers(tmp_path, caplog):
         "4",
     ])
 
-    assert any("num-workers" in rec.message for rec in caplog.records)
+    assert not any("num-workers" in rec.message for rec in caplog.records)
 


### PR DESCRIPTION
## Summary
- support multi-worker optimization with gradient accumulation
- add `--opt-batch-size` argument
- queue FP/TP results from workers and update optimizer in batches
- adjust tests accordingly

## Testing
- `python -m py_compile src/cli/explainer_rule_eval.py tests/test_optimize_num_workers.py`
- `pytest -q tests/test_optimize_num_workers.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887d7ae77c4832e9890d7d69a0b104e