### PR TITLE
Optimize categorical logits

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -82,6 +82,17 @@ def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torc
 
     cond_prob = F.gumbel_softmax(opt.condition_type_logits, tau=1.0, hard=False)
     comb_prob = F.gumbel_softmax(opt.combine_mode_logits, tau=1.0, hard=False)
+
+    cond_indicator = torch.tensor(
+        [trial.get("condition_type", "any") == c for c in opt.CONDITION_TYPES],
+        dtype=torch.float32,
+        device=opt.condition_type_logits.device,
+    )
+    comb_indicator = torch.tensor(
+        [trial.get("combine_mode", "or") == c for c in opt.COMBINE_MODES],
+        dtype=torch.float32,
+        device=opt.condition_type_logits.device,
+    )
     bool_probs = torch.sigmoid(
         torch.stack(
             [
@@ -95,8 +106,8 @@ def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torc
     )
 
     mix = bool_probs.mean()
-    fp_val = fp * cond_prob[0] * mix
-    tp_val = tp * comb_prob[1] * mix
+    fp_val = fp * torch.sum(cond_prob * cond_indicator) * mix
+    tp_val = tp * torch.sum(comb_prob * comb_indicator) * mix
     loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
     return loss
 

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -96,14 +96,20 @@ def test_step_updates_params():
         ])
     )
 
-    fp_val = cond_prob[0] * bool_probs.mean()
-    tp_val = comb_prob[1] * bool_probs.mean()
+    cond_indicator = torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])
+    comb_indicator = torch.tensor([0.0, 1.0])
+
+    fp_val = torch.sum(cond_prob * cond_indicator) * bool_probs.mean()
+    tp_val = torch.sum(comb_prob * comb_indicator) * bool_probs.mean()
     loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
 
     opt.step(loss)
 
     for p0, p1 in zip(init_vals, opt._params):
         assert not torch.allclose(p0, p1)
+
+    for p in opt._params:
+        assert p.grad is not None and torch.any(p.grad != 0)
 
 
 def test_evaluate_single_updates_optimizer(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- make optimizer loss differentiable for all categories
- verify gradients update every logit

## Testing
- `pytest tests/test_categorical_optimizer.py::test_evaluate_single_updates_optimizer -vv`
- `pytest tests/test_categorical_optimizer.py::test_step_updates_params -vv`

------
https://chatgpt.com/codex/tasks/task_e_6887dd9e5c9c832ea30b88571e9ff807