### PR TITLE
Include SHA in multiprocessing results

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1702,6 +1702,9 @@ def _eval_task(
         **kwargs,
     )
 
+    # include SHA in result so that downstream consumers can verify it
+    res["sha256"] = sha
+
     if result_queue is not None:
         result_queue.put((sha, res))
 
@@ -2240,8 +2243,17 @@ def main(argv: list[str] | None = None) -> None:
                         continue
 
                     sha_res, res = result_q.get()
+                    sha_expected = sha
+                    if sha_res != sha_expected or res.get("sha256") != sha_expected:
+                        LOGGER.warning(
+                            "SHA mismatch: expected %s, got %s (res %s)",
+                            sha_expected,
+                            sha_res,
+                            res.get("sha256"),
+                        )
+                    assert sha_res == sha_expected
+                    assert res.get("sha256") == sha_expected
                     sha = sha_res
-                    res["sha256"] = sha
                     results.append(res)
                     if optimizer:
                         batch.append(res)


### PR DESCRIPTION
## Summary
- ensure `_eval_task` attaches the SHA to the result before sending it through the queue
- verify that results received from worker processes match the expected SHA and warn otherwise

## Testing
- `pytest tests/test_optimize_num_workers.py -k optimize_multiworker_updates_params -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6887e30c107c832e8cff2d6b3851c70f