### PR TITLE
Update optimizer defaults

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -10,13 +10,24 @@ class CategoricalOptimizer:
     COMBINE_MODES = ["or", "and"]
 
     def __init__(self, lr: float = 0.1) -> None:
-        self.condition_type_logits = torch.nn.Parameter(torch.zeros(len(self.CONDITION_TYPES)))
+        """Initialize parameters with logits matching default CLI values."""
+
+        # condition_type defaults to "combo"
+        cond_init = torch.zeros(len(self.CONDITION_TYPES))
+        cond_init[self.CONDITION_TYPES.index("combo")] = 1.0
+        self.condition_type_logits = torch.nn.Parameter(cond_init)
+
+        # combine_mode defaults to "or" -> zeros so argmax selects first element
         self.combine_mode_logits = torch.nn.Parameter(torch.zeros(len(self.COMBINE_MODES)))
+
+        # boolean options default to False except auto_relax which defaults True
         self.dynamic_k_logit = torch.nn.Parameter(torch.tensor(0.0))
-        self.auto_relax_logit = torch.nn.Parameter(torch.tensor(0.0))
+        self.auto_relax_logit = torch.nn.Parameter(torch.tensor(10.0))
         self.adjust_group_percentage_logit = torch.nn.Parameter(torch.tensor(0.0))
-        self.group_min_ratio_logit = torch.nn.Parameter(torch.tensor(0.0))
-        self.combine_min_ratio_logit = torch.nn.Parameter(torch.tensor(0.0))
+
+        # ratio defaults
+        self.group_min_ratio_logit = torch.nn.Parameter(torch.logit(torch.tensor(1e-3)))
+        self.combine_min_ratio_logit = torch.nn.Parameter(torch.logit(torch.tensor(0.7)))
 
         self._params = [
             self.condition_type_logits,

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -2,6 +2,7 @@ import importlib
 import json
 from pathlib import Path
 
+import pytest
 import torch
 from torch_geometric.data import HeteroData
 
@@ -27,6 +28,19 @@ def test_build_parser_optimize_args():
     assert args.optimize is True
     assert args.optimizer_pkl == Path("opt.pkl")
     assert args.save_optimizer == Path("out.pkl")
+
+
+def test_default_discrete_params():
+    """Optimizer defaults should mirror CLI defaults."""
+    opt = CategoricalOptimizer()
+    params = opt.discrete_params()
+    assert params["condition_type"] == "combo"
+    assert params["combine_mode"] == "or"
+    assert params["dynamic_k"] is False
+    assert params["auto_relax"] is True
+    assert params["adjust_group_percentage"] is False
+    assert params["group_min_ratio"] == pytest.approx(1e-3, rel=0, abs=1e-6)
+    assert params["combine_min_ratio"] == pytest.approx(0.7, rel=0, abs=1e-6)
 
 
 def test_optimizer_state_roundtrip(tmp_path):


### PR DESCRIPTION
## Summary
- initialize logits in `CategoricalOptimizer` so defaults mirror CLI
- test the optimizer's default discrete parameters

## Testing
- `pytest -k default_discrete_params -q tests/test_categorical_optimizer.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887e35c2c64832e96d929c08e559115