### PR TITLE
Add benign FP ratio calculation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -748,6 +748,16 @@ def evaluate_single(
             human_bytes(cache_bytes),
         )
 
+    total_benign = 0
+    if clean_paths is not None:
+        total_benign = len(list(clean_paths))
+    elif clean_dir is not None and clean_dir.is_dir():
+        total_benign = len([p for p in clean_dir.iterdir() if p.is_file()])
+    elif clean_sample is not None:
+        total_benign = 1
+    else:
+        total_benign = len(clean_token_cache)
+
     def _apply_params(params: dict[str, object]) -> None:
         nonlocal condition_type, combine_mode, dynamic_k, auto_relax, adjust_group_percentage, group_min_ratio, combine_min_ratio
         condition_type = params.get("condition_type", condition_type)
@@ -774,7 +784,8 @@ def evaluate_single(
         mode: str = combine_mode,
         exclude: Sequence[str] | None = None,
         auto_gmin: bool = auto_group_min,
-        ) -> Dict[str, Any]:
+        total_benign: int = 0,
+    ) -> Dict[str, Any]:
         miner = FeatureMiner(
             top_k=top_k,
             top_k_percent=top_k_percent,
@@ -923,6 +934,7 @@ def evaluate_single(
             str,
             list[str] | None,
             list[str] | None,
+            int,
             int,
         ]:
             dyn_cnt = compute_dynamic_group_min_count(
@@ -1106,6 +1118,7 @@ def evaluate_single(
                     fp = False
                 fp_tokens = sorted(fp_tokens_set) if fp_tokens_set else None
                 fp_max = max(fp_match_counts) if fp_match_counts else 0
+                fp_count = len(fp_match_counts)
             else:
                 fp_tokens_set: set[str] = set()
                 fp_match_counts: list[int] = []
@@ -1205,6 +1218,7 @@ def evaluate_single(
 
                 fp_tokens = sorted(fp_tokens_set) if fp_tokens_set else None
                 fp_max = max(fp_match_counts) if fp_match_counts else 0
+                fp_count = len(fp_match_counts)
 
             return (
                 detected,
@@ -1214,13 +1228,15 @@ def evaluate_single(
                 fp_tokens,
                 matched_tokens,
                 fp_max,
+                fp_count,
             )
 
         fp_tokens_all: list[list[str] | None] = []
         matched_tokens_all: list[list[str] | None] = []
         fp_match_max_vals: list[int] = []
+        fp_counts: list[int] = []
         for grp in groups:
-            det, cov, fp, rt, fp_tok, match_tok, fp_mx = _eval_group(grp)
+            det, cov, fp, rt, fp_tok, match_tok, fp_mx, fp_cnt = _eval_group(grp)
             detections.append(det)
             coverages.append(cov)
             false_positives.append(fp)
@@ -1228,6 +1244,7 @@ def evaluate_single(
             fp_tokens_all.append(fp_tok)
             matched_tokens_all.append(match_tok)
             fp_match_max_vals.append(fp_mx)
+            fp_counts.append(fp_cnt)
 
         if isinstance(saliency, dict):
             flat = torch.cat(list(saliency.values()))
@@ -1273,6 +1290,12 @@ def evaluate_single(
                 matched_tokens_all_flat.extend(toks)
 
         fp_max_total = max(fp_match_max_vals) if fp_match_max_vals else 0
+        fp_matched_total = sum(fp_counts) if fp_counts else 0
+        fp_ratio_benign = (
+            float(fp_matched_total) / float(total_benign)
+            if total_benign > 0
+            else 0.0
+        )
 
         result: Dict[str, Any] = {
             "detected": combined_det,
@@ -1285,6 +1308,9 @@ def evaluate_single(
             "group_min_count": group_cnt,
             "freq_threshold": freq_thresh,
         }
+        result["fp_count"] = fp_matched_total
+        result["total_benign"] = total_benign
+        result["fp_ratio_benign"] = fp_ratio_benign
         result["rule_texts"] = rule_texts
         result["false_positives"] = false_positives
         if matched_tokens_all_flat:
@@ -1327,6 +1353,12 @@ def evaluate_single(
         if fp_max_total:
             LOGGER.debug("fp_max_matches: %d", fp_max_total)
             result["fp_max_matches"] = fp_max_total
+        LOGGER.debug(
+            "fp_matched_total=%d total_benign=%d fp_ratio_benign=%.4f",
+            fp_matched_total,
+            total_benign,
+            fp_ratio_benign,
+        )
 
         return result
 
@@ -1341,6 +1373,7 @@ def evaluate_single(
         mode: str = combine_mode,
         exclude: Sequence[str] | None = None,
         auto_gmin: bool = auto_group_min,
+        total_benign: int = total_benign,
     ) -> Dict[str, Any]:
         res = _build_and_eval(
             f_thresh,
@@ -1352,6 +1385,7 @@ def evaluate_single(
             mode=mode,
             exclude=exclude,
             auto_gmin=auto_gmin,
+            total_benign=total_benign,
         )
         cnts = res.get("fp_token_counts")
         if cnts:
@@ -2261,9 +2295,12 @@ def main(argv: list[str] | None = None) -> None:
                     fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(
                         results
                     )
+                    fp_ratio_b = sum(r.get("fp_ratio_benign", 0.0) for r in results) / len(
+                        results
+                    )
                     graph_bar.update(1)
                     graph_bar.set_postfix(
-                        avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}"
+                        avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}", fpb=f"{fp_ratio_b:.3f}"
                     )
 
                     if args.out_csv and args.flush_every:
@@ -2274,6 +2311,7 @@ def main(argv: list[str] | None = None) -> None:
                                 "matched_tokens",
                                 "fp_matched_tokens",
                                 "fp_token_counts",
+                                "fp_ratio_benign",
                                 "group_min_count",
                                 "freq_threshold",
                             ):
@@ -2352,8 +2390,11 @@ def main(argv: list[str] | None = None) -> None:
 
                 det_rate = sum(r.get("detected", False) for r in results) / len(results)
                 fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
+                fp_ratio_b = sum(r.get("fp_ratio_benign", 0.0) for r in results) / len(results)
                 graph_bar.update(1)
-                graph_bar.set_postfix(avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}")
+                graph_bar.set_postfix(
+                    avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}", fpb=f"{fp_ratio_b:.3f}"
+                )
 
                 if args.out_csv and args.flush_every:
                     flush_buffer.append(res)
@@ -2362,6 +2403,7 @@ def main(argv: list[str] | None = None) -> None:
                         for col in (
                             "matched_tokens",
                             "fp_matched_tokens",
+                            "fp_ratio_benign",
                             "group_min_count",
                             "freq_threshold",
                         ):
@@ -2434,6 +2476,7 @@ def main(argv: list[str] | None = None) -> None:
                     "matched_tokens",
                     "fp_matched_tokens",
                     "fp_token_counts",
+                    "fp_ratio_benign",
                     "group_min_count",
                     "freq_threshold",
                 ):
@@ -2451,7 +2494,13 @@ def main(argv: list[str] | None = None) -> None:
         if results:
             det_rate = sum(r.get("detected", False) for r in results) / len(results)
             fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
-            LOGGER.info("average detection=%.3f, FP ratio=%.3f", det_rate, fp_ratio)
+            fp_ratio_b = sum(r.get("fp_ratio_benign", 0.0) for r in results) / len(results)
+            LOGGER.info(
+                "average detection=%.3f, FP ratio=%.3f, FP ratio(b)=%.3f",
+                det_rate,
+                fp_ratio,
+                fp_ratio_b,
+            )
             if fp_token_counter_all:
                 top_tokens = sorted(fp_token_counter_all.items(), key=lambda x: (-x[1], x[0]))[:10]
                 LOGGER.info("Top FP tokens: %s", top_tokens)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2378,3 +2378,85 @@ def test_evaluate_single_saliency_cache(tmp_path, monkeypatch):
 
     assert calls["n"] == 0
 
+
+def test_fp_ratio_benign_computation(tmp_path, monkeypatch):
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "mal.bin"
+    sample.write_bytes(b"mal")
+    b1 = tmp_path / "b1.bin"
+    b1.write_bytes(b"ben1")
+    b2 = tmp_path / "b2.bin"
+    b2.write_bytes(b"ben2")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self, ident="$s0"):
+            self.strings = [(0, ident, b"x")]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            p = str(path)
+            if p == str(sample):
+                return [FakeMatch()]
+            if p == str(b1):
+                return [FakeMatch()]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=1,
+        chunk_size=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=[b1, b2],
+        sample_json=None,
+        json_match=False,
+        combine_mode="or",
+    )
+
+    assert abs(res.get("fp_ratio_benign", 0.0) - 0.5) < 1e-6
+


### PR DESCRIPTION
## Summary
- compute total benign samples in `evaluate_single`
- track per-group FP counts
- aggregate FP ratio over benign data
- show avg benign FP ratio in batch progress and logs
- include FP ratio in CSV output
- test benign FP ratio calculation

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_ratio_benign_computation -q`

------
https://chatgpt.com/codex/tasks/task_e_6887eeedafb0832ead2eeeacc8218e9f