### PR TITLE
Add fp_ratio_benign to optimizer loss

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -76,8 +76,16 @@ def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
 # Optimization utilities
 # ---------------------------------------------------------------------------
 
-def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torch.Tensor:
-    """Return differentiable loss for optimizer step."""
+def _optimizer_loss(
+    trial: Mapping[str, Any],
+    opt: CategoricalOptimizer,
+    fp_ratio_benign: float = 0.0,
+) -> torch.Tensor:
+    """Return differentiable loss for optimizer step.
+
+    ``fp_ratio_benign`` scales the penalty for false positives so that a higher
+    false-positive rate over the benign set yields a larger loss.
+    """
     fp = torch.tensor(float(trial.get("false_positive", False)), device=opt.condition_type_logits.device)
     tp = torch.tensor(float(trial.get("detected", False)), device=opt.condition_type_logits.device)
 
@@ -107,7 +115,8 @@ def _optimizer_loss(trial: Mapping[str, Any], opt: CategoricalOptimizer) -> torc
     )
 
     mix = bool_probs.mean()
-    fp_val = fp * torch.sum(cond_prob * cond_indicator) * mix
+    fp_weight = 1.0 + float(fp_ratio_benign)
+    fp_val = fp * torch.sum(cond_prob * cond_indicator) * mix * fp_weight
     tp_val = tp * torch.sum(comb_prob * comb_indicator) * mix
     loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
     return loss
@@ -340,7 +349,7 @@ def adaptive_fp_retry(
         attempts += 1
         trial = _try({tok_l}, group_min_count, combine_min_ratio)
         if optimizer is not None:
-            loss = _optimizer_loss(trial, optimizer)
+            loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
             optimizer.step(loss)
             params = optimizer.discrete_params()
             combine_min_ratio = params["combine_min_ratio"]
@@ -373,7 +382,7 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive"):
             trial = _try(set(), gmc, combine_min_ratio)
             if optimizer is not None:
-                loss = _optimizer_loss(trial, optimizer)
+                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
                 optimizer.step(loss)
                 params = optimizer.discrete_params()
                 combine_min_ratio = params["combine_min_ratio"]
@@ -411,7 +420,7 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive") and high_ratio - low_ratio > 0.001:
             trial = _try(set(), group_min_count, ratio)
             if optimizer is not None:
-                loss = _optimizer_loss(trial, optimizer)
+                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
                 optimizer.step(loss)
                 params = optimizer.discrete_params()
                 ratio = params["combine_min_ratio"]
@@ -1412,7 +1421,7 @@ def evaluate_single(
         auto_gmin=auto_group_min,
     )
     if optimizer is not None:
-        loss = _optimizer_loss(result, optimizer)
+        loss = _optimizer_loss(result, optimizer, result.get("fp_ratio_benign", 0.0))
         optimizer.step(loss)
         params_init = optimizer.discrete_params()
         _apply_params(params_init)
@@ -2281,7 +2290,8 @@ def main(argv: list[str] | None = None) -> None:
                         batch.append(res)
                         if len(batch) >= args.batch_size:
                             loss = torch.stack([
-                                _optimizer_loss(r, optimizer) for r in batch
+                                _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
+                                for r in batch
                             ]).mean()
                             optimizer.step(loss)
                             batch.clear()
@@ -2358,7 +2368,8 @@ def main(argv: list[str] | None = None) -> None:
                         batch.append(res_left)
                 if optimizer and batch:
                     loss = torch.stack([
-                        _optimizer_loss(r, optimizer) for r in batch
+                        _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
+                        for r in batch
                     ]).mean()
                     optimizer.step(loss)
         else:

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -113,7 +113,11 @@ def test_step_updates_params():
     cond_indicator = torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])
     comb_indicator = torch.tensor([0.0, 1.0])
 
-    fp_val = torch.sum(cond_prob * cond_indicator) * bool_probs.mean()
+    fp_ratio_benign = 0.5
+    fp_weight = 1.0 + fp_ratio_benign
+    fp_val = (
+        torch.sum(cond_prob * cond_indicator) * bool_probs.mean() * fp_weight
+    )
     tp_val = torch.sum(comb_prob * comb_indicator) * bool_probs.mean()
     loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
 
@@ -180,3 +184,22 @@ def test_evaluate_single_updates_optimizer(tmp_path, monkeypatch):
     )
 
     assert any(not torch.allclose(p0, p1) for p0, p1 in zip(init_vals, opt._params))
+
+
+def test_optimizer_loss_fp_ratio_weight():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    opt = mod.CategoricalOptimizer()
+    trial = {
+        "false_positive": True,
+        "detected": True,
+        "condition_type": "any",
+        "combine_mode": "or",
+    }
+
+    torch.manual_seed(0)
+    low = mod._optimizer_loss(trial, opt, fp_ratio_benign=0.0)
+    torch.manual_seed(0)
+    high = mod._optimizer_loss(trial, opt, fp_ratio_benign=1.0)
+
+    assert high > low
+


### PR DESCRIPTION
## Summary
- tune optimizer loss with fp_ratio_benign weight
- update evaluate_single to propagate fp_ratio_benign
- extend categorical optimizer tests for new weighting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887f38eb054832e8fc789ae5e4eec39