### PR TITLE
Update FP token index handling

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1031,7 +1031,7 @@ def evaluate_single(
 
             if json_match:
 
-                def _check_json(p: Path | None) -> list[str] | None:
+                def _check_json(p: Path | None) -> tuple[list[str], int] | None:
                     if token_index:
                         cand: Set[Path] | None = None
                         matched: list[str] = []
@@ -1044,7 +1044,7 @@ def evaluate_single(
                                 cand = paths if cand is None else cand & paths
                                 if not cand:
                                     return None
-                        return matched if cand else None
+                        return (matched, len(cand)) if cand else None
                     if p is None:
                         return None
                     toks_set = clean_token_cache.get(p)
@@ -1060,15 +1060,17 @@ def evaluate_single(
                         saliency_stats=saliency_stats,
                         return_matched=True,
                     )
-                    return mt if ok else None
+                    return (mt, 1) if ok else None
 
                 fp_tokens_set: set[str] = set()
                 fp_match_counts: list[int] = []
                 if token_index:
-                    toks = _check_json(None)
-                    fp = toks is not None
-                    if fp:
+                    res = _check_json(None)
+                    fp = res is not None
+                    if res is not None:
+                        toks, count = res
                         fp_tokens_set.update(toks)
+                        fp_match_counts.extend([_max_group_count(toks)] * count)
                 elif clean_dir is not None and clean_dir.is_dir():
                     files = [p for p in clean_dir.iterdir() if p.is_file()]
                     if fp_scan_workers > 1 and len(files) > 1:
@@ -1079,24 +1081,27 @@ def evaluate_single(
                         ) as executor:
                             futs = [executor.submit(_check_json, p) for p in files]
                             for fut in as_completed(futs):
-                                toks = fut.result()
-                                if toks is not None:
+                                res = fut.result()
+                                if res is not None:
                                     fp = True
+                                    toks, count = res
                                     fp_tokens_set.update(toks)
-                                    fp_match_counts.append(_max_group_count(toks))
+                                    fp_match_counts.extend([_max_group_count(toks)] * count)
                     else:
                         for p in files:
-                            toks = _check_json(p)
-                            if toks is not None:
+                            res = _check_json(p)
+                            if res is not None:
                                 fp = True
+                                toks, count = res
                                 fp_tokens_set.update(toks)
-                                fp_match_counts.append(_max_group_count(toks))
+                                fp_match_counts.extend([_max_group_count(toks)] * count)
                 elif clean_sample is not None:
-                    toks = _check_json(clean_sample)
-                    fp = toks is not None
-                    if fp:
+                    res = _check_json(clean_sample)
+                    fp = res is not None
+                    if res is not None:
+                        toks, count = res
                         fp_tokens_set.update(toks)
-                        fp_match_counts.append(_max_group_count(toks))
+                        fp_match_counts.extend([_max_group_count(toks)] * count)
                 elif clean_paths is not None:
                     paths = list(clean_paths)
                     if fp_scan_workers > 1 and len(paths) > 1:
@@ -1107,18 +1112,20 @@ def evaluate_single(
                         ) as executor:
                             futs = [executor.submit(_check_json, p) for p in paths]
                             for fut in as_completed(futs):
-                                toks = fut.result()
-                                if toks is not None:
+                                res = fut.result()
+                                if res is not None:
                                     fp = True
+                                    toks, count = res
                                     fp_tokens_set.update(toks)
-                                    fp_match_counts.append(_max_group_count(toks))
+                                    fp_match_counts.extend([_max_group_count(toks)] * count)
                     else:
                         for p in paths:
-                            toks = _check_json(p)
-                            if toks is not None:
+                            res = _check_json(p)
+                            if res is not None:
                                 fp = True
+                                toks, count = res
                                 fp_tokens_set.update(toks)
-                                fp_match_counts.append(_max_group_count(toks))
+                                fp_match_counts.extend([_max_group_count(toks)] * count)
                 elif (
                     clean_dir is not None
                     or clean_sample is not None

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2,6 +2,7 @@ import importlib
 import json
 from pathlib import Path
 import sys
+from collections import defaultdict
 
 import pytest
 
@@ -2458,5 +2459,84 @@ def test_fp_ratio_benign_computation(tmp_path, monkeypatch):
         combine_mode="or",
     )
 
+    assert abs(res.get("fp_ratio_benign", 0.0) - 0.5) < 1e-6
+
+
+def test_fp_ratio_benign_token_index(tmp_path, monkeypatch):
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "mal.bin"
+    sample.write_bytes(b"mal")
+    sample_json = tmp_path / "mal.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    b1 = tmp_path / "b1.bin"
+    b1.write_bytes(b"ben1")
+    b1_json = tmp_path / "b1.json"
+    b1_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    b2 = tmp_path / "b2.bin"
+    b2.write_bytes(b"ben2")
+    b2_json = tmp_path / "b2.json"
+    b2_json.write_text(json.dumps({"c_code": ["bar"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    cache = {
+        b1: mod.extract_json_tokens(json.loads(b1_json.read_text())),
+        b2: mod.extract_json_tokens(json.loads(b2_json.read_text())),
+    }
+    index: dict[str, set[Path]] = defaultdict(set)
+    for p, toks in cache.items():
+        for t in toks:
+            index[t].add(p)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=1,
+        chunk_size=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        clean_token_cache=cache,
+        token_index=index,
+    )
+
+    assert res["false_positive"] is True
     assert abs(res.get("fp_ratio_benign", 0.0) - 0.5) < 1e-6
 


### PR DESCRIPTION
## Summary
- refine `_check_json` in rule eval and update FP accounting
- extend CLI tests with coverage for token index FP ratio

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_ratio_benign_token_index -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*

------
https://chatgpt.com/codex/tasks/task_e_6887fa264c04832e8b0182c22fe7ba4a