### PR TITLE
Improve adaptive FP retry logic

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -374,6 +374,59 @@ def adaptive_fp_retry(
 
 
 
+    if result.get("false_positive") and comb_ratio_step > 0 and attempts < fp_retries:
+        ratio = combine_min_ratio
+        while (
+            attempts < fp_retries
+            and result.get("false_positive")
+            and ratio + comb_ratio_step <= combine_max_ratio + 1e-9
+        ):
+            ratio = min(combine_max_ratio, ratio + comb_ratio_step)
+            trial = _try(set(), group_min_count, ratio)
+            if optimizer is not None:
+                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
+                optimizer.step(loss)
+                params = optimizer.discrete_params()
+                ratio = params["combine_min_ratio"]
+                combine_mode = params["combine_mode"]
+                group_min_ratio = params["group_min_ratio"]
+                if param_update:
+                    param_update(params)
+            attempts += 1
+            if fp_bar:
+                fp_bar.update(1)
+            if is_better(trial, best_result):
+                best_result = trial
+                if best_result.get("detected"):
+                    last_detected = best_result
+            if trial.get("detected") and not trial.get("false_positive"):
+                combine_min_ratio = ratio
+                result = trial
+                break
+
+    if result.get("false_positive") and combine_mode != "and" and attempts < fp_retries:
+        trial = eval_fn(
+            freq_threshold,
+            group_min_count,
+            combine_min_ratio,
+            group_ratio=group_min_ratio,
+            n_rules=num_rules,
+            c_size=chunk_size,
+            mode="and",
+            exclude=exclude_set,
+            auto_gmin=auto_group_min,
+        )
+        attempts += 1
+        if fp_bar:
+            fp_bar.update(1)
+        if is_better(trial, best_result):
+            best_result = trial
+            if best_result.get("detected"):
+                last_detected = best_result
+        if trial.get("detected") and not trial.get("false_positive"):
+            combine_mode = "and"
+            result = trial
+
     if result.get("false_positive"):
         max_match = int(result.get("fp_max_matches", 0))
         low_cnt = max(group_min_count or 0, max_match + 1)


### PR DESCRIPTION
## Summary
- enhance `adaptive_fp_retry` to try raising `combine_min_ratio` in steps before switching to AND mode

## Testing
- `python -m py_compile src/cli/explainer_rule_eval.py`
- `pytest -q` *(fails: missing heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888089d6ab4832ea3e959b19e63b1f8