### PR TITLE
Add fp_ratio_benign tie‑breaker

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1575,8 +1575,9 @@ def evaluate_single(
         Priority order:
         1. Detection (prefer detected rules)
         2. False positives (prefer fewer)
-        3. Coverage (prefer higher)
-        4. Rule length (prefer shorter)
+        3. False-positive ratio in benign samples (prefer lower)
+        4. Coverage (prefer higher)
+        5. Rule length (prefer shorter)
         """
 
         new_det = bool(new.get("detected"))
@@ -1588,6 +1589,12 @@ def evaluate_single(
         cur_fp = bool(current.get("false_positive"))
         if new_fp != cur_fp:
             return not new_fp
+
+        if new_fp and cur_fp:
+            new_ratio = float(new.get("fp_ratio_benign", 0.0))
+            cur_ratio = float(current.get("fp_ratio_benign", 0.0))
+            if not math.isclose(new_ratio, cur_ratio):
+                return new_ratio < cur_ratio
 
         new_cov = float(new.get("coverage", 0.0))
         cur_cov = float(current.get("coverage", 0.0))

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2540,3 +2540,110 @@ def test_fp_ratio_benign_token_index(tmp_path, monkeypatch):
     assert res["false_positive"] is True
     assert abs(res.get("fp_ratio_benign", 0.0) - 0.5) < 1e-6
 
+
+def test_is_better_prefers_lower_fp_ratio(tmp_path, monkeypatch):
+    """_is_better should favor lower fp_ratio_benign when both are FP."""
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "mal.bin"
+    sample.write_bytes(b"mal")
+    b1 = tmp_path / "b1.bin"
+    b1.write_bytes(b"ben1")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    class FakeMatch:
+        def __init__(self, ident="$s0"):
+            self.strings = [(0, ident, b"x")]
+
+    class FakeCompiled:
+        def __init__(self, text):
+            self.text = text
+
+        def match(self, path):
+            p = str(path)
+            if p == str(sample) or p == str(b1):
+                return [FakeMatch()]
+            return []
+
+    class FakeYara:
+        @staticmethod
+        def compile(source):
+            return FakeCompiled(source)
+
+    monkeypatch.setitem(sys.modules, "yara", FakeYara)
+
+    captured: dict[str, object] = {}
+
+    def fake_retry(*args, **kwargs):
+        captured["fn"] = kwargs.get("is_better")
+        return kwargs["result"], kwargs["exclude_set"], kwargs["best_result"]
+
+    monkeypatch.setattr(mod, "adaptive_fp_retry", fake_retry)
+
+    mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        num_rules=1,
+        chunk_size=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=[b1],
+        sample_json=None,
+        json_match=False,
+        combine_mode="or",
+        fp_retries=1,
+    )
+
+    is_better = captured.get("fn")
+    assert is_better is not None
+
+    low = {
+        "detected": True,
+        "false_positive": True,
+        "coverage": 0.0,
+        "rule_length": 1,
+        "fp_ratio_benign": 0.1,
+    }
+    high = {
+        "detected": True,
+        "false_positive": True,
+        "coverage": 0.0,
+        "rule_length": 1,
+        "fp_ratio_benign": 0.5,
+    }
+
+    assert is_better(low, high) is True
+    assert is_better(high, low) is False
+


### PR DESCRIPTION
## Summary
- prefer the result with a lower `fp_ratio_benign` when both rules are false positives
- test the new comparison logic in `_is_better`

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_is_better_prefers_lower_fp_ratio -q`

------
https://chatgpt.com/codex/tasks/task_e_688808e978a4832e840fa7998518020d