### PR TITLE
Add beta-weighted optimizer loss

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import torch
+from typing import Mapping, Any
 
 
 class CategoricalOptimizer:
@@ -9,7 +10,7 @@ class CategoricalOptimizer:
     CONDITION_TYPES = ["any", "all", "percentage", "count", "combo"]
     COMBINE_MODES = ["or", "and"]
 
-    def __init__(self, lr: float = 0.1) -> None:
+    def __init__(self, lr: float = 0.1, beta: float = 0.5) -> None:
         """Initialize parameters with logits matching default CLI values."""
 
         # condition_type defaults to "combo"
@@ -38,6 +39,7 @@ class CategoricalOptimizer:
             self.group_min_ratio_logit,
             self.combine_min_ratio_logit,
         ]
+        self.beta = beta
         self.optimizer = torch.optim.AdamW(self._params, lr=lr)
 
     # ------------------------------------------------------------------
@@ -45,6 +47,7 @@ class CategoricalOptimizer:
         return {
             "logits": {k: p.detach().cpu() for k, p in self._logit_map().items()},
             "optimizer": self.optimizer.state_dict(),
+            "beta": float(self.beta),
         }
 
     def load_state_dict(self, state: dict) -> None:
@@ -54,6 +57,8 @@ class CategoricalOptimizer:
                 param.data.copy_(torch.tensor(logits[name]))
         if "optimizer" in state:
             self.optimizer.load_state_dict(state["optimizer"])
+        if "beta" in state:
+            self.beta = float(state["beta"])
 
     def _logit_map(self) -> dict[str, torch.nn.Parameter]:
         return {
@@ -86,10 +91,20 @@ class CategoricalOptimizer:
         }
 
     # ------------------------------------------------------------------
-    def step(self, loss: torch.Tensor | float) -> None:
+    def step(
+        self,
+        trial_or_loss: torch.Tensor | float | Mapping[str, Any],
+        fp_ratio_benign: float = 0.0,
+    ) -> None:
+        from .explainer_rule_eval import _optimizer_loss
+
+        if isinstance(trial_or_loss, Mapping):
+            loss = _optimizer_loss(trial_or_loss, self, fp_ratio_benign, beta=self.beta)
+        else:
+            loss = trial_or_loss
+            if not isinstance(loss, torch.Tensor):
+                loss = torch.tensor(float(loss), device=self.condition_type_logits.device)
         self.optimizer.zero_grad()
-        if not isinstance(loss, torch.Tensor):
-            loss = torch.tensor(float(loss), device=self.condition_type_logits.device)
         loss.backward()
         self.optimizer.step()
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -80,6 +80,7 @@ def _optimizer_loss(
     trial: Mapping[str, Any],
     opt: CategoricalOptimizer,
     fp_ratio_benign: float = 0.0,
+    beta: float | None = None,
 ) -> torch.Tensor:
     """Return differentiable loss for optimizer step.
 
@@ -116,9 +117,11 @@ def _optimizer_loss(
 
     mix = bool_probs.mean()
     fp_weight = 1.0 + float(fp_ratio_benign)
-    fp_val = fp * torch.sum(cond_prob * cond_indicator) * mix * fp_weight
+    if beta is None:
+        beta = getattr(opt, "beta", 0.5)
+    fp_val = fp * torch.sum(cond_prob * cond_indicator) * mix
     tp_val = tp * torch.sum(comb_prob * comb_indicator) * mix
-    loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
+    loss = fp_weight * fp_val + float(beta) * (1.0 - tp_val)
     return loss
 
 
@@ -349,8 +352,7 @@ def adaptive_fp_retry(
         attempts += 1
         trial = _try({tok_l}, group_min_count, combine_min_ratio)
         if optimizer is not None:
-            loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-            optimizer.step(loss)
+            optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
             params = optimizer.discrete_params()
             combine_min_ratio = params["combine_min_ratio"]
             combine_mode = params["combine_mode"]
@@ -382,8 +384,7 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive"):
             trial = _try(set(), gmc, combine_min_ratio)
             if optimizer is not None:
-                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-                optimizer.step(loss)
+                optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
                 params = optimizer.discrete_params()
                 combine_min_ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
@@ -420,8 +421,7 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive") and high_ratio - low_ratio > 0.001:
             trial = _try(set(), group_min_count, ratio)
             if optimizer is not None:
-                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-                optimizer.step(loss)
+                optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
                 params = optimizer.discrete_params()
                 ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
@@ -1428,8 +1428,7 @@ def evaluate_single(
         auto_gmin=auto_group_min,
     )
     if optimizer is not None:
-        loss = _optimizer_loss(result, optimizer, result.get("fp_ratio_benign", 0.0))
-        optimizer.step(loss)
+        optimizer.step(result, fp_ratio_benign=result.get("fp_ratio_benign", 0.0))
         params_init = optimizer.discrete_params()
         _apply_params(params_init)
         combine_min_ratio = params_init["combine_min_ratio"]
@@ -1817,6 +1816,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Save optimizer state to this path after execution",
     )
+    p.add_argument(
+        "--opt-beta",
+        type=float,
+        default=0.5,
+        help="Weight for detection rate term in optimizer loss",
+    )
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
     p.add_argument(
         "--classifier", type=Path, required=True, help="Classifier checkpoint"
@@ -2102,7 +2107,7 @@ def main(argv: list[str] | None = None) -> None:
 
     optimizer: CategoricalOptimizer | None = None
     if args.optimize:
-        optimizer = CategoricalOptimizer()
+        optimizer = CategoricalOptimizer(beta=args.opt_beta)
         if args.optimizer_pkl and args.optimizer_pkl.is_file():
             try:
                 state = torch.load(args.optimizer_pkl, map_location="cpu")

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -24,10 +24,13 @@ def test_build_parser_optimize_args():
         "opt.pkl",
         "--save-optimizer",
         "out.pkl",
+        "--opt-beta",
+        "0.7",
     ])
     assert args.optimize is True
     assert args.optimizer_pkl == Path("opt.pkl")
     assert args.save_optimizer == Path("out.pkl")
+    assert args.opt_beta == 0.7
 
 
 def test_default_discrete_params():
@@ -44,7 +47,7 @@ def test_default_discrete_params():
 
 
 def test_optimizer_state_roundtrip(tmp_path):
-    opt = CategoricalOptimizer()
+    opt = CategoricalOptimizer(beta=0.8)
     opt.condition_type_logits.data[1] = 1.0
     state = opt.state_dict()
     p = tmp_path / "opt.pkl"
@@ -52,6 +55,7 @@ def test_optimizer_state_roundtrip(tmp_path):
     new_opt = CategoricalOptimizer()
     new_opt.load_state_dict(torch.load(p))
     assert new_opt.discrete_params()["condition_type"] == opt.discrete_params()["condition_type"]
+    assert new_opt.beta == pytest.approx(0.8)
 
 
 def test_cli_optimize_saves_state(tmp_path):
@@ -115,11 +119,9 @@ def test_step_updates_params():
 
     fp_ratio_benign = 0.5
     fp_weight = 1.0 + fp_ratio_benign
-    fp_val = (
-        torch.sum(cond_prob * cond_indicator) * bool_probs.mean() * fp_weight
-    )
+    fp_val = torch.sum(cond_prob * cond_indicator) * bool_probs.mean()
     tp_val = torch.sum(comb_prob * comb_indicator) * bool_probs.mean()
-    loss = fp_val + 0.5 * torch.relu(1.0 - tp_val)
+    loss = fp_weight * fp_val + opt.beta * (1.0 - tp_val)
 
     opt.step(loss)
 


### PR DESCRIPTION
## Summary
- add beta weighting to `_optimizer_loss`
- support beta hyperparameter in `CategoricalOptimizer`
- include beta in optimizer state
- expose `--opt-beta` CLI option
- adjust optimizer step to compute loss from trials
- update optimizer tests

## Testing
- `pytest -q tests/test_categorical_optimizer.py`
- `pytest -q` *(fails: 20 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68880937037c832eb93e2b935c7ec072