### PR TITLE
Improve FP retry using minimal hitting set

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -322,6 +322,30 @@ def adaptive_fp_retry(
     if not tokens_sorted:
         tokens_sorted = list(result.get("fp_matched_tokens", []))
 
+    token_sets = result.get("fp_tokens_by_sample")
+    min_tokens: list[str] = []
+    if token_sets:
+        def _hitting_set(sets: Sequence[Sequence[str]]) -> list[str]:
+            remaining = [set(s) for s in sets if s]
+            selected: list[str] = []
+            while remaining:
+                counter = Counter()
+                for s in remaining:
+                    for t in s:
+                        counter[t] += 1
+                tok, _ = max(counter.items(), key=lambda x: (x[1], x[0]))
+                selected.append(tok)
+                new_remaining = []
+                for s in remaining:
+                    if tok not in s:
+                        new_remaining.append(s)
+                remaining = new_remaining
+            return selected
+
+        min_tokens = _hitting_set(token_sets)
+        if min_tokens:
+            tokens_sorted = [t for t in min_tokens + [t for t in tokens_sorted if t not in min_tokens]]
+
     if optimizer is not None and param_update is not None:
         param_update(optimizer.discrete_params())
 
@@ -338,6 +362,38 @@ def adaptive_fp_retry(
             auto_gmin=auto_group_min,
         )
 
+    tried_tokens: set[str] = set()
+    if min_tokens:
+        if attempts < fp_retries:
+            attempts += 1
+            excl_set = {t.lower() for t in min_tokens}
+            tried_tokens.update(excl_set)
+            trial = _try(excl_set, group_min_count, combine_min_ratio)
+            if optimizer is not None:
+                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
+                optimizer.step(loss)
+                params = optimizer.discrete_params()
+                combine_min_ratio = params["combine_min_ratio"]
+                combine_mode = params["combine_mode"]
+                group_min_ratio = params["group_min_ratio"]
+                if param_update:
+                    param_update(params)
+            if fp_bar:
+                fp_bar.update(1)
+            if is_better(trial, best_result):
+                best_result = trial
+                if best_result.get("detected"):
+                    last_detected = best_result
+            if trial.get("detected") and not trial.get("false_positive"):
+                exclude_set.update(excl_set)
+                result = trial
+                if persist_fp_exclude is not None:
+                    for tok in excl_set:
+                        _FP_EXCLUDE_COUNTS[tok] += 1
+                        _FP_EXCLUDE_SET.add(tok)
+                    _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
+                return result, exclude_set, best_result
+
     for i, tok in enumerate(tokens_sorted):
         if (
             attempts >= fp_retries
@@ -345,6 +401,8 @@ def adaptive_fp_retry(
             or i >= max_exclude_tokens
         ):
             break
+        if tok.lower() in tried_tokens:
+            continue
         tok_l = tok.lower()
         attempts += 1
         trial = _try({tok_l}, group_min_count, combine_min_ratio)
@@ -945,6 +1003,7 @@ def evaluate_single(
             list[str] | None,
             int,
             int,
+            list[list[str]] | None,
         ]:
             dyn_cnt = compute_dynamic_group_min_count(
                 feats,
@@ -968,6 +1027,7 @@ def evaluate_single(
 
             fp_tokens: list[str] | None = None
             matched_tokens: list[str] | None = None
+            fp_tokens_samples: list[list[str]] = []
 
             if json_match:
                 jpath = (
@@ -1064,13 +1124,18 @@ def evaluate_single(
 
                 fp_tokens_set: set[str] = set()
                 fp_match_counts: list[int] = []
+                fp_tokens_samples: list[list[str]] = []
+                fp_tokens_samples: list[list[str]] = []
                 if token_index:
                     res = _check_json(None)
                     fp = res is not None
                     if res is not None:
                         toks, count = res
-                        fp_tokens_set.update(toks)
-                        fp_match_counts.extend([_max_group_count(toks)] * count)
+                        toks_sorted = sorted(set(toks))
+                        fp_tokens_set.update(toks_sorted)
+                        fp_match_counts.extend([_max_group_count(toks_sorted)] * count)
+                        for _ in range(count):
+                            fp_tokens_samples.append(toks_sorted)
                 elif clean_dir is not None and clean_dir.is_dir():
                     files = [p for p in clean_dir.iterdir() if p.is_file()]
                     if fp_scan_workers > 1 and len(files) > 1:
@@ -1085,23 +1150,35 @@ def evaluate_single(
                                 if res is not None:
                                     fp = True
                                     toks, count = res
-                                    fp_tokens_set.update(toks)
-                                    fp_match_counts.extend([_max_group_count(toks)] * count)
+                                    toks_sorted = sorted(set(toks))
+                                    fp_tokens_set.update(toks_sorted)
+                                    fp_match_counts.extend([
+                                        _max_group_count(toks_sorted)
+                                    ] * count)
+                                    fp_tokens_samples.extend([toks_sorted] * count)
                     else:
                         for p in files:
                             res = _check_json(p)
                             if res is not None:
                                 fp = True
                                 toks, count = res
-                                fp_tokens_set.update(toks)
-                                fp_match_counts.extend([_max_group_count(toks)] * count)
+                                toks_sorted = sorted(set(toks))
+                                fp_tokens_set.update(toks_sorted)
+                                fp_match_counts.extend([
+                                    _max_group_count(toks_sorted)
+                                ] * count)
+                                fp_tokens_samples.extend([toks_sorted] * count)
                 elif clean_sample is not None:
                     res = _check_json(clean_sample)
                     fp = res is not None
                     if res is not None:
                         toks, count = res
-                        fp_tokens_set.update(toks)
-                        fp_match_counts.extend([_max_group_count(toks)] * count)
+                        toks_sorted = sorted(set(toks))
+                        fp_tokens_set.update(toks_sorted)
+                        fp_match_counts.extend([
+                            _max_group_count(toks_sorted)
+                        ] * count)
+                        fp_tokens_samples.extend([toks_sorted] * count)
                 elif clean_paths is not None:
                     paths = list(clean_paths)
                     if fp_scan_workers > 1 and len(paths) > 1:
@@ -1116,16 +1193,24 @@ def evaluate_single(
                                 if res is not None:
                                     fp = True
                                     toks, count = res
-                                    fp_tokens_set.update(toks)
-                                    fp_match_counts.extend([_max_group_count(toks)] * count)
+                                    toks_sorted = sorted(set(toks))
+                                    fp_tokens_set.update(toks_sorted)
+                                    fp_match_counts.extend([
+                                        _max_group_count(toks_sorted)
+                                    ] * count)
+                                    fp_tokens_samples.extend([toks_sorted] * count)
                     else:
                         for p in paths:
                             res = _check_json(p)
                             if res is not None:
                                 fp = True
                                 toks, count = res
-                                fp_tokens_set.update(toks)
-                                fp_match_counts.extend([_max_group_count(toks)] * count)
+                                toks_sorted = sorted(set(toks))
+                                fp_tokens_set.update(toks_sorted)
+                                fp_match_counts.extend([
+                                    _max_group_count(toks_sorted)
+                                ] * count)
+                                fp_tokens_samples.extend([toks_sorted] * count)
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
@@ -1135,6 +1220,7 @@ def evaluate_single(
                 fp_tokens = sorted(fp_tokens_set) if fp_tokens_set else None
                 fp_max = max(fp_match_counts) if fp_match_counts else 0
                 fp_count = len(fp_match_counts)
+                fp_tokens_by_sample = fp_tokens_samples if fp_tokens_samples else None
             else:
                 fp_tokens_set: set[str] = set()
                 fp_match_counts: list[int] = []
@@ -1167,28 +1253,35 @@ def evaluate_single(
                                 toks = fut.result()
                                 if toks:
                                     fp = True
-                                    fp_tokens_set.update(toks)
-                                    fp_match_counts.append(_max_group_count(toks))
+                                    toks_sorted = sorted(set(toks))
+                                    fp_tokens_set.update(toks_sorted)
+                                    fp_match_counts.append(_max_group_count(toks_sorted))
+                                    fp_tokens_samples.append(toks_sorted)
                     else:
                         for fp_path in files:
                             toks = _scan_file(fp_path)
                             if toks:
                                 fp = True
-                                fp_tokens_set.update(toks)
-                                fp_match_counts.append(_max_group_count(toks))
+                                toks_sorted = sorted(set(toks))
+                                fp_tokens_set.update(toks_sorted)
+                                fp_match_counts.append(_max_group_count(toks_sorted))
+                                fp_tokens_samples.append(toks_sorted)
                 elif clean_sample is not None and compiled is not None:
                     try:
                         matches = compiled.match(str(clean_sample))
                         fp = bool(matches)
                         if fp:
-                            fp_tokens_set.update(
-                                id_map.get(s[1], s[1]) for s in matches[0].strings
+                            toks = [id_map.get(s[1], s[1]) for s in matches[0].strings]
+                            toks_sorted = sorted(set(toks))
+                            fp_tokens_set.update(toks_sorted)
+                            fp_match_counts.append(_max_group_count(toks_sorted))
+                            fp_tokens_samples.append(toks_sorted)
+                        else:
+                            fp_match_counts.append(
+                                _max_group_count([
+                                    id_map.get(s[1], s[1]) for s in matches[0].strings
+                                ])
                             )
-                        fp_match_counts.append(
-                            _max_group_count(
-                                [id_map.get(s[1], s[1]) for s in matches[0].strings]
-                            )
-                        )
                     except Exception:
                         fp = False
                 elif clean_paths is not None and compiled is not None:
@@ -1216,15 +1309,19 @@ def evaluate_single(
                                 toks = fut.result()
                                 if toks:
                                     fp = True
-                                    fp_tokens_set.update(toks)
-                                    fp_match_counts.append(_max_group_count(toks))
+                                    toks_sorted = sorted(set(toks))
+                                    fp_tokens_set.update(toks_sorted)
+                                    fp_match_counts.append(_max_group_count(toks_sorted))
+                                    fp_tokens_samples.append(toks_sorted)
                     else:
                         for p in paths:
                             toks = _scan_path(p)
                             if toks:
                                 fp = True
-                                fp_tokens_set.update(toks)
-                                fp_match_counts.append(_max_group_count(toks))
+                                toks_sorted = sorted(set(toks))
+                                fp_tokens_set.update(toks_sorted)
+                                fp_match_counts.append(_max_group_count(toks_sorted))
+                                fp_tokens_samples.append(toks_sorted)
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
@@ -1235,6 +1332,7 @@ def evaluate_single(
                 fp_tokens = sorted(fp_tokens_set) if fp_tokens_set else None
                 fp_max = max(fp_match_counts) if fp_match_counts else 0
                 fp_count = len(fp_match_counts)
+                fp_tokens_by_sample = fp_tokens_samples if fp_tokens_samples else None
 
             return (
                 detected,
@@ -1245,14 +1343,16 @@ def evaluate_single(
                 matched_tokens,
                 fp_max,
                 fp_count,
+                fp_tokens_by_sample,
             )
 
         fp_tokens_all: list[list[str] | None] = []
         matched_tokens_all: list[list[str] | None] = []
         fp_match_max_vals: list[int] = []
         fp_counts: list[int] = []
+        fp_tokens_samples_all: list[list[str]] = []
         for grp in groups:
-            det, cov, fp, rt, fp_tok, match_tok, fp_mx, fp_cnt = _eval_group(grp)
+            det, cov, fp, rt, fp_tok, match_tok, fp_mx, fp_cnt, fp_sample = _eval_group(grp)
             detections.append(det)
             coverages.append(cov)
             false_positives.append(fp)
@@ -1261,6 +1361,8 @@ def evaluate_single(
             matched_tokens_all.append(match_tok)
             fp_match_max_vals.append(fp_mx)
             fp_counts.append(fp_cnt)
+            if fp_sample:
+                fp_tokens_samples_all.extend(fp_sample)
 
         if isinstance(saliency, dict):
             flat = torch.cat(list(saliency.values()))
@@ -1329,6 +1431,8 @@ def evaluate_single(
         result["fp_ratio_benign"] = fp_ratio_benign
         result["rule_texts"] = rule_texts
         result["false_positives"] = false_positives
+        if fp_tokens_samples_all:
+            result["fp_tokens_by_sample"] = fp_tokens_samples_all
         if matched_tokens_all_flat:
             result["matched_tokens"] = matched_tokens_all_flat
         if matched_tokens_fp:

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1751,6 +1751,53 @@ def test_adaptive_fp_retry_token_order(tmp_path, monkeypatch):
     assert res["detected"] is True
 
 
+def test_fp_retry_hitting_set(tmp_path, monkeypatch):
+    from collections import Counter
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    calls: list[set[str]] = []
+
+    def fake_eval(*args, **kwargs):
+        calls.append(set(kwargs.get("exclude", [])))
+        return {"detected": True, "false_positive": True}
+
+    result = {
+        "false_positive": True,
+        "fp_tokens_by_sample": [["aa", "ab"], ["ba", "bb"]],
+        "fp_token_counts": {"aa": 1, "ab": 1, "ba": 1, "bb": 1},
+    }
+
+    mod.adaptive_fp_retry(
+        fake_eval,
+        result=result,
+        exclude_set=set(),
+        fp_token_counter=Counter(),
+        group_min_count=None,
+        combine_min_ratio=0.7,
+        freq_threshold=10,
+        group_min_ratio=0.0,
+        num_rules=1,
+        chunk_size=None,
+        combine_mode="or",
+        auto_group_min=True,
+        freq_threshold_step=0.0,
+        comb_ratio_step=0.1,
+        chunk_size_step=1,
+        combine_max_ratio=1.0,
+        fp_retries=1,
+        fp_timeout=None,
+        max_exclude_tokens=5,
+        persist_fp_exclude=None,
+        fp_bar=None,
+        is_better=lambda n, c: True,
+        best_result={"detected": True, "false_positive": True},
+        last_detected=None,
+    )
+
+    assert calls and calls[0] == {"ab", "bb"}
+
+
 def test_fp_retry_token_exclusion_rollback(tmp_path, monkeypatch):
     pytest.importorskip("torch")
     pytest.importorskip("torch_geometric")


### PR DESCRIPTION
## Summary
- collect FP tokens per benign sample when evaluating rules
- compute greedy hitting set covering all benign samples
- try excluding minimal hitting set first during FP retry loop
- prioritize hitting set tokens before others
- test adaptive FP retry hitting set selection

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_retry_hitting_set -q`

------
https://chatgpt.com/codex/tasks/task_e_688809984318832eb70c30d9a2f9c1ba