### PR TITLE
Optimize token index usage

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -807,13 +807,15 @@ def evaluate_single(
 
     if clean_token_cache is None:
         clean_token_cache = {}
-    if token_index is None:
-        token_index = defaultdict(set)
+    if isinstance(token_index, (str, os.PathLike)):
+        token_index = _load_token_index(token_index)
+    elif token_index is None:
+        token_index = _WORKER_TOKEN_INDEX or defaultdict(set)
     if clean_token_cache and not token_index:
         for p, toks in clean_token_cache.items():
             for t in toks:
                 token_index[t].add(p)
-    if not clean_token_cache:
+    if not clean_token_cache and not token_index:
         if clean_dir is not None and clean_dir.is_dir():
             files = [p for p in clean_dir.iterdir() if p.is_file()]
             for p in tqdm_wrap(files, desc="load clean json", unit="file"):
@@ -1145,7 +1147,7 @@ def evaluate_single(
             if json_match:
 
                 def _check_json(p: Path | None) -> tuple[list[str], int] | None:
-                    if token_index:
+                    if token_index and p is None:
                         cand: Set[Path] | None = None
                         matched: list[str] = []
                         for feat in feats:
@@ -1157,7 +1159,33 @@ def evaluate_single(
                                 cand = paths if cand is None else cand & paths
                                 if not cand:
                                     return None
-                        return (matched, len(cand)) if cand else None
+                        if not cand:
+                            return None
+                        count = 0
+                        for cp in cand:
+                            toks_set = clean_token_cache.get(cp)
+                            if toks_set is None:
+                                j = cp.with_suffix(".json")
+                                if not j.is_file():
+                                    continue
+                                try:
+                                    obj = json.loads(j.read_text(encoding="utf-8"))
+                                    toks_set = extract_json_tokens(obj)
+                                    clean_token_cache[cp] = toks_set
+                                except Exception:  # noqa: BLE001
+                                    continue
+                            ok = verify_features(
+                                toks_set,
+                                feats,
+                                condition_type=condition_type,
+                                group_percentage=group_pct,
+                                group_min_count=group_cnt,
+                                adjust_group_percentage=adjust_group_percentage,
+                                saliency_stats=saliency_stats,
+                            )
+                            if ok:
+                                count += 1
+                        return (matched, count) if count > 0 else None
                     if p is None:
                         return None
                     toks_set = clean_token_cache.get(p)
@@ -1811,17 +1839,27 @@ def evaluate_single(
 _WORKER_CLASSIFIER = None
 _WORKER_EXPLAINER = None
 _WORKER_DEVICE: torch.device | None = None
+_WORKER_TOKEN_INDEX: dict[str, set[Path]] | None = None
 
 _SAL_CLASSIFIER = None
 _SAL_EXPLAINER = None
 _SAL_DEVICE: torch.device | None = None
 
 
+def _load_token_index(path: str | Path) -> dict[str, set[Path]]:
+    """Load token index from JSON file."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return {k: {Path(p) for p in v} for k, v in data.items()}
+
+
 def _init_worker(
-    classifier_ckpt: str | None, explainer_ckpt: str | None, device: str
+    classifier_ckpt: str | None,
+    explainer_ckpt: str | None,
+    device: str,
+    token_index_file: str | None = None,
 ) -> None:
     """Load models in subprocess."""
-    global _WORKER_CLASSIFIER, _WORKER_EXPLAINER, _WORKER_DEVICE
+    global _WORKER_CLASSIFIER, _WORKER_EXPLAINER, _WORKER_DEVICE, _WORKER_TOKEN_INDEX
     _WORKER_DEVICE = torch.device(device)
     if classifier_ckpt:
         from src.models.gnn.res_wrapper import RESGCLClassifier
@@ -1833,6 +1871,8 @@ def _init_worker(
         _WORKER_EXPLAINER = torch.load(
             explainer_ckpt, map_location=_WORKER_DEVICE, weights_only=False
         )
+    if token_index_file and Path(token_index_file).is_file():
+        _WORKER_TOKEN_INDEX = _load_token_index(token_index_file)
 
 
 def _init_saliency_worker(
@@ -2330,6 +2370,13 @@ def main(argv: list[str] | None = None) -> None:
             len(clean_token_cache),
             human_bytes(cache_bytes),
         )
+        token_index_file: Path | None = None
+        if args.num_workers > 1 and token_index:
+            tmpdir = Path(tempfile.mkdtemp(prefix="token_index_"))
+            token_index_file = tmpdir / "index.json"
+            token_index_file.write_text(
+                json.dumps({k: [str(p) for p in v] for k, v in token_index.items()})
+            )
         results: list[dict[str, Any]] = []
         fp_token_counter_all: Counter[str] = Counter()
         flush_buffer: list[dict[str, Any]] = []
@@ -2387,7 +2434,7 @@ def main(argv: list[str] | None = None) -> None:
                 "enforce_self_detect": args.enforce_self_detect,
                 "fp_scan_workers": args.fp_scan_workers,
                 "clean_token_cache": clean_token_cache,
-                "token_index": token_index,
+                "token_index": token_index if args.num_workers <= 1 else None,
                 "fp_timeout": args.fp_timeout,
                 "max_exclude_tokens": args.max_exclude_tokens,
                 "cache_saliency": args.cache_saliency,
@@ -2430,7 +2477,7 @@ def main(argv: list[str] | None = None) -> None:
                 max_workers=args.num_workers,
                 mp_context=ctx,
                 initializer=_init_worker,
-                initargs=(None, None, args.device),
+                initargs=(None, None, args.device, str(token_index_file) if token_index_file else None),
             ) as executor:
                 future_map = {}
                 for t in tasks:

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2694,3 +2694,113 @@ def test_is_better_prefers_lower_fp_ratio(tmp_path, monkeypatch):
     assert is_better(low, high) is True
     assert is_better(high, low) is False
 
+
+def test_adaptive_fp_retry_token_index_profile(tmp_path, monkeypatch):
+    """Using token_index should reduce JSON reads during FP checks."""
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+    from collections import defaultdict
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "s.bin"
+    sample.write_bytes(b"mal")
+    sample_json = tmp_path / "s.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    clean_paths = []
+    tokens_map = {}
+    index = defaultdict(set)
+    for i, tok in enumerate(["bar", "baz", "foo"]):
+        c = tmp_path / f"c{i}.bin"
+        c.write_bytes(b"ben")
+        clean_paths.append(c)
+        cj = tmp_path / f"c{i}.json"
+        cj.write_text(json.dumps({"c_code": [tok]}))
+        tokens_map[c] = tok
+        index[tok].add(c)
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    index = defaultdict(set)
+    for p, tok in tokens_map.items():
+        index[tok].add(p)
+
+    read_count = 0
+    orig_read = Path.read_text
+
+    def fake_read(self, *a, **k):
+        nonlocal read_count
+        if self.suffix == ".json" and self.name.startswith("c"):
+            read_count += 1
+        return orig_read(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", fake_read)
+
+    mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_paths=clean_paths,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        fp_retries=1,
+    )
+    no_index = read_count
+
+    read_count = 0
+    mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_paths=clean_paths,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        token_index=index,
+        fp_retries=1,
+    )
+    with_index = read_count
+
+    assert with_index < no_index
+


### PR DESCRIPTION
## Summary
- load clean JSON lazily when token index is available
- share token index across workers via temp file
- validate fewer FP checks using token index

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_fp_ratio_benign_token_index tests/test_explainer_rule_eval_cli.py::test_adaptive_fp_retry_token_index_profile -q`

------
https://chatgpt.com/codex/tasks/task_e_68887da649c4832e8e3f1c78aa70e4a3