### PR TITLE
Add cache sharing for rule evaluation

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import importlib
+import pickle
 from pathlib import Path
 from typing import Any, Dict, Sequence, Mapping, Set
 from collections import Counter, defaultdict
@@ -806,7 +807,7 @@ def evaluate_single(
                     LOGGER.warning("Failed to save saliency cache %s: %s", cache_path, exc)
 
     if clean_token_cache is None:
-        clean_token_cache = {}
+        clean_token_cache = _WORKER_CLEAN_CACHE or {}
     if isinstance(token_index, (str, os.PathLike)):
         token_index = _load_token_index(token_index)
     elif token_index is None:
@@ -1840,6 +1841,7 @@ _WORKER_CLASSIFIER = None
 _WORKER_EXPLAINER = None
 _WORKER_DEVICE: torch.device | None = None
 _WORKER_TOKEN_INDEX: dict[str, set[Path]] | None = None
+_WORKER_CLEAN_CACHE: dict[Path, set[str]] | None = None
 
 _SAL_CLASSIFIER = None
 _SAL_EXPLAINER = None
@@ -1852,14 +1854,64 @@ def _load_token_index(path: str | Path) -> dict[str, set[Path]]:
     return {k: {Path(p) for p in v} for k, v in data.items()}
 
 
+_CACHE_VERSION = 1
+
+
+def _cache_version_info(paths: Sequence[Path]) -> dict[str, float]:
+    return {
+        str(p.with_suffix(".json")): os.path.getmtime(p.with_suffix(".json"))
+        if p.with_suffix(".json").is_file()
+        else -1
+        for p in paths
+    }
+
+
+def _load_clean_cache(path: Path) -> tuple[
+    dict[Path, set[str]], dict[str, set[Path]], dict[str, float]
+] | None:
+    try:
+        with path.open("rb") as f:
+            data = pickle.load(f)
+        if data.get("cache_version") != _CACHE_VERSION:
+            return None
+        clean_cache = {Path(p): set(t) for p, t in data.get("clean_token_cache", {}).items()}
+        index = {k: {Path(p) for p in v} for k, v in data.get("token_index", {}).items()}
+        version = data.get("version_info", {})
+        return clean_cache, index, version
+    except Exception:
+        return None
+
+
+def _save_clean_cache(
+    path: Path,
+    clean_cache: Mapping[Path, set[str]],
+    index: Mapping[str, Set[Path]],
+    version: Mapping[str, float],
+) -> None:
+    try:
+        with path.open("wb") as f:
+            pickle.dump(
+                {
+                    "cache_version": _CACHE_VERSION,
+                    "clean_token_cache": {str(p): list(t) for p, t in clean_cache.items()},
+                    "token_index": {k: [str(p) for p in v] for k, v in index.items()},
+                    "version_info": dict(version),
+                },
+                f,
+            )
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Failed to save clean cache %s: %s", path, exc)
+
+
 def _init_worker(
     classifier_ckpt: str | None,
     explainer_ckpt: str | None,
     device: str,
     token_index_file: str | None = None,
+    clean_cache_file: str | None = None,
 ) -> None:
     """Load models in subprocess."""
-    global _WORKER_CLASSIFIER, _WORKER_EXPLAINER, _WORKER_DEVICE, _WORKER_TOKEN_INDEX
+    global _WORKER_CLASSIFIER, _WORKER_EXPLAINER, _WORKER_DEVICE, _WORKER_TOKEN_INDEX, _WORKER_CLEAN_CACHE
     _WORKER_DEVICE = torch.device(device)
     if classifier_ckpt:
         from src.models.gnn.res_wrapper import RESGCLClassifier
@@ -1871,7 +1923,11 @@ def _init_worker(
         _WORKER_EXPLAINER = torch.load(
             explainer_ckpt, map_location=_WORKER_DEVICE, weights_only=False
         )
-    if token_index_file and Path(token_index_file).is_file():
+    if clean_cache_file and Path(clean_cache_file).is_file():
+        loaded = _load_clean_cache(Path(clean_cache_file))
+        if loaded is not None:
+            _WORKER_CLEAN_CACHE, _WORKER_TOKEN_INDEX, _ = loaded
+    elif token_index_file and Path(token_index_file).is_file():
         _WORKER_TOKEN_INDEX = _load_token_index(token_index_file)
 
 
@@ -2200,6 +2256,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--clean-sample", type=Path, help="Optional clean sample for FP check"
     )
+    p.add_argument(
+        "--save-clean-cache",
+        type=Path,
+        help="Save/load clean token cache to this path",
+    )
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")
     p.add_argument(
@@ -2349,7 +2410,13 @@ def main(argv: list[str] | None = None) -> None:
 
         clean_token_cache: dict[Path, set[str]] = {}
         token_index: dict[str, set[Path]] = {}
-        if args.clean_dir is None and args.clean_sample is None:
+        cache_version = _cache_version_info(benign_paths)
+        if args.save_clean_cache and args.save_clean_cache.is_file():
+            loaded = _load_clean_cache(args.save_clean_cache)
+            if loaded is not None and loaded[2] == cache_version:
+                clean_token_cache, token_index, _ = loaded
+                LOGGER.debug("Loaded clean cache from %s", args.save_clean_cache)
+        if not clean_token_cache and args.clean_dir is None and args.clean_sample is None:
             for p in tqdm_wrap(benign_paths, desc="preload clean json", unit="file"):
                 j = p.with_suffix(".json")
                 if not j.is_file():
@@ -2370,8 +2437,10 @@ def main(argv: list[str] | None = None) -> None:
             len(clean_token_cache),
             human_bytes(cache_bytes),
         )
+        if args.save_clean_cache:
+            _save_clean_cache(args.save_clean_cache, clean_token_cache, token_index, cache_version)
         token_index_file: Path | None = None
-        if args.num_workers > 1 and token_index:
+        if args.num_workers > 1 and token_index and not args.save_clean_cache:
             tmpdir = Path(tempfile.mkdtemp(prefix="token_index_"))
             token_index_file = tmpdir / "index.json"
             token_index_file.write_text(
@@ -2433,8 +2502,12 @@ def main(argv: list[str] | None = None) -> None:
                 "persist_fp_exclude": args.persist_fp_exclude,
                 "enforce_self_detect": args.enforce_self_detect,
                 "fp_scan_workers": args.fp_scan_workers,
-                "clean_token_cache": clean_token_cache,
-                "token_index": token_index if args.num_workers <= 1 else None,
+                "clean_token_cache": (
+                    None if args.num_workers > 1 and args.save_clean_cache else clean_token_cache
+                ),
+                "token_index": (
+                    None if args.num_workers > 1 and args.save_clean_cache else token_index if args.num_workers <= 1 else None
+                ),
                 "fp_timeout": args.fp_timeout,
                 "max_exclude_tokens": args.max_exclude_tokens,
                 "cache_saliency": args.cache_saliency,
@@ -2477,7 +2550,13 @@ def main(argv: list[str] | None = None) -> None:
                 max_workers=args.num_workers,
                 mp_context=ctx,
                 initializer=_init_worker,
-                initargs=(None, None, args.device, str(token_index_file) if token_index_file else None),
+                initargs=(
+                    None,
+                    None,
+                    args.device,
+                    str(token_index_file) if token_index_file else None,
+                    str(args.save_clean_cache) if args.save_clean_cache else None,
+                ),
             ) as executor:
                 future_map = {}
                 for t in tasks:


### PR DESCRIPTION
## Summary
- allow caching clean token sets and token index via `--save-clean-cache`
- share clean token cache across workers
- reload caches when unchanged for faster startup

## Testing
- `python -m py_compile src/cli/explainer_rule_eval.py`
- `pytest -k evaluate_single_uses_clean_token_cache -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68888240d344832e9c413c6c42b6f030