### PR TITLE
Allow lowering freq threshold with custom min limit

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -217,8 +217,8 @@ python -m src.cli.explainer_rule_eval \
 
 `--freq-threshold-step`과 `--comb-ratio-step`을 사용하면 재시도 과정에서
 빈도 임계값을 낮추거나 병합 비율을 높여가며 규칙을 조정할 수 있습니다.
-`--freq-threshold`는 0 이상으로 설정할 수 있으며 `--freq-threshold-step`으로
-단계적 완화를 할 수 있습니다.
+`--min-freq-threshold` 옵션을 지정하면 임계값 하한을 음수로도 설정할 수 있으며,
+`--freq-threshold-step` 값을 0.1 등으로 두어 0.1 단위로 완화하는 것도 가능합니다.
 `--enforce-self-detect` 옵션을 주면 현재 샘플이 탐지될 때까지 조건을 단계적으로 완화합니다.
 `--fp-timeout` 옵션을 지정하면 FP 재시도를 해당 시간(초) 이후 중단합니다.
 `--persist-fp-exclude` 옵션에 JSON 파일을 지정하면 재시도 과정에서

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -295,6 +295,7 @@ def adaptive_fp_retry(
     group_min_count: int | None,
     combine_min_ratio: float,
     freq_threshold: float | int,
+    min_freq_threshold: float,
     group_min_ratio: float,
     num_rules: int,
     chunk_size: int | None,
@@ -718,6 +719,7 @@ def evaluate_single(
     mal_freqs: dict[str, int] | None = None,
     freq_ratio: float = 1.0,
     freq_threshold: float | int = 10,
+    min_freq_threshold: float = 0.0,
     auto_relax: bool = True,
     condition_type: str,
     percentage: int,
@@ -1715,12 +1717,12 @@ def evaluate_single(
 
         # step 2: lower freq_threshold gradually and enlarge chunk_size.
         # exit early whenever detection succeeds
-        freq_step = freq_threshold_step if freq_threshold_step > 0 else 1
+        freq_step = freq_threshold_step
         chunk_step = chunk_size_step if chunk_size_step > 0 else 1
         attempts = 0
         while not result.get("detected") and attempts < 10:
-            if freq_th > 0:
-                freq_th = max(0, freq_th - freq_step)
+            if freq_step != 0 and freq_th > min_freq_threshold:
+                freq_th = max(min_freq_threshold, freq_th - freq_step)
             result = _eval_with_count(
                 freq_th,
                 grp_cnt,
@@ -1799,6 +1801,7 @@ def evaluate_single(
             group_min_count=group_min_count,
             combine_min_ratio=combine_min_ratio,
             freq_threshold=freq_threshold,
+            min_freq_threshold=min_freq_threshold,
             group_min_ratio=group_min_ratio,
             num_rules=num_rules,
             chunk_size=chunk_size,
@@ -2068,6 +2071,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=float,
         default=10.0,
         help="Frequency threshold for filtering",
+    )
+    p.add_argument(
+        "--min-freq-threshold",
+        type=float,
+        default=0.0,
+        help="Lower bound for freq_threshold during FP retries",
     )
     p.add_argument(
         "--no-auto-relax",
@@ -2797,6 +2806,7 @@ def main(argv: list[str] | None = None) -> None:
             mal_freqs=mal_freqs,
             freq_ratio=args.freq_ratio,
             freq_threshold=args.freq_threshold,
+            min_freq_threshold=args.min_freq_threshold,
             auto_relax=args.auto_relax,
             condition_type=args.condition_type,
             percentage=args.percentage,

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -37,6 +37,24 @@ def test_build_parser_fp_retries():
     assert args.comb_ratio_step == 0.2
 
 
+def test_build_parser_min_freq_threshold():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--min-freq-threshold",
+            "-1",
+        ]
+    )
+    assert args.min_freq_threshold == -1.0
+
+
 def test_build_parser_fp_timeout():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()
@@ -1776,6 +1794,7 @@ def test_fp_retry_hitting_set(tmp_path, monkeypatch):
         group_min_count=None,
         combine_min_ratio=0.7,
         freq_threshold=10,
+        min_freq_threshold=0.0,
         group_min_ratio=0.0,
         num_rules=1,
         chunk_size=None,
@@ -1796,6 +1815,53 @@ def test_fp_retry_hitting_set(tmp_path, monkeypatch):
     )
 
     assert calls and calls[0] == {"ab", "bb"}
+
+
+def test_adaptive_fp_retry_freq_step_and_min_threshold():
+    from collections import Counter
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    freqs: list[float] = []
+
+    def fake_eval(freq, *args, **kwargs):
+        freqs.append(freq)
+        return {"detected": False, "false_positive": True}
+
+    result = {"false_positive": True}
+
+    mod.adaptive_fp_retry(
+        fake_eval,
+        result=result,
+        exclude_set=set(),
+        fp_token_counter=Counter(),
+        group_min_count=None,
+        combine_min_ratio=0.7,
+        freq_threshold=0.5,
+        min_freq_threshold=-1.0,
+        group_min_ratio=0.0,
+        num_rules=1,
+        chunk_size=None,
+        combine_mode="or",
+        auto_group_min=True,
+        freq_threshold_step=1.0,
+        comb_ratio_step=0.0,
+        chunk_size_step=1,
+        combine_max_ratio=1.0,
+        fp_retries=1,
+        fp_timeout=None,
+        max_exclude_tokens=5,
+        persist_fp_exclude=None,
+        fp_bar=None,
+        is_better=lambda n, c: True,
+        best_result={"detected": False, "false_positive": True},
+        last_detected=None,
+    )
+
+    # second call should use lowered threshold allowing negatives
+    assert len(freqs) >= 2
+    assert freqs[0] == 0.5
+    assert freqs[1] == -0.5
 
 
 def test_fp_retry_token_exclusion_rollback(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- allow custom lower bound for frequency threshold via `--min-freq-threshold`
- keep `freq_threshold_step` unchanged when non-positive
- document that thresholds can be relaxed in 0.1 increments
- test new parser arg and adaptive retry behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gensim')*

------
https://chatgpt.com/codex/tasks/task_e_6888825dfcec832e9551b963c55dc7dc