### PR TITLE
Refactor token cache integration

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -7,6 +7,7 @@ import json
 import os
 import importlib
 import pickle
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Sequence, Mapping, Set
 from collections import Counter, defaultdict
@@ -32,6 +33,23 @@ from rulegen.feature_miner import FeatureMiner
 from rulegen.yara_builder import YaraBuilder
 
 LOGGER = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Token cache
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TokenCache:
+    """Store clean sample tokens and token index."""
+
+    tokens: dict[Path, set[str]] = field(default_factory=dict)
+    index: dict[str, set[Path]] = field(default_factory=lambda: defaultdict(set))
+
+    def add(self, path: Path, tokens: set[str]) -> None:
+        """Add ``tokens`` for ``path`` updating the index."""
+        self.tokens[path] = tokens
+        for t in tokens:
+            self.index.setdefault(t, set()).add(path)
 
 # Persistent false positive exclude tokens
 _FP_EXCLUDE_COUNTS: Counter[str] = Counter()
@@ -277,10 +295,14 @@ def extract_json_tokens(js_obj: Mapping[str, Any]) -> set[str]:
     return tokens
 
 
-def estimate_token_cache_size(cache: Mapping[Path, set[str]]) -> int:
+def estimate_token_cache_size(cache: Mapping[Path, set[str]] | TokenCache) -> int:
     """Roughly estimate total memory usage of a token cache."""
+    if isinstance(cache, TokenCache):
+        values = cache.tokens.values()
+    else:
+        values = cache.values()
     total = 0
-    for token_set in cache.values():
+    for token_set in values:
         total += sys.getsizeof(token_set)
         for tok in token_set:
             total += sys.getsizeof(tok)
@@ -750,8 +772,7 @@ def evaluate_single(
     auto_group_min: bool = True,
     exclude_tokens: Sequence[str] | None = None,
     persist_fp_exclude: Path | None = None,
-    clean_token_cache: Dict[Path, set[str]] | None = None,
-    token_index: Dict[str, Set[Path]] | None = None,
+    token_cache: TokenCache | None = None,
     fp_timeout: float | None = None,
     max_exclude_tokens: int = 5,
     fp_bar: tqdm | None = None,
@@ -808,17 +829,13 @@ def evaluate_single(
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("Failed to save saliency cache %s: %s", cache_path, exc)
 
-    if clean_token_cache is None:
-        clean_token_cache = _WORKER_CLEAN_CACHE or {}
-    if isinstance(token_index, (str, os.PathLike)):
-        token_index = _load_token_index(token_index)
-    elif token_index is None:
-        token_index = _WORKER_TOKEN_INDEX or defaultdict(set)
-    if clean_token_cache and not token_index:
-        for p, toks in clean_token_cache.items():
+    if token_cache is None:
+        token_cache = _WORKER_TOKEN_CACHE or TokenCache()
+    if token_cache.tokens and not token_cache.index:
+        for p, toks in token_cache.tokens.items():
             for t in toks:
-                token_index[t].add(p)
-    if not clean_token_cache and not token_index:
+                token_cache.index[t].add(p)
+    if not token_cache.tokens and not token_cache.index:
         if clean_dir is not None and clean_dir.is_dir():
             files = [p for p in clean_dir.iterdir() if p.is_file()]
             for p in tqdm_wrap(files, desc="load clean json", unit="file"):
@@ -829,9 +846,7 @@ def evaluate_single(
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     toks = extract_json_tokens(obj)
-                    clean_token_cache[p] = toks
-                    for t in toks:
-                        token_index[t].add(p)
+                    token_cache.add(p, toks)
                     del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
@@ -844,9 +859,7 @@ def evaluate_single(
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     toks = extract_json_tokens(obj)
-                    clean_token_cache[p] = toks
-                    for t in toks:
-                        token_index[t].add(p)
+                    token_cache.add(p, toks)
                     del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
@@ -858,18 +871,16 @@ def evaluate_single(
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     toks = extract_json_tokens(obj)
-                    clean_token_cache[clean_sample] = toks
-                    for t in toks:
-                        token_index[t].add(clean_sample)
+                    token_cache.add(clean_sample, toks)
                     del obj
 
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
 
-        cache_bytes = estimate_token_cache_size(clean_token_cache)
+        cache_bytes = estimate_token_cache_size(token_cache)
         LOGGER.info(
             "Clean token cache loaded: %d samples (%s)",
-            len(clean_token_cache),
+            len(token_cache.tokens),
             human_bytes(cache_bytes),
         )
 
@@ -881,7 +892,7 @@ def evaluate_single(
     elif clean_sample is not None:
         total_benign = 1
     else:
-        total_benign = len(clean_token_cache)
+        total_benign = len(token_cache.tokens)
 
     def _apply_params(params: dict[str, object]) -> None:
         nonlocal condition_type, combine_mode, dynamic_k, auto_relax, adjust_group_percentage, group_min_ratio, combine_min_ratio
@@ -1150,12 +1161,12 @@ def evaluate_single(
             if json_match:
 
                 def _check_json(p: Path | None) -> tuple[list[str], int] | None:
-                    if token_index and p is None:
+                    if token_cache.index and p is None:
                         cand: Set[Path] | None = None
                         matched: list[str] = []
                         for feat in feats:
                             for tok in _extract_tokens(feat):
-                                paths = token_index.get(tok.lower())
+                                paths = token_cache.index.get(tok.lower())
                                 if not paths:
                                     return None
                                 matched.append(tok.lower())
@@ -1166,7 +1177,7 @@ def evaluate_single(
                             return None
                         count = 0
                         for cp in cand:
-                            toks_set = clean_token_cache.get(cp)
+                            toks_set = token_cache.tokens.get(cp)
                             if toks_set is None:
                                 j = cp.with_suffix(".json")
                                 if not j.is_file():
@@ -1174,7 +1185,7 @@ def evaluate_single(
                                 try:
                                     obj = json.loads(j.read_text(encoding="utf-8"))
                                     toks_set = extract_json_tokens(obj)
-                                    clean_token_cache[cp] = toks_set
+                                    token_cache.add(cp, toks_set)
                                 except Exception:  # noqa: BLE001
                                     continue
                             ok = verify_features(
@@ -1191,7 +1202,7 @@ def evaluate_single(
                         return (matched, count) if count > 0 else None
                     if p is None:
                         return None
-                    toks_set = clean_token_cache.get(p)
+                    toks_set = token_cache.tokens.get(p)
                     if toks_set is None:
                         return None
                     ok, mt = verify_features(
@@ -1210,7 +1221,7 @@ def evaluate_single(
                 fp_match_counts: list[int] = []
                 fp_tokens_samples: list[list[str]] = []
                 fp_tokens_samples: list[list[str]] = []
-                if token_index:
+                if token_cache.index:
                     res = _check_json(None)
                     fp = res is not None
                     if res is not None:
@@ -1843,8 +1854,7 @@ def evaluate_single(
 _WORKER_CLASSIFIER = None
 _WORKER_EXPLAINER = None
 _WORKER_DEVICE: torch.device | None = None
-_WORKER_TOKEN_INDEX: dict[str, set[Path]] | None = None
-_WORKER_CLEAN_CACHE: dict[Path, set[str]] | None = None
+_WORKER_TOKEN_CACHE: TokenCache | None = None
 
 _SAL_CLASSIFIER = None
 _SAL_EXPLAINER = None
@@ -1869,9 +1879,7 @@ def _cache_version_info(paths: Sequence[Path]) -> dict[str, float]:
     }
 
 
-def _load_clean_cache(path: Path) -> tuple[
-    dict[Path, set[str]], dict[str, set[Path]], dict[str, float]
-] | None:
+def _load_clean_cache(path: Path) -> tuple[TokenCache, dict[str, float]] | None:
     try:
         with path.open("rb") as f:
             data = pickle.load(f)
@@ -1880,15 +1888,15 @@ def _load_clean_cache(path: Path) -> tuple[
         clean_cache = {Path(p): set(t) for p, t in data.get("clean_token_cache", {}).items()}
         index = {k: {Path(p) for p in v} for k, v in data.get("token_index", {}).items()}
         version = data.get("version_info", {})
-        return clean_cache, index, version
+        tc = TokenCache(clean_cache, defaultdict(set, index))
+        return tc, version
     except Exception:
         return None
 
 
 def _save_clean_cache(
     path: Path,
-    clean_cache: Mapping[Path, set[str]],
-    index: Mapping[str, Set[Path]],
+    cache: TokenCache,
     version: Mapping[str, float],
 ) -> None:
     try:
@@ -1896,8 +1904,8 @@ def _save_clean_cache(
             pickle.dump(
                 {
                     "cache_version": _CACHE_VERSION,
-                    "clean_token_cache": {str(p): list(t) for p, t in clean_cache.items()},
-                    "token_index": {k: [str(p) for p in v] for k, v in index.items()},
+                    "clean_token_cache": {str(p): list(t) for p, t in cache.tokens.items()},
+                    "token_index": {k: [str(p) for p in v] for k, v in cache.index.items()},
                     "version_info": dict(version),
                 },
                 f,
@@ -1914,7 +1922,7 @@ def _init_worker(
     clean_cache_file: str | None = None,
 ) -> None:
     """Load models in subprocess."""
-    global _WORKER_CLASSIFIER, _WORKER_EXPLAINER, _WORKER_DEVICE, _WORKER_TOKEN_INDEX, _WORKER_CLEAN_CACHE
+    global _WORKER_CLASSIFIER, _WORKER_EXPLAINER, _WORKER_DEVICE, _WORKER_TOKEN_CACHE
     _WORKER_DEVICE = torch.device(device)
     if classifier_ckpt:
         from src.models.gnn.res_wrapper import RESGCLClassifier
@@ -1929,9 +1937,10 @@ def _init_worker(
     if clean_cache_file and Path(clean_cache_file).is_file():
         loaded = _load_clean_cache(Path(clean_cache_file))
         if loaded is not None:
-            _WORKER_CLEAN_CACHE, _WORKER_TOKEN_INDEX, _ = loaded
+            _WORKER_TOKEN_CACHE, _ = loaded
     elif token_index_file and Path(token_index_file).is_file():
-        _WORKER_TOKEN_INDEX = _load_token_index(token_index_file)
+        idx = _load_token_index(token_index_file)
+        _WORKER_TOKEN_CACHE = TokenCache({}, defaultdict(set, idx))
 
 
 def _init_saliency_worker(
@@ -2417,15 +2426,14 @@ def main(argv: list[str] | None = None) -> None:
             bname = b_row.get("filename") or b_row.get("name") or f"{bsha}.bin"
             benign_paths.append(Path(args.sample_dir or args.graph_dir) / bname)
 
-        clean_token_cache: dict[Path, set[str]] = {}
-        token_index: dict[str, set[Path]] = {}
+        token_cache = TokenCache()
         cache_version = _cache_version_info(benign_paths)
         if args.save_clean_cache and args.save_clean_cache.is_file():
             loaded = _load_clean_cache(args.save_clean_cache)
-            if loaded is not None and loaded[2] == cache_version:
-                clean_token_cache, token_index, _ = loaded
+            if loaded is not None and loaded[1] == cache_version:
+                token_cache, _ = loaded
                 LOGGER.debug("Loaded clean cache from %s", args.save_clean_cache)
-        if not clean_token_cache and args.clean_dir is None and args.clean_sample is None:
+        if not token_cache.tokens and args.clean_dir is None and args.clean_sample is None:
             for p in tqdm_wrap(benign_paths, desc="preload clean json", unit="file"):
                 j = p.with_suffix(".json")
                 if not j.is_file():
@@ -2433,27 +2441,25 @@ def main(argv: list[str] | None = None) -> None:
                 try:
                     obj = json.loads(j.read_text(encoding="utf-8"))
                     toks = extract_json_tokens(obj)
-                    clean_token_cache[p] = toks
-                    for t in toks:
-                        token_index.setdefault(t, set()).add(p)
+                    token_cache.add(p, toks)
                     del obj
                 except Exception as exc:  # noqa: BLE001
                     LOGGER.warning("failed to read %s: %s", j, exc)
 
-        cache_bytes = estimate_token_cache_size(clean_token_cache)
+        cache_bytes = estimate_token_cache_size(token_cache)
         LOGGER.debug(
             "Preloaded clean token cache: %d samples (%s)",
-            len(clean_token_cache),
+            len(token_cache.tokens),
             human_bytes(cache_bytes),
         )
         if args.save_clean_cache:
-            _save_clean_cache(args.save_clean_cache, clean_token_cache, token_index, cache_version)
+            _save_clean_cache(args.save_clean_cache, token_cache, cache_version)
         token_index_file: Path | None = None
-        if args.num_workers > 1 and token_index and not args.save_clean_cache:
+        if args.num_workers > 1 and token_cache.index and not args.save_clean_cache:
             tmpdir = Path(tempfile.mkdtemp(prefix="token_index_"))
             token_index_file = tmpdir / "index.json"
             token_index_file.write_text(
-                json.dumps({k: [str(p) for p in v] for k, v in token_index.items()})
+                json.dumps({k: [str(p) for p in v] for k, v in token_cache.index.items()})
             )
         results: list[dict[str, Any]] = []
         fp_token_counter_all: Counter[str] = Counter()
@@ -2511,11 +2517,8 @@ def main(argv: list[str] | None = None) -> None:
                 "persist_fp_exclude": args.persist_fp_exclude,
                 "enforce_self_detect": args.enforce_self_detect,
                 "fp_scan_workers": args.fp_scan_workers,
-                "clean_token_cache": (
-                    None if args.num_workers > 1 and args.save_clean_cache else clean_token_cache
-                ),
-                "token_index": (
-                    None if args.num_workers > 1 and args.save_clean_cache else token_index if args.num_workers <= 1 else None
+                "token_cache": (
+                    None if args.num_workers > 1 and args.save_clean_cache else token_cache if args.num_workers <= 1 else None
                 ),
                 "fp_timeout": args.fp_timeout,
                 "max_exclude_tokens": args.max_exclude_tokens,
@@ -2908,7 +2911,7 @@ def main(argv: list[str] | None = None) -> None:
             json_match=args.json_match,
             fp_scan_workers=args.fp_scan_workers,
             saliency_stats=saliency_stats,
-            clean_token_cache=None,
+            token_cache=None,
             combine_mode=combine_mode,
             combine_min_ratio=args.combine_min_ratio,
             combine_max_ratio=args.combine_max_ratio,

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1070,7 +1070,8 @@ def test_evaluate_single_uses_clean_token_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
 
     js_obj = json.loads(clean_json.read_text())
-    cache = {clean: mod.extract_json_tokens(js_obj)}
+    cache = mod.TokenCache()
+    cache.add(clean, mod.extract_json_tokens(js_obj))
 
     orig_read = Path.read_text
 
@@ -1100,7 +1101,7 @@ def test_evaluate_single_uses_clean_token_cache(tmp_path, monkeypatch):
         sample_json=sample_json,
         json_match=True,
         combine_mode="or",
-        clean_token_cache=cache,
+        token_cache=cache,
     )
 
     assert res["false_positive"] is True
@@ -1519,13 +1520,13 @@ def test_verify_features_token_set_equivalence(tmp_path):
 def test_estimate_token_cache_size(tmp_path):
     mod = importlib.import_module("src.cli.explainer_rule_eval")
 
-    cache: dict[Path, set[str]] = {}
+    cache = mod.TokenCache()
     for i in range(100):
         p = tmp_path / f"s{i}.bin"
         p.write_text("dummy")
         j = tmp_path / f"s{i}.json"
         j.write_text(json.dumps({"c_code": ["foo bar baz"]}))
-        cache[p] = mod.extract_json_tokens(json.loads(j.read_text()))
+        cache.add(p, mod.extract_json_tokens(json.loads(j.read_text())))
 
     size = mod.estimate_token_cache_size(cache)
     assert size < 1_000_000  # <1MB
@@ -2616,14 +2617,11 @@ def test_fp_ratio_benign_token_index(tmp_path, monkeypatch):
 
     monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
 
-    cache = {
-        b1: mod.extract_json_tokens(json.loads(b1_json.read_text())),
-        b2: mod.extract_json_tokens(json.loads(b2_json.read_text())),
-    }
-    index: dict[str, set[Path]] = defaultdict(set)
-    for p, toks in cache.items():
-        for t in toks:
-            index[t].add(p)
+    cache = mod.TokenCache()
+    toks1 = mod.extract_json_tokens(json.loads(b1_json.read_text()))
+    toks2 = mod.extract_json_tokens(json.loads(b2_json.read_text()))
+    cache.add(b1, toks1)
+    cache.add(b2, toks2)
 
     res = mod.evaluate_single(
         gpath,
@@ -2646,8 +2644,7 @@ def test_fp_ratio_benign_token_index(tmp_path, monkeypatch):
         sample_json=sample_json,
         json_match=True,
         combine_mode="or",
-        clean_token_cache=cache,
-        token_index=index,
+        token_cache=cache,
     )
 
     assert res["false_positive"] is True
@@ -2809,9 +2806,9 @@ def test_adaptive_fp_retry_token_index_profile(tmp_path, monkeypatch):
 
     monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
 
-    index = defaultdict(set)
+    index = mod.TokenCache()
     for p, tok in tokens_map.items():
-        index[tok].add(p)
+        index.index[tok].add(p)
 
     read_count = 0
     orig_read = Path.read_text
@@ -2863,7 +2860,7 @@ def test_adaptive_fp_retry_token_index_profile(tmp_path, monkeypatch):
         sample_json=sample_json,
         json_match=True,
         combine_mode="or",
-        token_index=index,
+        token_cache=index,
         fp_retries=1,
     )
     with_index = read_count


### PR DESCRIPTION
## Summary
- introduce `TokenCache` dataclass combining path->tokens and token->paths
- refactor `evaluate_single` to use unified structure
- adapt cache loading/saving helpers for new structure
- update tests for TokenCache usage

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_estimate_token_cache_size -q` *(fails: 1 skipped)*
- `pip install torch==2.2.1 psutil pandas gymnasium torch_geometric==2.5.3 -q` *(failed: operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68888752f014832e90eb31e7f6344a4f