### PR TITLE
Add RL optimizer to rule eval

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -224,9 +224,11 @@ python -m src.cli.explainer_rule_eval \
 `--persist-fp-exclude` 옵션에 JSON 파일을 지정하면 재시도 과정에서
 제외된 토큰을 누적 저장하며, 다음 실행에서도 동일 파일을 지정하면
 자동으로 로드되어 동일 토큰을 계속 제외합니다.
+
 `--optimize` 플래그를 사용하면 재시도 과정에서 하이퍼파라미터를 온라인으로
 조정합니다. `--optimizer-pkl` 로 이전 상태를 불러오거나
 `--save-optimizer` 로 실행 후 상태를 저장할 수 있습니다.
+`--use-rl-optimizer` 옵션을 주면 PPO 기반 규칙 최적화를 수행합니다.
 
 배치 모드에서도 `--save-optimizer` 를 사용하면 종료 시점에 상태가 지정한 경로에 저장됩니다.
 

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -2089,6 +2089,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Save optimizer state to this path after execution",
     )
     p.add_argument(
+        "--use-rl-optimizer",
+        action="store_true",
+        help="Use PPO-based rule optimizer",
+    )
+    p.add_argument(
+        "--rl-steps",
+        type=int,
+        default=100,
+        help="Number of PPO training steps when using RL optimizer",
+    )
+    p.add_argument(
         "--opt-beta",
         type=float,
         default=0.5,
@@ -2939,6 +2950,37 @@ def main(argv: list[str] | None = None) -> None:
             mode=combine_mode,
             min_match_ratio=args.combine_min_ratio,
         )
+
+        if args.use_rl_optimizer:
+            import rulegen
+
+            tokens = rulegen.rl_env.RuleGenEnv._rule_tokenize(rule_txt)
+            hints = YaraBuilder()._extract_features(tokens)
+
+            env = rulegen.make_env(
+                rule_type="yara",
+                classifier_checkpoint=args.classifier,
+                hint_features=hints,
+            )
+            try:
+                agent = rulegen.load_agent(env=env, seed=42, agent_kwargs={"use_hint": True})
+            except Exception:
+                from rulegen.rl_agent import PPORuleAgent
+
+                agent = PPORuleAgent(env, seed=42, use_hint=True)
+
+            _, baseline_metrics, _ = env._compute_reward(rule_txt)
+            agent.train(total_timesteps=args.rl_steps)
+            rl_tokens = agent.sample_rules(n=1)[0]
+            rl_rule = YaraBuilder().build(rl_tokens)
+            _, rl_metrics, _ = env._compute_reward(rl_rule)
+
+            print(
+                f"[Heuristic] F1={baseline_metrics['f1_dummy']:.3f} FP={baseline_metrics['fp_rate']:.3f}"
+            )
+            print(
+                f"[RL]        F1={rl_metrics['f1_dummy']:.3f} FP={rl_metrics['fp_rate']:.3f}"
+            )
 
         if args.sample_rules_out:
             args.sample_rules_out.mkdir(parents=True, exist_ok=True)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -293,6 +293,23 @@ def test_build_parser_batch_size():
     assert args.batch_size == 4
 
 
+def test_build_parser_use_rl_optimizer():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--use-rl-optimizer",
+        ]
+    )
+    assert args.use_rl_optimizer is True
+
+
 def test_cli_runs_and_writes_json(tmp_path, caplog):
     g = HeteroData()
     g["bb"].x = torch.zeros(2, 1)


### PR DESCRIPTION
## Summary
- expose `--use-rl-optimizer` and `--rl-steps` in `explainer_rule_eval` CLI
- integrate PPO environment for RL fine-tuning
- show heuristic vs. RL metrics
- document `--use-rl-optimizer`
- test CLI flag parsing

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6888944a9570832eb02005b840a4843f