### PR TITLE
Add population optimizer with CLI options

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -108,3 +108,115 @@ class CategoricalOptimizer:
         loss.backward()
         self.optimizer.step()
 
+    # ------------------------------------------------------------------
+    def load_discrete_params(self, params: Mapping[str, Any]) -> None:
+        """Load discrete parameters into optimizer logits."""
+
+        if (val := params.get("condition_type")) in self.CONDITION_TYPES:
+            idx = self.CONDITION_TYPES.index(val)
+            self.condition_type_logits.data.zero_()
+            self.condition_type_logits.data[idx] = 10.0
+        if (val := params.get("combine_mode")) in self.COMBINE_MODES:
+            idx = self.COMBINE_MODES.index(val)
+            self.combine_mode_logits.data.zero_()
+            self.combine_mode_logits.data[idx] = 10.0
+        if "dynamic_k" in params:
+            self.dynamic_k_logit.data.fill_(10.0 if params["dynamic_k"] else -10.0)
+        if "auto_relax" in params:
+            self.auto_relax_logit.data.fill_(10.0 if params["auto_relax"] else -10.0)
+        if "adjust_group_percentage" in params:
+            self.adjust_group_percentage_logit.data.fill_(
+                10.0 if params["adjust_group_percentage"] else -10.0
+            )
+        if "group_min_ratio" in params:
+            val = float(params["group_min_ratio"])
+            val = min(max(val, 0.0), 1.0)
+            self.group_min_ratio_logit.data.copy_(torch.logit(torch.tensor(val)))
+        if "combine_min_ratio" in params:
+            val = float(params["combine_min_ratio"])
+            val = min(max(val, 0.0), 1.0)
+            self.combine_min_ratio_logit.data.copy_(torch.logit(torch.tensor(val)))
+
+
+class PopulationOptimizer:
+    """Simple genetic optimizer wrapping multiple ``CategoricalOptimizer``s."""
+
+    def __init__(
+        self,
+        population_size: int = 4,
+        *,
+        mutation_rate: float = 0.1,
+        crossover_rate: float = 0.5,
+        steps: int = 1,
+        beta: float = 0.5,
+    ) -> None:
+        self.population_size = max(1, population_size)
+        self.mutation_rate = mutation_rate
+        self.crossover_rate = crossover_rate
+        self.steps = steps
+        self.optimizers = [CategoricalOptimizer(beta=beta) for _ in range(self.population_size)]
+
+    # ------------------------------------------------------------------
+    def state_dict(self) -> dict:
+        return {
+            "population": [opt.state_dict() for opt in self.optimizers],
+            "mutation_rate": self.mutation_rate,
+            "crossover_rate": self.crossover_rate,
+            "steps": self.steps,
+        }
+
+    def load_state_dict(self, state: dict) -> None:
+        pop = state.get("population", [])
+        for opt, st in zip(self.optimizers, pop):
+            opt.load_state_dict(st)
+        self.mutation_rate = float(state.get("mutation_rate", self.mutation_rate))
+        self.crossover_rate = float(state.get("crossover_rate", self.crossover_rate))
+        self.steps = int(state.get("steps", self.steps))
+
+    # ------------------------------------------------------------------
+    def step(self, results: list[Mapping[str, Any]]) -> None:
+        from .explainer_rule_eval import _optimizer_loss
+        losses: list[float] = []
+        for opt, res in zip(self.optimizers, results):
+            loss = _optimizer_loss(res, opt, res.get("fp_ratio_benign", 0.0))
+            opt.step(loss)
+            losses.append(float(loss.item()))
+
+        # selection
+        order = sorted(range(len(losses)), key=lambda i: losses[i])
+        parents = [self.optimizers[i] for i in order[: max(1, len(order) // 2)]]
+
+        import random
+
+        new_opts: list[CategoricalOptimizer] = []
+        while len(new_opts) < self.population_size:
+            parent1 = random.choice(parents)
+            parent2 = random.choice(parents)
+            child_params = parent1.discrete_params()
+            other = parent2.discrete_params()
+            for k in child_params.keys():
+                if random.random() < self.crossover_rate:
+                    child_params[k] = other[k]
+            if random.random() < self.mutation_rate:
+                key = random.choice(list(child_params.keys()))
+                self._mutate_param(child_params, key)
+            child = CategoricalOptimizer(beta=parent1.beta)
+            child.load_discrete_params(child_params)
+            new_opts.append(child)
+        self.optimizers = new_opts
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _mutate_param(params: dict, key: str) -> None:
+        import random
+
+        if key == "condition_type":
+            params[key] = random.choice(CategoricalOptimizer.CONDITION_TYPES)
+        elif key == "combine_mode":
+            params[key] = random.choice(CategoricalOptimizer.COMBINE_MODES)
+        elif key in {"dynamic_k", "auto_relax", "adjust_group_percentage"}:
+            params[key] = not params.get(key, False)
+        elif key in {"group_min_ratio", "combine_min_ratio"}:
+            params[key] = min(1.0, max(0.0, params.get(key, 0.5) + random.uniform(-0.1, 0.1)))
+
+

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -25,7 +25,7 @@ from src.graphs.loaders.common_token_utils import split_name, TOKEN_RE
 import torch
 from torch_geometric.data import HeteroData
 from src.graphs.dataset.graph_dataset import GraphDataset
-from src.cli.categorical_optimizer import CategoricalOptimizer
+from src.cli.categorical_optimizer import CategoricalOptimizer, PopulationOptimizer
 import torch.nn.functional as F
 import multiprocessing as mp
 
@@ -336,7 +336,7 @@ def adaptive_fp_retry(
     is_better,
     best_result: Dict[str, Any],
     last_detected: Dict[str, Any] | None,
-    optimizer: CategoricalOptimizer | None = None,
+    optimizer: CategoricalOptimizer | PopulationOptimizer | None = None,
     param_update=None,
 ) -> tuple[Dict[str, Any], set[str], Dict[str, Any]]:
     start_time = time.perf_counter()
@@ -397,9 +397,13 @@ def adaptive_fp_retry(
             tried_tokens.update(excl_set)
             trial = _try(excl_set, group_min_count, combine_min_ratio)
             if optimizer is not None:
-                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-                optimizer.step(loss)
-                params = optimizer.discrete_params()
+                if isinstance(optimizer, PopulationOptimizer):
+                    optimizer.step([trial])
+                    params = optimizer.optimizers[0].discrete_params()
+                else:
+                    loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
+                    optimizer.step(loss)
+                    params = optimizer.discrete_params()
                 combine_min_ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
                 group_min_ratio = params["group_min_ratio"]
@@ -434,8 +438,12 @@ def adaptive_fp_retry(
         attempts += 1
         trial = _try({tok_l}, group_min_count, combine_min_ratio)
         if optimizer is not None:
-            optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
-            params = optimizer.discrete_params()
+            if isinstance(optimizer, PopulationOptimizer):
+                optimizer.step([trial])
+                params = optimizer.optimizers[0].discrete_params()
+            else:
+                optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
+                params = optimizer.discrete_params()
             combine_min_ratio = params["combine_min_ratio"]
             combine_mode = params["combine_mode"]
             group_min_ratio = params["group_min_ratio"]
@@ -468,9 +476,13 @@ def adaptive_fp_retry(
             ratio = min(combine_max_ratio, ratio + comb_ratio_step)
             trial = _try(set(), group_min_count, ratio)
             if optimizer is not None:
-                loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-                optimizer.step(loss)
-                params = optimizer.discrete_params()
+                if isinstance(optimizer, PopulationOptimizer):
+                    optimizer.step([trial])
+                    params = optimizer.optimizers[0].discrete_params()
+                else:
+                    loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
+                    optimizer.step(loss)
+                    params = optimizer.discrete_params()
                 ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
                 group_min_ratio = params["group_min_ratio"]
@@ -519,8 +531,12 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive"):
             trial = _try(set(), gmc, combine_min_ratio)
             if optimizer is not None:
-                optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
-                params = optimizer.discrete_params()
+                if isinstance(optimizer, PopulationOptimizer):
+                    optimizer.step([trial])
+                    params = optimizer.optimizers[0].discrete_params()
+                else:
+                    optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
+                    params = optimizer.discrete_params()
                 combine_min_ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
                 group_min_ratio = params["group_min_ratio"]
@@ -556,8 +572,12 @@ def adaptive_fp_retry(
         while attempts < fp_retries and result.get("false_positive") and high_ratio - low_ratio > 0.001:
             trial = _try(set(), group_min_count, ratio)
             if optimizer is not None:
-                optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
-                params = optimizer.discrete_params()
+                if isinstance(optimizer, PopulationOptimizer):
+                    optimizer.step([trial])
+                    params = optimizer.optimizers[0].discrete_params()
+                else:
+                    optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
+                    params = optimizer.discrete_params()
                 ratio = params["combine_min_ratio"]
                 combine_mode = params["combine_mode"]
                 group_min_ratio = params["group_min_ratio"]
@@ -776,7 +796,7 @@ def evaluate_single(
     fp_timeout: float | None = None,
     max_exclude_tokens: int = 5,
     fp_bar: tqdm | None = None,
-    optimizer: CategoricalOptimizer | None = None,
+    optimizer: CategoricalOptimizer | PopulationOptimizer | None = None,
 ) -> Dict[str, Any]:
     """Evaluate one graph/sample pair and return stats."""
 
@@ -1627,8 +1647,12 @@ def evaluate_single(
         auto_gmin=auto_group_min,
     )
     if optimizer is not None:
-        optimizer.step(result, fp_ratio_benign=result.get("fp_ratio_benign", 0.0))
-        params_init = optimizer.discrete_params()
+        if isinstance(optimizer, PopulationOptimizer):
+            optimizer.step([result])
+            params_init = optimizer.optimizers[0].discrete_params()
+        else:
+            optimizer.step(result, fp_ratio_benign=result.get("fp_ratio_benign", 0.0))
+            params_init = optimizer.discrete_params()
         _apply_params(params_init)
         combine_min_ratio = params_init["combine_min_ratio"]
         group_min_ratio = params_init["group_min_ratio"]
@@ -1991,7 +2015,7 @@ def _eval_task(
     explainer: Any | None,
     device: torch.device | None,
     fp_bar: tqdm | None = None,
-    optimizer: CategoricalOptimizer | None = None,
+    optimizer: CategoricalOptimizer | PopulationOptimizer | None = None,
     result_queue: "mp.Queue" | None = None,
 ) -> Dict[str, Any]:
     sha, gpath, spath, jpath, kwargs = task
@@ -2094,6 +2118,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=0.5,
         help="Weight for detection rate term in optimizer loss",
     )
+    p.add_argument("--pop-size", type=int, default=1, help="Population size for global search")
+    p.add_argument("--global-steps", type=int, default=0, help="Number of global optimization steps")
+    p.add_argument("--mutation-rate", type=float, default=0.1, help="Mutation rate for global search")
     p.add_argument("--explainer", type=Path, help="Explainer checkpoint")
     p.add_argument(
         "--classifier", type=Path, required=True, help="Classifier checkpoint"
@@ -2388,9 +2415,17 @@ def main(argv: list[str] | None = None) -> None:
 
     device = torch.device(args.device)
 
-    optimizer: CategoricalOptimizer | None = None
+    optimizer: CategoricalOptimizer | PopulationOptimizer | None = None
     if args.optimize:
-        optimizer = CategoricalOptimizer(beta=args.opt_beta)
+        if args.pop_size > 1 or args.global_steps > 0:
+            optimizer = PopulationOptimizer(
+                population_size=args.pop_size,
+                mutation_rate=args.mutation_rate,
+                steps=args.global_steps,
+                beta=args.opt_beta,
+            )
+        else:
+            optimizer = CategoricalOptimizer(beta=args.opt_beta)
         if args.optimizer_pkl and args.optimizer_pkl.is_file():
             try:
                 state = torch.load(args.optimizer_pkl, map_location="cpu")
@@ -2603,11 +2638,14 @@ def main(argv: list[str] | None = None) -> None:
                     if optimizer:
                         batch.append(res)
                         if len(batch) >= args.batch_size:
-                            loss = torch.stack([
-                                _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
-                                for r in batch
-                            ]).mean()
-                            optimizer.step(loss)
+                            if isinstance(optimizer, PopulationOptimizer):
+                                optimizer.step(batch)
+                            else:
+                                loss = torch.stack([
+                                    _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
+                                    for r in batch
+                                ]).mean()
+                                optimizer.step(loss)
                             batch.clear()
                     cnts = res.get("fp_token_counts_total")
                     if cnts:
@@ -2681,11 +2719,14 @@ def main(argv: list[str] | None = None) -> None:
                     if optimizer:
                         batch.append(res_left)
                 if optimizer and batch:
-                    loss = torch.stack([
-                        _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
-                        for r in batch
-                    ]).mean()
-                    optimizer.step(loss)
+                    if isinstance(optimizer, PopulationOptimizer):
+                        optimizer.step(batch)
+                    else:
+                        loss = torch.stack([
+                            _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
+                            for r in batch
+                        ]).mean()
+                        optimizer.step(loss)
         else:
             for task in tasks:
                 fp_bar.reset()

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -293,6 +293,30 @@ def test_build_parser_batch_size():
     assert args.batch_size == 4
 
 
+def test_build_parser_global_opts():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--pop-size",
+            "3",
+            "--global-steps",
+            "2",
+            "--mutation-rate",
+            "0.2",
+        ]
+    )
+    assert args.pop_size == 3
+    assert args.global_steps == 2
+    assert args.mutation_rate == 0.2
+
+
 def test_cli_runs_and_writes_json(tmp_path, caplog):
     g = HeteroData()
     g["bb"].x = torch.zeros(2, 1)


### PR DESCRIPTION
## Summary
- implement `PopulationOptimizer` in categorical optimizer module
- update rule evaluation to accept population optimizer and add options
- extend CLI parser for population parameters
- test parser handling of new population optimizer options

## Testing
- `pytest tests/test_categorical_optimizer.py::test_build_parser_optimize_args tests/test_explainer_rule_eval_cli.py::test_build_parser_global_opts -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a7d46afc832e8905050c0f224c39