### PR TITLE
Refactor adaptive_fp_retry helpers

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -309,6 +309,266 @@ def estimate_token_cache_size(cache: Mapping[Path, set[str]] | TokenCache) -> in
     return total
 
 
+@dataclass
+class RetryState:
+    """Mutable state used during ``adaptive_fp_retry``."""
+
+    result: Dict[str, Any]
+    exclude_set: set[str]
+    combine_min_ratio: float
+    combine_mode: str
+    group_min_ratio: float
+    group_min_count: int | None
+    best_result: Dict[str, Any]
+    last_detected: Dict[str, Any] | None
+
+
+def _select_exclude_tokens(
+    result: Mapping[str, Any], fp_counter: Counter[str]
+) -> tuple[list[str], list[str]]:
+    """Return sorted tokens and minimal hitting-set tokens."""
+
+    counts = result.get("fp_token_counts")
+    if counts:
+        for t, c in counts.items():
+            fp_counter[t.lower()] += int(c)
+    tokens_sorted = [
+        t for t, _ in sorted(fp_counter.items(), key=lambda x: (-x[1], x[0]))
+    ]
+    if not tokens_sorted:
+        tokens_sorted = list(result.get("fp_matched_tokens", []))
+
+    token_sets = result.get("fp_tokens_by_sample")
+    min_tokens: list[str] = []
+    if token_sets:
+        def _hitting_set(sets: Sequence[Sequence[str]]) -> list[str]:
+            remaining = [set(s) for s in sets if s]
+            selected: list[str] = []
+            while remaining:
+                counter = Counter()
+                for s in remaining:
+                    for t in s:
+                        counter[t] += 1
+                tok, _ = max(counter.items(), key=lambda x: (x[1], x[0]))
+                selected.append(tok)
+                remaining = [s for s in remaining if tok not in s]
+            return selected
+
+        min_tokens = _hitting_set(token_sets)
+        if min_tokens:
+            tokens_sorted = [
+                t for t in min_tokens + [t for t in tokens_sorted if t not in min_tokens]
+            ]
+
+    return tokens_sorted, min_tokens
+
+
+def _optimizer_step(
+    trial: Mapping[str, Any],
+    optimizer: CategoricalOptimizer | PopulationOptimizer | None,
+    param_update=None,
+) -> tuple[float, str, float] | None:
+    """Update optimizer with ``trial`` and return new parameters."""
+
+    if optimizer is None:
+        return None
+
+    if isinstance(optimizer, PopulationOptimizer):
+        optimizer.step([trial])
+        params = optimizer.optimizers[0].discrete_params()
+    else:
+        loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
+        optimizer.step(loss)
+        params = optimizer.discrete_params()
+
+    if param_update:
+        param_update(params)
+
+    return (
+        params["combine_min_ratio"],
+        params["combine_mode"],
+        params["group_min_ratio"],
+    )
+
+
+def _evaluate_and_update(
+    trial: Mapping[str, Any],
+    state: RetryState,
+    *,
+    exclude_tokens: set[str],
+    persist_fp_exclude: Path | None,
+    fp_bar: tqdm | None,
+    is_better,
+    optimizer: CategoricalOptimizer | PopulationOptimizer | None = None,
+    param_update=None,
+) -> bool:
+    """Apply ``trial`` result to ``state`` and return True if FP resolved."""
+
+    opt_res = _optimizer_step(trial, optimizer, param_update)
+    if opt_res is not None:
+        state.combine_min_ratio, state.combine_mode, state.group_min_ratio = opt_res
+
+    if fp_bar:
+        fp_bar.update(1)
+
+    if is_better(trial, state.best_result):
+        state.best_result = trial
+        if state.best_result.get("detected"):
+            state.last_detected = state.best_result
+
+    if trial.get("detected") and not trial.get("false_positive"):
+        state.result = trial
+        if exclude_tokens:
+            state.exclude_set.update(exclude_tokens)
+            if persist_fp_exclude is not None:
+                for tok in exclude_tokens:
+                    _FP_EXCLUDE_COUNTS[tok] += 1
+                    _FP_EXCLUDE_SET.add(tok)
+                _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
+        return True
+    return False
+
+
+def _adjust_thresholds(
+    _try,
+    eval_fn,
+    state: RetryState,
+    *,
+    freq_threshold: float | int,
+    num_rules: int,
+    chunk_size: int | None,
+    auto_group_min: bool,
+    comb_ratio_step: float,
+    combine_max_ratio: float,
+    fp_retries: int,
+    attempts: int,
+    fp_bar: tqdm | None,
+    is_better,
+    persist_fp_exclude: Path | None,
+    optimizer: CategoricalOptimizer | PopulationOptimizer | None = None,
+    param_update=None,
+) -> int:
+    """Relax parameters to resolve remaining false positives."""
+
+    # step through combine_min_ratio values
+    if state.result.get("false_positive") and comb_ratio_step > 0 and attempts < fp_retries:
+        ratio = state.combine_min_ratio
+        while (
+            attempts < fp_retries
+            and state.result.get("false_positive")
+            and ratio + comb_ratio_step <= combine_max_ratio + 1e-9
+        ):
+            ratio = min(combine_max_ratio, ratio + comb_ratio_step)
+            trial = _try(set(), state.group_min_count, ratio)
+            attempts += 1
+            if _evaluate_and_update(
+                trial,
+                state,
+                exclude_tokens=set(),
+                persist_fp_exclude=persist_fp_exclude,
+                fp_bar=fp_bar,
+                is_better=is_better,
+                optimizer=optimizer,
+                param_update=param_update,
+            ):
+                state.combine_min_ratio = ratio
+                return attempts
+
+    if (
+        state.result.get("false_positive")
+        and state.combine_mode != "and"
+        and attempts < fp_retries
+    ):
+        trial = eval_fn(
+            freq_threshold,
+            state.group_min_count,
+            state.combine_min_ratio,
+            group_ratio=state.group_min_ratio,
+            n_rules=num_rules,
+            c_size=chunk_size,
+            mode="and",
+            exclude=state.exclude_set,
+            auto_gmin=auto_group_min,
+        )
+        attempts += 1
+        if _evaluate_and_update(
+            trial,
+            state,
+            exclude_tokens=set(),
+            persist_fp_exclude=persist_fp_exclude,
+            fp_bar=fp_bar,
+            is_better=is_better,
+            optimizer=optimizer,
+            param_update=param_update,
+        ):
+            state.combine_mode = "and"
+            return attempts
+
+    if state.result.get("false_positive"):
+        max_match = int(state.result.get("fp_max_matches", 0))
+        low_cnt = max(state.group_min_count or 0, max_match + 1)
+        high_cnt: int | None = None
+        gmc = low_cnt
+        while attempts < fp_retries and state.result.get("false_positive"):
+            trial = _try(set(), gmc, state.combine_min_ratio)
+            attempts += 1
+            if _evaluate_and_update(
+                trial,
+                state,
+                exclude_tokens=set(),
+                persist_fp_exclude=persist_fp_exclude,
+                fp_bar=fp_bar,
+                is_better=is_better,
+                optimizer=optimizer,
+                param_update=param_update,
+            ):
+                state.group_min_count = gmc
+                return attempts
+            if trial.get("false_positive"):
+                low_cnt = gmc + 1
+                gmc = gmc * 2 if high_cnt is None else (gmc + high_cnt) // 2
+            else:
+                high_cnt = gmc - 1
+                if high_cnt < low_cnt:
+                    break
+                gmc = (low_cnt + high_cnt) // 2
+
+    if state.result.get("false_positive"):
+        max_match = int(state.result.get("fp_max_matches", 0))
+        low_ratio = state.combine_min_ratio
+        high_ratio = combine_max_ratio
+        ratio = min(high_ratio, max(low_ratio, (max_match + 1) / max(1, num_rules)))
+        if math.isclose(ratio, state.combine_min_ratio):
+            ratio = (low_ratio + high_ratio) / 2.0
+        while (
+            attempts < fp_retries
+            and state.result.get("false_positive")
+            and high_ratio - low_ratio > 0.001
+        ):
+            trial = _try(set(), state.group_min_count, ratio)
+            attempts += 1
+            if _evaluate_and_update(
+                trial,
+                state,
+                exclude_tokens=set(),
+                persist_fp_exclude=persist_fp_exclude,
+                fp_bar=fp_bar,
+                is_better=is_better,
+                optimizer=optimizer,
+                param_update=param_update,
+            ):
+                state.combine_min_ratio = ratio
+                high_ratio = ratio
+                break
+            if trial.get("false_positive"):
+                low_ratio = ratio
+            else:
+                high_ratio = ratio
+            ratio = (low_ratio + high_ratio) / 2.0
+
+    return attempts
+
+
 def adaptive_fp_retry(
     eval_fn,
     *,
@@ -341,37 +601,8 @@ def adaptive_fp_retry(
 ) -> tuple[Dict[str, Any], set[str], Dict[str, Any]]:
     start_time = time.perf_counter()
     attempts = 0
-    counts = result.get("fp_token_counts")
-    if counts:
-        for t, c in counts.items():
-            fp_token_counter[t.lower()] += int(c)
-    tokens_sorted = [t for t, _ in sorted(fp_token_counter.items(), key=lambda x: (-x[1], x[0]))]
-    if not tokens_sorted:
-        tokens_sorted = list(result.get("fp_matched_tokens", []))
 
-    token_sets = result.get("fp_tokens_by_sample")
-    min_tokens: list[str] = []
-    if token_sets:
-        def _hitting_set(sets: Sequence[Sequence[str]]) -> list[str]:
-            remaining = [set(s) for s in sets if s]
-            selected: list[str] = []
-            while remaining:
-                counter = Counter()
-                for s in remaining:
-                    for t in s:
-                        counter[t] += 1
-                tok, _ = max(counter.items(), key=lambda x: (x[1], x[0]))
-                selected.append(tok)
-                new_remaining = []
-                for s in remaining:
-                    if tok not in s:
-                        new_remaining.append(s)
-                remaining = new_remaining
-            return selected
-
-        min_tokens = _hitting_set(token_sets)
-        if min_tokens:
-            tokens_sorted = [t for t in min_tokens + [t for t in tokens_sorted if t not in min_tokens]]
+    tokens_sorted, min_tokens = _select_exclude_tokens(result, fp_token_counter)
 
     if optimizer is not None and param_update is not None:
         param_update(optimizer.discrete_params())
@@ -389,41 +620,34 @@ def adaptive_fp_retry(
             auto_gmin=auto_group_min,
         )
 
+    state = RetryState(
+        result=result,
+        exclude_set=exclude_set,
+        combine_min_ratio=combine_min_ratio,
+        combine_mode=combine_mode,
+        group_min_ratio=group_min_ratio,
+        group_min_count=group_min_count,
+        best_result=best_result,
+        last_detected=last_detected,
+    )
+
     tried_tokens: set[str] = set()
-    if min_tokens:
-        if attempts < fp_retries:
-            attempts += 1
-            excl_set = {t.lower() for t in min_tokens}
-            tried_tokens.update(excl_set)
-            trial = _try(excl_set, group_min_count, combine_min_ratio)
-            if optimizer is not None:
-                if isinstance(optimizer, PopulationOptimizer):
-                    optimizer.step([trial])
-                    params = optimizer.optimizers[0].discrete_params()
-                else:
-                    loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-                    optimizer.step(loss)
-                    params = optimizer.discrete_params()
-                combine_min_ratio = params["combine_min_ratio"]
-                combine_mode = params["combine_mode"]
-                group_min_ratio = params["group_min_ratio"]
-                if param_update:
-                    param_update(params)
-            if fp_bar:
-                fp_bar.update(1)
-            if is_better(trial, best_result):
-                best_result = trial
-                if best_result.get("detected"):
-                    last_detected = best_result
-            if trial.get("detected") and not trial.get("false_positive"):
-                exclude_set.update(excl_set)
-                result = trial
-                if persist_fp_exclude is not None:
-                    for tok in excl_set:
-                        _FP_EXCLUDE_COUNTS[tok] += 1
-                        _FP_EXCLUDE_SET.add(tok)
-                    _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
-                return result, exclude_set, best_result
+    if min_tokens and attempts < fp_retries:
+        attempts += 1
+        excl_set = {t.lower() for t in min_tokens}
+        tried_tokens.update(excl_set)
+        trial = _try(excl_set, state.group_min_count, state.combine_min_ratio)
+        if _evaluate_and_update(
+            trial,
+            state,
+            exclude_tokens=excl_set,
+            persist_fp_exclude=persist_fp_exclude,
+            fp_bar=fp_bar,
+            is_better=is_better,
+            optimizer=optimizer,
+            param_update=param_update,
+        ):
+            return state.result, state.exclude_set, state.best_result
 
     for i, tok in enumerate(tokens_sorted):
         if (
@@ -436,172 +660,39 @@ def adaptive_fp_retry(
             continue
         tok_l = tok.lower()
         attempts += 1
-        trial = _try({tok_l}, group_min_count, combine_min_ratio)
-        if optimizer is not None:
-            if isinstance(optimizer, PopulationOptimizer):
-                optimizer.step([trial])
-                params = optimizer.optimizers[0].discrete_params()
-            else:
-                optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
-                params = optimizer.discrete_params()
-            combine_min_ratio = params["combine_min_ratio"]
-            combine_mode = params["combine_mode"]
-            group_min_ratio = params["group_min_ratio"]
-            if param_update:
-                param_update(params)
-        if fp_bar:
-            fp_bar.update(1)
-        if is_better(trial, best_result):
-            best_result = trial
-            if best_result.get("detected"):
-                last_detected = best_result
-        if trial.get("detected") and not trial.get("false_positive"):
-            exclude_set.add(tok_l)
-            result = trial
-            if persist_fp_exclude is not None:
-                _FP_EXCLUDE_COUNTS[tok_l] += 1
-                _FP_EXCLUDE_SET.add(tok_l)
-                _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
+        trial = _try({tok_l}, state.group_min_count, state.combine_min_ratio)
+        if _evaluate_and_update(
+            trial,
+            state,
+            exclude_tokens={tok_l},
+            persist_fp_exclude=persist_fp_exclude,
+            fp_bar=fp_bar,
+            is_better=is_better,
+            optimizer=optimizer,
+            param_update=param_update,
+        ):
             break
 
+    attempts = _adjust_thresholds(
+        _try,
+        eval_fn,
+        state,
+        freq_threshold=freq_threshold,
+        num_rules=num_rules,
+        chunk_size=chunk_size,
+        auto_group_min=auto_group_min,
+        comb_ratio_step=comb_ratio_step,
+        combine_max_ratio=combine_max_ratio,
+        fp_retries=fp_retries,
+        attempts=attempts,
+        fp_bar=fp_bar,
+        is_better=is_better,
+        persist_fp_exclude=persist_fp_exclude,
+        optimizer=optimizer,
+        param_update=param_update,
+    )
 
-
-    if result.get("false_positive") and comb_ratio_step > 0 and attempts < fp_retries:
-        ratio = combine_min_ratio
-        while (
-            attempts < fp_retries
-            and result.get("false_positive")
-            and ratio + comb_ratio_step <= combine_max_ratio + 1e-9
-        ):
-            ratio = min(combine_max_ratio, ratio + comb_ratio_step)
-            trial = _try(set(), group_min_count, ratio)
-            if optimizer is not None:
-                if isinstance(optimizer, PopulationOptimizer):
-                    optimizer.step([trial])
-                    params = optimizer.optimizers[0].discrete_params()
-                else:
-                    loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-                    optimizer.step(loss)
-                    params = optimizer.discrete_params()
-                ratio = params["combine_min_ratio"]
-                combine_mode = params["combine_mode"]
-                group_min_ratio = params["group_min_ratio"]
-                if param_update:
-                    param_update(params)
-            attempts += 1
-            if fp_bar:
-                fp_bar.update(1)
-            if is_better(trial, best_result):
-                best_result = trial
-                if best_result.get("detected"):
-                    last_detected = best_result
-            if trial.get("detected") and not trial.get("false_positive"):
-                combine_min_ratio = ratio
-                result = trial
-                break
-
-    if result.get("false_positive") and combine_mode != "and" and attempts < fp_retries:
-        trial = eval_fn(
-            freq_threshold,
-            group_min_count,
-            combine_min_ratio,
-            group_ratio=group_min_ratio,
-            n_rules=num_rules,
-            c_size=chunk_size,
-            mode="and",
-            exclude=exclude_set,
-            auto_gmin=auto_group_min,
-        )
-        attempts += 1
-        if fp_bar:
-            fp_bar.update(1)
-        if is_better(trial, best_result):
-            best_result = trial
-            if best_result.get("detected"):
-                last_detected = best_result
-        if trial.get("detected") and not trial.get("false_positive"):
-            combine_mode = "and"
-            result = trial
-
-    if result.get("false_positive"):
-        max_match = int(result.get("fp_max_matches", 0))
-        low_cnt = max(group_min_count or 0, max_match + 1)
-        high_cnt: int | None = None
-        gmc = low_cnt
-        while attempts < fp_retries and result.get("false_positive"):
-            trial = _try(set(), gmc, combine_min_ratio)
-            if optimizer is not None:
-                if isinstance(optimizer, PopulationOptimizer):
-                    optimizer.step([trial])
-                    params = optimizer.optimizers[0].discrete_params()
-                else:
-                    optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
-                    params = optimizer.discrete_params()
-                combine_min_ratio = params["combine_min_ratio"]
-                combine_mode = params["combine_mode"]
-                group_min_ratio = params["group_min_ratio"]
-                if param_update:
-                    param_update(params)
-            attempts += 1
-            if fp_bar:
-                fp_bar.update(1)
-            if is_better(trial, best_result):
-                best_result = trial
-                if best_result.get("detected"):
-                    last_detected = best_result
-            if trial.get("detected") and not trial.get("false_positive"):
-                group_min_count = gmc
-                result = trial
-                break
-            if trial.get("false_positive"):
-                low_cnt = gmc + 1
-                gmc = gmc * 2 if high_cnt is None else (gmc + high_cnt) // 2
-            else:
-                high_cnt = gmc - 1
-                if high_cnt < low_cnt:
-                    break
-                gmc = (low_cnt + high_cnt) // 2
-
-    if result.get("false_positive"):
-        max_match = int(result.get("fp_max_matches", 0))
-        low_ratio = combine_min_ratio
-        high_ratio = combine_max_ratio
-        ratio = min(high_ratio, max(low_ratio, (max_match + 1) / max(1, num_rules)))
-        if math.isclose(ratio, combine_min_ratio):
-            ratio = (low_ratio + high_ratio) / 2.0
-        while attempts < fp_retries and result.get("false_positive") and high_ratio - low_ratio > 0.001:
-            trial = _try(set(), group_min_count, ratio)
-            if optimizer is not None:
-                if isinstance(optimizer, PopulationOptimizer):
-                    optimizer.step([trial])
-                    params = optimizer.optimizers[0].discrete_params()
-                else:
-                    optimizer.step(trial, fp_ratio_benign=trial.get("fp_ratio_benign", 0.0))
-                    params = optimizer.discrete_params()
-                ratio = params["combine_min_ratio"]
-                combine_mode = params["combine_mode"]
-                group_min_ratio = params["group_min_ratio"]
-                if param_update:
-                    param_update(params)
-            attempts += 1
-            if fp_bar:
-                fp_bar.update(1)
-            if is_better(trial, best_result):
-                best_result = trial
-                if best_result.get("detected"):
-                    last_detected = best_result
-            if trial.get("detected") and not trial.get("false_positive"):
-                combine_min_ratio = ratio
-                result = trial
-                high_ratio = ratio
-                break
-            if trial.get("false_positive"):
-                low_ratio = ratio
-            else:
-                high_ratio = ratio
-            ratio = (low_ratio + high_ratio) / 2.0
-
-    return result, exclude_set, best_result
+    return state.result, state.exclude_set, state.best_result
 
 
 def verify_features(

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2891,3 +2891,53 @@ def test_adaptive_fp_retry_token_index_profile(tmp_path, monkeypatch):
 
     assert with_index < no_index
 
+
+def test_select_exclude_tokens_hitting_set():
+    from collections import Counter
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    result = {
+        "fp_token_counts": {"aa": 3, "bb": 1},
+        "fp_tokens_by_sample": [["aa", "cc"], ["bb", "cc"]],
+        "fp_matched_tokens": ["aa", "bb", "cc"],
+    }
+
+    tokens_sorted, min_tokens = mod._select_exclude_tokens(result, Counter())
+
+    assert min_tokens == ["cc"]
+    assert tokens_sorted[0] == "cc"
+
+
+def test_evaluate_and_update(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    state = mod.RetryState(
+        result={"false_positive": True},
+        exclude_set=set(),
+        combine_min_ratio=0.7,
+        combine_mode="or",
+        group_min_ratio=0.0,
+        group_min_count=None,
+        best_result={"detected": False, "false_positive": True},
+        last_detected=None,
+    )
+
+    trial = {"detected": True, "false_positive": False}
+    persist = tmp_path / "ex.json"
+
+    success = mod._evaluate_and_update(
+        trial,
+        state,
+        exclude_tokens={"tok"},
+        persist_fp_exclude=persist,
+        fp_bar=None,
+        is_better=lambda n, c: True,
+    )
+
+    assert success is True
+    assert state.result.get("detected") is True
+    assert "tok" in state.exclude_set
+    data = json.loads(persist.read_text())
+    assert "tok" in data
+
+


### PR DESCRIPTION
## Summary
- modularize `adaptive_fp_retry` via `RetryState` dataclass
- add helper utilities `_select_exclude_tokens`, `_optimizer_step`, `_evaluate_and_update`, `_adjust_thresholds`
- update tests for new helpers

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_select_exclude_tokens_hitting_set tests/test_explainer_rule_eval_cli.py::test_evaluate_and_update -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ab82af80832e9a13a844f8e096e7