### PR TITLE
Enable batch updates for optimizer

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -93,12 +93,24 @@ class CategoricalOptimizer:
     # ------------------------------------------------------------------
     def step(
         self,
-        trial_or_loss: torch.Tensor | float | Mapping[str, Any],
+        trial_or_loss: torch.Tensor | float | Mapping[str, Any] | Sequence[Mapping[str, Any]],
         fp_ratio_benign: float = 0.0,
     ) -> None:
+        """Perform one optimizer step.
+
+        ``trial_or_loss`` may be a loss ``Tensor``/``float`` or a result mapping
+        from :func:`evaluate_single`.  When a sequence of mappings is provided,
+        the mean loss over the batch is used for the update.
+        """
+
+        from collections.abc import Sequence
         from .explainer_rule_eval import _optimizer_loss
 
-        if isinstance(trial_or_loss, Mapping):
+        if isinstance(trial_or_loss, Mapping) or (
+            isinstance(trial_or_loss, Sequence)
+            and trial_or_loss
+            and isinstance(trial_or_loss[0], Mapping)
+        ):
             loss = _optimizer_loss(trial_or_loss, self, fp_ratio_benign, beta=self.beta)
         else:
             loss = trial_or_loss

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -96,7 +96,7 @@ def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
 # ---------------------------------------------------------------------------
 
 def _optimizer_loss(
-    trial: Mapping[str, Any],
+    trial: Mapping[str, Any] | Sequence[Mapping[str, Any]],
     opt: CategoricalOptimizer,
     fp_ratio_benign: float = 0.0,
     beta: float | None = None,
@@ -104,8 +104,26 @@ def _optimizer_loss(
     """Return differentiable loss for optimizer step.
 
     ``fp_ratio_benign`` scales the penalty for false positives so that a higher
-    false-positive rate over the benign set yields a larger loss.
+    false-positive rate over the benign set yields a larger loss. When
+    ``trial`` is a sequence of result mappings the average loss over the batch
+    is returned.
     """
+    from collections.abc import Sequence
+
+    if isinstance(trial, Sequence) and trial and not isinstance(trial, Mapping):
+        fp_ratio_benign = float(
+            sum(t.get("fp_ratio_benign", fp_ratio_benign) for t in trial) / len(trial)
+        )
+        fp_avg = sum(float(t.get("false_positive", False)) for t in trial) / len(trial)
+        tp_avg = sum(float(t.get("detected", False)) for t in trial) / len(trial)
+        base = trial[0]
+        trial = {
+            "false_positive": fp_avg,
+            "detected": tp_avg,
+            "condition_type": base.get("condition_type", "any"),
+            "combine_mode": base.get("combine_mode", "or"),
+        }
+
     fp = torch.tensor(float(trial.get("false_positive", False)), device=opt.condition_type_logits.device)
     tp = torch.tensor(float(trial.get("detected", False)), device=opt.condition_type_logits.device)
 
@@ -2729,14 +2747,7 @@ def main(argv: list[str] | None = None) -> None:
                     if optimizer:
                         batch.append(res)
                         if len(batch) >= args.batch_size:
-                            if isinstance(optimizer, PopulationOptimizer):
-                                optimizer.step(batch)
-                            else:
-                                loss = torch.stack([
-                                    _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
-                                    for r in batch
-                                ]).mean()
-                                optimizer.step(loss)
+                            optimizer.step(batch)
                             batch.clear()
                     cnts = res.get("fp_token_counts_total")
                     if cnts:
@@ -2810,15 +2821,9 @@ def main(argv: list[str] | None = None) -> None:
                     if optimizer:
                         batch.append(res_left)
                 if optimizer and batch:
-                    if isinstance(optimizer, PopulationOptimizer):
-                        optimizer.step(batch)
-                    else:
-                        loss = torch.stack([
-                            _optimizer_loss(r, optimizer, r.get("fp_ratio_benign", 0.0))
-                            for r in batch
-                        ]).mean()
-                        optimizer.step(loss)
+                    optimizer.step(batch)
         else:
+            batch: list[dict[str, Any]] = []
             for task in tasks:
                 fp_bar.reset()
                 sha, gpath, spath, jpath, kw = task
@@ -2835,12 +2840,17 @@ def main(argv: list[str] | None = None) -> None:
                     explainer,
                     device,
                     fp_bar=fp_bar,
-                    optimizer=optimizer,
+                    optimizer=None,
                 )
                 sha = task[0]
 
                 res["sha256"] = sha
                 results.append(res)
+                if optimizer:
+                    batch.append(res)
+                    if len(batch) >= args.batch_size:
+                        optimizer.step(batch)
+                        batch.clear()
                 cnts = res.get("fp_token_counts_total")
                 if cnts:
                     fp_token_counter_all.update({k.lower(): int(v) for k, v in cnts.items()})
@@ -2899,6 +2909,8 @@ def main(argv: list[str] | None = None) -> None:
                             rule_txt, encoding="utf-8"
                         )
 
+            if optimizer and batch:
+                optimizer.step(batch)
         graph_bar.close()
         fp_bar.close()
         df = pd.DataFrame(results)


### PR DESCRIPTION
## Summary
- extend `_optimizer_loss` to handle lists and aggregate stats
- update `CategoricalOptimizer.step` to accept batches
- run optimizer steps on result batches in `main`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6888ade75de0832e964cf1a1a1b0c298