### PR TITLE
Ensure FP exclude updates are locked

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ tqdm>=4.66
 networkx>=3.0
 joblib>=1.3
 psutil>=5.9
+filelock>=3.12
 
 # ───────── Config / CLI ─────────
 omegaconf>=2.3

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -31,6 +31,7 @@ import multiprocessing as mp
 
 from rulegen.feature_miner import FeatureMiner
 from rulegen.yara_builder import YaraBuilder
+from filelock import FileLock
 
 LOGGER = get_logger(__name__)
 
@@ -79,14 +80,23 @@ def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
     """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        merged = _load_fp_exclude(path)
-        for k, v in tokens.items():
-            merged[k.lower()] += int(v)
-        data = {k: int(v) for k, v in sorted(merged.items(), key=lambda x: (-x[1], x[0]))}
-        path.write_text(
-            json.dumps(data, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+        lock_path = path.with_suffix(path.suffix + ".lock")
+        lock = FileLock(str(lock_path))
+        lock.acquire()
+        try:
+            merged = _load_fp_exclude(path)
+            for k, v in tokens.items():
+                merged[k.lower()] += int(v)
+            data = {
+                k: int(v)
+                for k, v in sorted(merged.items(), key=lambda x: (-x[1], x[0]))
+            }
+            path.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        finally:
+            lock.release()
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Failed to write %s: %s", path, exc)
 

--- a/tests/test_fp_exclude_persist.py
+++ b/tests/test_fp_exclude_persist.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from concurrent.futures import ProcessPoolExecutor
+
 from src.cli.explainer_rule_eval import _save_fp_exclude, _load_fp_exclude
 
 
@@ -16,3 +18,24 @@ def test_save_and_load_fp_exclude(tmp_path):
 
     data = json.loads(fp.read_text())
     assert list(data.keys()) == ["a", "b", "c"]
+
+
+def _worker(args):
+    fp, tokens = args
+    _save_fp_exclude(Path(fp), tokens)
+
+
+def test_fp_exclude_concurrent(tmp_path):
+    fp = tmp_path / "tokens.json"
+    inputs = [
+        (str(fp), {"a": 1}),
+        (str(fp), {"b": 1}),
+        (str(fp), {"c": 1}),
+        (str(fp), {"a": 2}),
+    ]
+
+    with ProcessPoolExecutor(max_workers=4) as exe:
+        list(exe.map(_worker, inputs))
+
+    counts = _load_fp_exclude(fp)
+    assert counts == {"a": 3, "b": 1, "c": 1}


### PR DESCRIPTION
## Summary
- serialize FP exclude writes using `FileLock`
- add `filelock` dependency
- test concurrent `_save_fp_exclude` calls

## Testing
- `pytest tests/test_fp_exclude_persist.py::test_fp_exclude_concurrent -q`
- `pytest tests/test_fp_exclude_persist.py::test_save_and_load_fp_exclude -q`


------
https://chatgpt.com/codex/tasks/task_e_6888b0970ff4832e914aa1dc581d1285