### PR TITLE
Fix file lock usage

### DIFF
--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -81,9 +81,7 @@ def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         lock_path = path.with_suffix(path.suffix + ".lock")
-        lock = FileLock(str(lock_path))
-        lock.acquire()
-        try:
+        with FileLock(str(lock_path)):
             merged = _load_fp_exclude(path)
             for k, v in tokens.items():
                 merged[k.lower()] += int(v)
@@ -95,8 +93,6 @@ def _save_fp_exclude(path: Path, tokens: Mapping[str, int]) -> None:
                 json.dumps(data, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
-        finally:
-            lock.release()
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Failed to write %s: %s", path, exc)
 


### PR DESCRIPTION
## Summary
- improve fp exclude persistence

## Testing
- `pytest tests/test_fp_exclude_persist.py::test_save_and_load_fp_exclude -q`
- `pytest tests/test_fp_exclude_persist.py::test_fp_exclude_concurrent -q`


------
https://chatgpt.com/codex/tasks/task_e_6888b443a0d0832eb030b62862a88f48