### PR TITLE
Implement multi-step population optimization

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -188,34 +188,40 @@ class PopulationOptimizer:
     # ------------------------------------------------------------------
     def step(self, results: list[Mapping[str, Any]]) -> None:
         from .explainer_rule_eval import _optimizer_loss
+
         losses: list[float] = []
         for opt, res in zip(self.optimizers, results):
             loss = _optimizer_loss(res, opt, res.get("fp_ratio_benign", 0.0))
             opt.step(loss)
             losses.append(float(loss.item()))
 
-        # selection
+        # selection based on current generation losses
         order = sorted(range(len(losses)), key=lambda i: losses[i])
         parents = [self.optimizers[i] for i in order[: max(1, len(order) // 2)]]
 
         import random
 
-        new_opts: list[CategoricalOptimizer] = []
-        while len(new_opts) < self.population_size:
-            parent1 = random.choice(parents)
-            parent2 = random.choice(parents)
-            child_params = parent1.discrete_params()
-            other = parent2.discrete_params()
-            for k in child_params.keys():
-                if random.random() < self.crossover_rate:
-                    child_params[k] = other[k]
-            if random.random() < self.mutation_rate:
-                key = random.choice(list(child_params.keys()))
-                self._mutate_param(child_params, key)
-            child = CategoricalOptimizer(beta=parent1.beta)
-            child.load_discrete_params(child_params)
-            new_opts.append(child)
-        self.optimizers = new_opts
+        current = parents
+        steps = max(1, int(self.steps))
+        for _ in range(steps):
+            new_opts: list[CategoricalOptimizer] = []
+            while len(new_opts) < self.population_size:
+                parent1 = random.choice(current)
+                parent2 = random.choice(current)
+                child_params = parent1.discrete_params()
+                other = parent2.discrete_params()
+                for k in child_params.keys():
+                    if random.random() < self.crossover_rate:
+                        child_params[k] = other[k]
+                if random.random() < self.mutation_rate:
+                    key = random.choice(list(child_params.keys()))
+                    self._mutate_param(child_params, key)
+                child = CategoricalOptimizer(beta=parent1.beta)
+                child.load_discrete_params(child_params)
+                new_opts.append(child)
+            current = new_opts
+
+        self.optimizers = current
 
     # ------------------------------------------------------------------
     @staticmethod

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -205,3 +205,68 @@ def test_optimizer_loss_fp_ratio_weight():
 
     assert high > low
 
+
+def test_cli_global_steps_multiple_generations(tmp_path, monkeypatch):
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    calls: list[str] = []
+
+    def record_mutate(params: dict, key: str) -> None:
+        calls.append(key)
+
+    monkeypatch.setattr(mod.PopulationOptimizer, "_mutate_param", staticmethod(record_mutate))
+
+    def fake_eval(*a, optimizer=None, **k):
+        trial = {"detected": True, "condition_type": "any", "combine_mode": "or"}
+        if optimizer is not None:
+            from src.cli.explainer_rule_eval import _optimizer_step
+            _optimizer_step(trial, optimizer)
+        return trial
+
+    monkeypatch.setattr(mod, "evaluate_single", fake_eval)
+
+    mod.main(
+        [
+            "--graph",
+            str(gpath),
+            "--sample",
+            str(sample),
+            "--saliency",
+            str(salpath),
+            "--classifier",
+            str(sample),
+            "--optimize",
+            "--pop-size",
+            "2",
+            "--global-steps",
+            "3",
+            "--mutation-rate",
+            "1.0",
+        ]
+    )
+
+    assert len(calls) == 6
+


### PR DESCRIPTION
## Summary
- repeat crossover/mutation for `PopulationOptimizer` according to configured steps
- verify `--global-steps` triggers multiple generation updates via CLI

## Testing
- `pytest tests/test_categorical_optimizer.py::test_cli_global_steps_multiple_generations -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b44296a0832ea5aea73f3e4794af