### PR TITLE
Add local optimization to population optimizer

### DIFF
--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -160,14 +160,16 @@ class PopulationOptimizer:
         mutation_rate: float = 0.1,
         crossover_rate: float = 0.5,
         steps: int = 1,
+        local_steps: int = 1,
         beta: float = 0.5,
     ) -> None:
         self.population_size = max(1, population_size)
         self.mutation_rate = mutation_rate
         self.crossover_rate = crossover_rate
         self.steps = steps
+        self.local_steps = max(1, int(local_steps))
         self.optimizers = [CategoricalOptimizer(beta=beta) for _ in range(self.population_size)]
-
+        self.best_index = 0
     # ------------------------------------------------------------------
     def state_dict(self) -> dict:
         return {
@@ -175,6 +177,7 @@ class PopulationOptimizer:
             "mutation_rate": self.mutation_rate,
             "crossover_rate": self.crossover_rate,
             "steps": self.steps,
+            "local_steps": self.local_steps,
         }
 
     def load_state_dict(self, state: dict) -> None:
@@ -184,6 +187,7 @@ class PopulationOptimizer:
         self.mutation_rate = float(state.get("mutation_rate", self.mutation_rate))
         self.crossover_rate = float(state.get("crossover_rate", self.crossover_rate))
         self.steps = int(state.get("steps", self.steps))
+        self.local_steps = int(state.get("local_steps", self.local_steps))
 
     # ------------------------------------------------------------------
     def step(self, results: list[Mapping[str, Any]]) -> None:
@@ -194,6 +198,12 @@ class PopulationOptimizer:
             loss = _optimizer_loss(res, opt, res.get("fp_ratio_benign", 0.0))
             opt.step(loss)
             losses.append(float(loss.item()))
+
+        if losses:
+            self.best_index = int(sorted(range(len(losses)), key=lambda i: losses[i])[0])
+            best_result = results[self.best_index]
+        else:
+            best_result = {}
 
         # selection based on current generation losses
         order = sorted(range(len(losses)), key=lambda i: losses[i])
@@ -221,7 +231,20 @@ class PopulationOptimizer:
                 new_opts.append(child)
             current = new_opts
 
+        # local optimization on new population using best result
+        if best_result:
+            for opt in current:
+                for _ in range(self.local_steps):
+                    loss = _optimizer_loss(best_result, opt, best_result.get("fp_ratio_benign", 0.0))
+                    opt.step(loss)
+
         self.optimizers = current
+
+    # ------------------------------------------------------------------
+    def best_discrete_params(self) -> dict[str, object]:
+        if not self.optimizers:
+            return CategoricalOptimizer().discrete_params()
+        return self.optimizers[self.best_index].discrete_params()
 
     # ------------------------------------------------------------------
     @staticmethod

--- a/src/cli/explainer_rule_eval.py
+++ b/src/cli/explainer_rule_eval.py
@@ -1042,7 +1042,10 @@ def evaluate_single(
         combine_min_ratio = params.get("combine_min_ratio", combine_min_ratio)
 
     if optimizer is not None:
-        _apply_params(optimizer.discrete_params())
+        if isinstance(optimizer, PopulationOptimizer):
+            _apply_params(optimizer.best_discrete_params())
+        else:
+            _apply_params(optimizer.discrete_params())
 
     def _build_and_eval(
         freq_thresh: float | int,
@@ -1763,8 +1766,10 @@ def evaluate_single(
     )
     if optimizer is not None:
         if isinstance(optimizer, PopulationOptimizer):
+            best_opt = optimizer.optimizers[optimizer.best_index]
+            best_opt.step(result, fp_ratio_benign=result.get("fp_ratio_benign", 0.0))
             optimizer.step([result])
-            params_init = optimizer.optimizers[0].discrete_params()
+            params_init = optimizer.best_discrete_params()
         else:
             optimizer.step(result, fp_ratio_benign=result.get("fp_ratio_benign", 0.0))
             params_init = optimizer.discrete_params()

--- a/tests/test_categorical_optimizer.py
+++ b/tests/test_categorical_optimizer.py
@@ -270,3 +270,20 @@ def test_cli_global_steps_multiple_generations(tmp_path, monkeypatch):
 
     assert len(calls) == 6
 
+
+def test_population_optimizer_local_steps(monkeypatch):
+    mod = importlib.import_module("src.cli.categorical_optimizer")
+
+    calls: list[int] = []
+
+    def record_step(self, *a, **k):
+        calls.append(id(self))
+
+    monkeypatch.setattr(mod.CategoricalOptimizer, "step", record_step)
+
+    pop = mod.PopulationOptimizer(population_size=3, steps=1, local_steps=2)
+    result = {"detected": True, "false_positive": False, "fp_ratio_benign": 0.0}
+    pop.step([result] * 3)
+
+    assert len(calls) == 3 + 3 * 2
+


### PR DESCRIPTION
## Summary
- allow PopulationOptimizer to run local `CategoricalOptimizer.step` for each new individual
- expose best parameters from the population for evaluation
- update `evaluate_single` to use the best individual's parameters and step it before global update
- test that local steps run for the population

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888b91b8cb4832e82fdf2e1ce788c81