### PR TITLE
Fix missing import in explainer CLI

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -22,6 +22,7 @@ from .evaluation import (
     TokenCache,
     _cache_version_info,
     _load_clean_cache,
+    extract_json_tokens,
 )
 from .optimizer_utils import CategoricalOptimizer, PopulationOptimizer
 


### PR DESCRIPTION
## Summary
- expose `extract_json_tokens` from `evaluation.py` in CLI
- verify the CLI loads successfully

## Testing
- `python -m src.cli.explainer_rule_eval --help | head -n 2`
- `python - <<'PY'
from src.cli.explainer_rule_eval.cli import extract_json_tokens
print('result', extract_json_tokens({'foo': 'bar'}))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6888d10ad800832eada9e08180954601