### PR TITLE
Fix missing fp_token_utils import in CLI

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -24,6 +24,7 @@ from .evaluation import (
     _load_clean_cache,
     extract_json_tokens,
 )
+from .fp_token_utils import estimate_token_cache_size, _save_clean_cache
 from .optimizer_utils import CategoricalOptimizer, PopulationOptimizer
 
 LOGGER = get_logger(__name__)


### PR DESCRIPTION
## Summary
- fix missing import for estimate_token_cache_size and _save_clean_cache in `cli.py`

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_estimate_token_cache_size -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d605939c832ebccda03810cd5df6