### PR TITLE
Fix import for explainer_rule_eval CLI

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -5,6 +5,7 @@ import json
 import os
 import pickle
 import logging
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, Sequence, Mapping
 


### PR DESCRIPTION
## Summary
- add missing tempfile import

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py -k test_build_parser_fp_retries -q`
- `pytest -k build_parser -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888dbab56a0832eaf3837e2c59c693c