### PR TITLE
Add imports to explainer CLI

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -9,6 +9,9 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Sequence, Mapping
 
+from collections import Counter
+from rulegen.yara_builder import YaraBuilder
+
 import torch
 from tqdm.auto import tqdm
 from src.common.utils import get_logger, tqdm_wrap, human_bytes


### PR DESCRIPTION
## Summary
- ensure `Counter` and `YaraBuilder` are imported in explainer rule eval CLI

## Testing
- `pytest tests/test_yara_builder_combine_rules.py tests/test_yara_builder_prefix_strip.py tests/test_yara_builder_percentage.py -q`
- `python -m py_compile src/cli/explainer_rule_eval/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6888e01f62f4832e983963efd5ecc947