### PR TITLE
Fix missing import for saliency worker

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -20,6 +20,7 @@ from .evaluation import (
     evaluate_single,
     adaptive_fp_retry,
     _init_worker,
+    _init_saliency_worker,
     _eval_task,
     _saliency_task,
     compute_dynamic_group_min_count,


### PR DESCRIPTION
## Summary
- update evaluation imports for saliency worker

## Testing
- `pytest -q` *(fails: 66 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6888e4955368832e817f2a313919b5f5