### PR TITLE
Fix as_completed import in explainer CLI

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -535,7 +535,12 @@ def main(argv: list[str] | None = None) -> None:
         fp_bar = tqdm(total=args.fp_retries or 1, desc="fp retries", unit="try", position=1, leave=True)
 
         import multiprocessing as mp
-        from concurrent.futures import ProcessPoolExecutor, wait, FIRST_COMPLETED
+        from concurrent.futures import (
+            ProcessPoolExecutor,
+            wait,
+            FIRST_COMPLETED,
+            as_completed,
+        )
 
         sal_dir = args.precomputed_saliency_dir or Path(tempfile.mkdtemp(prefix="saliency_"))
         sal_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- fix NameError in `explainer_rule_eval` CLI by importing `as_completed`

## Testing
- `pytest -k test_fp_exclude_persist -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888e69003a0832ea75d1d5010c44b09