### PR TITLE
Fix _adjust_thresholds parameter order

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -323,6 +323,8 @@ def _evaluate_and_update(
 
 
 def _adjust_thresholds(
+    _try,
+    eval_fn,
     state: RetryState,
     *,
     freq_threshold: float | int,


### PR DESCRIPTION
## Summary
- include `_try` and `eval_fn` parameters in `_adjust_thresholds`

## Testing
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6888e9b2566c832e8cb342ab5864ef00