### PR TITLE
Fix optimizer step reference

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -26,7 +26,7 @@ import torch
 from torch_geometric.data import HeteroData
 from src.graphs.dataset.graph_dataset import GraphDataset
 from src.cli.categorical_optimizer import CategoricalOptimizer, PopulationOptimizer
-from .optimizer_utils import _optimizer_loss, _optimizer_step
+from . import optimizer_utils
 import torch.nn.functional as F
 from .fp_token_utils import (TokenCache, _load_fp_exclude, _save_fp_exclude, estimate_token_cache_size, _load_token_index, _cache_version_info, _load_clean_cache, _save_clean_cache, _FP_EXCLUDE_COUNTS, _FP_EXCLUDE_SET, _FP_EXCLUDE_PATH)
 import multiprocessing as mp
@@ -256,32 +256,6 @@ def _select_exclude_tokens(
     return tokens_sorted, min_tokens
 
 
-def _optimizer_step(
-    trial: Mapping[str, Any],
-    optimizer: CategoricalOptimizer | PopulationOptimizer | None,
-    param_update=None,
-) -> tuple[float, str, float] | None:
-    """Update optimizer with ``trial`` and return new parameters."""
-
-    if optimizer is None:
-        return None
-
-    if isinstance(optimizer, PopulationOptimizer):
-        optimizer.step([trial])
-        params = optimizer.optimizers[0].discrete_params()
-    else:
-        loss = _optimizer_loss(trial, optimizer, trial.get("fp_ratio_benign", 0.0))
-        optimizer.step(loss)
-        params = optimizer.discrete_params()
-
-    if param_update:
-        param_update(params)
-
-    return (
-        params["combine_min_ratio"],
-        params["combine_mode"],
-        params["group_min_ratio"],
-    )
 
 
 def _evaluate_and_update(
@@ -297,7 +271,7 @@ def _evaluate_and_update(
 ) -> bool:
     """Apply ``trial`` result to ``state`` and return True if FP resolved."""
 
-    opt_res = _optimizer_step(trial, optimizer, param_update)
+    opt_res = optimizer_utils._optimizer_step(trial, optimizer, param_update)
     if opt_res is not None:
         state.combine_min_ratio, state.combine_mode, state.group_min_ratio = opt_res
 


### PR DESCRIPTION
## Summary
- clean up optimizer step handling by importing from optimizer_utils
- remove duplicate `_optimizer_step` implementation
- call `optimizer_utils._optimizer_step` within evaluation

## Testing
- `pytest tests/test_categorical_optimizer.py::test_evaluate_single_updates_optimizer -q` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_6888f584796c832eb2019990e395cf0b