### PR TITLE
Improve FP retry with cached tokens

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -9,7 +9,7 @@ import importlib
 import pickle
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Sequence, Mapping, Set
+from typing import Any, Dict, Sequence, Mapping, Set, Callable
 from collections import Counter, defaultdict
 import math
 import re
@@ -340,6 +340,7 @@ def _adjust_thresholds(
     persist_fp_exclude: Path | None,
     optimizer: CategoricalOptimizer | PopulationOptimizer | None = None,
     param_update=None,
+    set_clean_paths: Callable[[Sequence[Path] | None], None] | None = None,
 ) -> int:
     """Relax parameters to resolve remaining false positives."""
 
@@ -353,6 +354,8 @@ def _adjust_thresholds(
         ):
             ratio = min(combine_max_ratio, ratio + comb_ratio_step)
             trial = _try(set(), state.group_min_count, ratio)
+            if set_clean_paths and trial.get("fp_samples"):
+                set_clean_paths([Path(p) for p in trial["fp_samples"]])
             attempts += 1
             if _evaluate_and_update(
                 trial,
@@ -383,6 +386,8 @@ def _adjust_thresholds(
             exclude=state.exclude_set,
             auto_gmin=auto_group_min,
         )
+        if set_clean_paths and trial.get("fp_samples"):
+            set_clean_paths([Path(p) for p in trial["fp_samples"]])
         attempts += 1
         if _evaluate_and_update(
             trial,
@@ -404,6 +409,8 @@ def _adjust_thresholds(
         gmc = low_cnt
         while attempts < fp_retries and state.result.get("false_positive"):
             trial = _try(set(), gmc, state.combine_min_ratio)
+            if set_clean_paths and trial.get("fp_samples"):
+                set_clean_paths([Path(p) for p in trial["fp_samples"]])
             attempts += 1
             if _evaluate_and_update(
                 trial,
@@ -439,6 +446,8 @@ def _adjust_thresholds(
             and high_ratio - low_ratio > 0.001
         ):
             trial = _try(set(), state.group_min_count, ratio)
+            if set_clean_paths and trial.get("fp_samples"):
+                set_clean_paths([Path(p) for p in trial["fp_samples"]])
             attempts += 1
             if _evaluate_and_update(
                 trial,
@@ -492,11 +501,15 @@ def adaptive_fp_retry(
     last_detected: Dict[str, Any] | None,
     optimizer: CategoricalOptimizer | PopulationOptimizer | None = None,
     param_update=None,
+    set_clean_paths: Callable[[Sequence[Path] | None], None] | None = None,
 ) -> tuple[Dict[str, Any], set[str], Dict[str, Any]]:
     start_time = time.perf_counter()
     attempts = 0
 
     tokens_sorted, min_tokens = _select_exclude_tokens(result, fp_token_counter)
+
+    if set_clean_paths and result.get("fp_samples"):
+        set_clean_paths([Path(p) for p in result["fp_samples"]])
 
     if optimizer is not None and param_update is not None:
         param_update(optimizer.discrete_params())
@@ -531,6 +544,8 @@ def adaptive_fp_retry(
         excl_set = {t.lower() for t in min_tokens}
         tried_tokens.update(excl_set)
         trial = _try(excl_set, state.group_min_count, state.combine_min_ratio)
+        if set_clean_paths and trial.get("fp_samples"):
+            set_clean_paths([Path(p) for p in trial["fp_samples"]])
         if _evaluate_and_update(
             trial,
             state,
@@ -555,6 +570,8 @@ def adaptive_fp_retry(
         tok_l = tok.lower()
         attempts += 1
         trial = _try({tok_l}, state.group_min_count, state.combine_min_ratio)
+        if set_clean_paths and trial.get("fp_samples"):
+            set_clean_paths([Path(p) for p in trial["fp_samples"]])
         if _evaluate_and_update(
             trial,
             state,
@@ -584,6 +601,7 @@ def adaptive_fp_retry(
         persist_fp_exclude=persist_fp_exclude,
         optimizer=optimizer,
         param_update=param_update,
+        set_clean_paths=set_clean_paths,
     )
 
     return state.result, state.exclude_set, state.best_result
@@ -899,6 +917,21 @@ def evaluate_single(
     else:
         total_benign = len(token_cache.tokens)
 
+    cur_clean_paths = clean_paths
+    cur_total_benign = total_benign
+
+    def _set_clean_paths(paths: Sequence[Path] | None) -> None:
+        nonlocal cur_clean_paths, cur_total_benign
+        cur_clean_paths = paths
+        if paths is not None:
+            cur_total_benign = len(list(paths))
+        elif clean_dir is not None and clean_dir.is_dir():
+            cur_total_benign = len([p for p in clean_dir.iterdir() if p.is_file()])
+        elif clean_sample is not None:
+            cur_total_benign = 1
+        else:
+            cur_total_benign = len(token_cache.tokens)
+
     def _apply_params(params: dict[str, object]) -> None:
         nonlocal condition_type, combine_mode, dynamic_k, auto_relax, adjust_group_percentage, group_min_ratio, combine_min_ratio
         condition_type = params.get("condition_type", condition_type)
@@ -1168,7 +1201,7 @@ def evaluate_single(
 
             if json_match:
 
-                def _check_json(p: Path | None) -> tuple[list[str], int] | None:
+                def _check_json(p: Path | None) -> tuple[list[str], int, list[Path]] | None:
                     if token_cache.index and p is None:
                         cand: Set[Path] | None = None
                         matched: list[str] = []
@@ -1184,6 +1217,7 @@ def evaluate_single(
                         if not cand:
                             return None
                         count = 0
+                        matched_paths: list[Path] = []
                         for cp in cand:
                             toks_set = token_cache.tokens.get(cp)
                             if toks_set is None:
@@ -1207,7 +1241,8 @@ def evaluate_single(
                             )
                             if ok:
                                 count += 1
-                        return (matched, count) if count > 0 else None
+                                matched_paths.append(cp)
+                        return (matched, count, matched_paths) if count > 0 else None
                     if p is None:
                         return None
                     toks_set = token_cache.tokens.get(p)
@@ -1223,22 +1258,23 @@ def evaluate_single(
                         saliency_stats=saliency_stats,
                         return_matched=True,
                     )
-                    return (mt, 1) if ok else None
+                    return (mt, 1, [p]) if ok else None
 
                 fp_tokens_set: set[str] = set()
                 fp_match_counts: list[int] = []
                 fp_tokens_samples: list[list[str]] = []
-                fp_tokens_samples: list[list[str]] = []
+                fp_sample_paths: list[str] = []
                 if token_cache.index:
                     res = _check_json(None)
                     fp = res is not None
                     if res is not None:
-                        toks, count = res
+                        toks, count, paths = res
                         toks_sorted = sorted(set(toks))
                         fp_tokens_set.update(toks_sorted)
                         fp_match_counts.extend([_max_group_count(toks_sorted)] * count)
                         for _ in range(count):
                             fp_tokens_samples.append(toks_sorted)
+                        fp_sample_paths.extend(str(p) for p in paths)
                 elif clean_dir is not None and clean_dir.is_dir():
                     files = [p for p in clean_dir.iterdir() if p.is_file()]
                     if fp_scan_workers > 1 and len(files) > 1:
@@ -1252,38 +1288,41 @@ def evaluate_single(
                                 res = fut.result()
                                 if res is not None:
                                     fp = True
-                                    toks, count = res
+                                    toks, count, paths = res
                                     toks_sorted = sorted(set(toks))
                                     fp_tokens_set.update(toks_sorted)
                                     fp_match_counts.extend([
                                         _max_group_count(toks_sorted)
                                     ] * count)
                                     fp_tokens_samples.extend([toks_sorted] * count)
+                                    fp_sample_paths.extend(str(p) for p in paths)
                     else:
                         for p in files:
                             res = _check_json(p)
                             if res is not None:
                                 fp = True
-                                toks, count = res
+                                toks, count, paths = res
                                 toks_sorted = sorted(set(toks))
                                 fp_tokens_set.update(toks_sorted)
                                 fp_match_counts.extend([
                                     _max_group_count(toks_sorted)
                                 ] * count)
                                 fp_tokens_samples.extend([toks_sorted] * count)
+                                fp_sample_paths.extend(str(pa) for pa in paths)
                 elif clean_sample is not None:
                     res = _check_json(clean_sample)
                     fp = res is not None
                     if res is not None:
-                        toks, count = res
+                        toks, count, paths = res
                         toks_sorted = sorted(set(toks))
                         fp_tokens_set.update(toks_sorted)
                         fp_match_counts.extend([
                             _max_group_count(toks_sorted)
                         ] * count)
                         fp_tokens_samples.extend([toks_sorted] * count)
-                elif clean_paths is not None:
-                    paths = list(clean_paths)
+                        fp_sample_paths.extend(str(p) for p in paths)
+                elif cur_clean_paths is not None:
+                    paths = list(cur_clean_paths)
                     if fp_scan_workers > 1 and len(paths) > 1:
                         from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -1295,38 +1334,42 @@ def evaluate_single(
                                 res = fut.result()
                                 if res is not None:
                                     fp = True
-                                    toks, count = res
+                                    toks, count, paths = res
                                     toks_sorted = sorted(set(toks))
                                     fp_tokens_set.update(toks_sorted)
                                     fp_match_counts.extend([
                                         _max_group_count(toks_sorted)
                                     ] * count)
                                     fp_tokens_samples.extend([toks_sorted] * count)
+                                    fp_sample_paths.extend(str(p) for p in paths)
                     else:
                         for p in paths:
                             res = _check_json(p)
                             if res is not None:
                                 fp = True
-                                toks, count = res
+                                toks, count, paths = res
                                 toks_sorted = sorted(set(toks))
                                 fp_tokens_set.update(toks_sorted)
                                 fp_match_counts.extend([
                                     _max_group_count(toks_sorted)
                                 ] * count)
                                 fp_tokens_samples.extend([toks_sorted] * count)
+                                fp_sample_paths.extend(str(pa) for pa in paths)
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
-                    or clean_paths is not None
+                    or cur_clean_paths is not None
                 ):
                     fp = False
                 fp_tokens = sorted(fp_tokens_set) if fp_tokens_set else None
                 fp_max = max(fp_match_counts) if fp_match_counts else 0
                 fp_count = len(fp_match_counts)
                 fp_tokens_by_sample = fp_tokens_samples if fp_tokens_samples else None
+                fp_paths = fp_sample_paths if fp_sample_paths else None
             else:
                 fp_tokens_set: set[str] = set()
                 fp_match_counts: list[int] = []
+                fp_sample_paths: list[str] = []
                 if (
                     clean_dir is not None
                     and clean_dir.is_dir()
@@ -1334,13 +1377,14 @@ def evaluate_single(
                 ):
                     files = [p for p in clean_dir.iterdir() if p.is_file()]
 
-                    def _scan_file(p: Path) -> list[str] | None:
+                    def _scan_file(p: Path) -> tuple[list[str], Path] | None:
                         try:
                             matches = compiled.match(str(p))
                             if matches:
-                                return [
-                                    id_map.get(s[1], s[1]) for s in matches[0].strings
-                                ]
+                                return (
+                                    [id_map.get(s[1], s[1]) for s in matches[0].strings],
+                                    p,
+                                )
                         except Exception:
                             return None
                         return None
@@ -1353,22 +1397,26 @@ def evaluate_single(
                         ) as executor:
                             futs = [executor.submit(_scan_file, p) for p in files]
                             for fut in as_completed(futs):
-                                toks = fut.result()
-                                if toks:
+                                res = fut.result()
+                                if res:
                                     fp = True
+                                    toks, pa = res
                                     toks_sorted = sorted(set(toks))
                                     fp_tokens_set.update(toks_sorted)
                                     fp_match_counts.append(_max_group_count(toks_sorted))
                                     fp_tokens_samples.append(toks_sorted)
+                                    fp_sample_paths.append(str(pa))
                     else:
                         for fp_path in files:
-                            toks = _scan_file(fp_path)
-                            if toks:
+                            res = _scan_file(fp_path)
+                            if res:
                                 fp = True
+                                toks, pa = res
                                 toks_sorted = sorted(set(toks))
                                 fp_tokens_set.update(toks_sorted)
                                 fp_match_counts.append(_max_group_count(toks_sorted))
                                 fp_tokens_samples.append(toks_sorted)
+                                fp_sample_paths.append(str(pa))
                 elif clean_sample is not None and compiled is not None:
                     try:
                         matches = compiled.match(str(clean_sample))
@@ -1379,6 +1427,7 @@ def evaluate_single(
                             fp_tokens_set.update(toks_sorted)
                             fp_match_counts.append(_max_group_count(toks_sorted))
                             fp_tokens_samples.append(toks_sorted)
+                            fp_sample_paths.append(str(clean_sample))
                         else:
                             fp_match_counts.append(
                                 _max_group_count([
@@ -1387,16 +1436,17 @@ def evaluate_single(
                             )
                     except Exception:
                         fp = False
-                elif clean_paths is not None and compiled is not None:
-                    paths = list(clean_paths)
+                elif cur_clean_paths is not None and compiled is not None:
+                    paths = list(cur_clean_paths)
 
-                    def _scan_path(p: Path) -> list[str] | None:
+                    def _scan_path(p: Path) -> tuple[list[str], Path] | None:
                         try:
                             matches = compiled.match(str(p))
                             if matches:
-                                return [
-                                    id_map.get(s[1], s[1]) for s in matches[0].strings
-                                ]
+                                return (
+                                    [id_map.get(s[1], s[1]) for s in matches[0].strings],
+                                    p,
+                                )
                         except Exception:
                             return None
                         return None
@@ -1409,26 +1459,30 @@ def evaluate_single(
                         ) as executor:
                             futs = [executor.submit(_scan_path, p) for p in paths]
                             for fut in as_completed(futs):
-                                toks = fut.result()
-                                if toks:
+                                res = fut.result()
+                                if res:
                                     fp = True
+                                    toks, pa = res
                                     toks_sorted = sorted(set(toks))
                                     fp_tokens_set.update(toks_sorted)
                                     fp_match_counts.append(_max_group_count(toks_sorted))
                                     fp_tokens_samples.append(toks_sorted)
+                                    fp_sample_paths.append(str(pa))
                     else:
                         for p in paths:
-                            toks = _scan_path(p)
-                            if toks:
+                            res = _scan_path(p)
+                            if res:
                                 fp = True
+                                toks, pa = res
                                 toks_sorted = sorted(set(toks))
                                 fp_tokens_set.update(toks_sorted)
                                 fp_match_counts.append(_max_group_count(toks_sorted))
                                 fp_tokens_samples.append(toks_sorted)
+                                fp_sample_paths.append(str(pa))
                 elif (
                     clean_dir is not None
                     or clean_sample is not None
-                    or clean_paths is not None
+                    or cur_clean_paths is not None
                 ):
                     fp = False
 
@@ -1436,6 +1490,7 @@ def evaluate_single(
                 fp_max = max(fp_match_counts) if fp_match_counts else 0
                 fp_count = len(fp_match_counts)
                 fp_tokens_by_sample = fp_tokens_samples if fp_tokens_samples else None
+                fp_paths = fp_sample_paths if fp_sample_paths else None
 
             return (
                 detected,
@@ -1447,6 +1502,7 @@ def evaluate_single(
                 fp_max,
                 fp_count,
                 fp_tokens_by_sample,
+                fp_paths,
             )
 
         fp_tokens_all: list[list[str] | None] = []
@@ -1454,8 +1510,9 @@ def evaluate_single(
         fp_match_max_vals: list[int] = []
         fp_counts: list[int] = []
         fp_tokens_samples_all: list[list[str]] = []
+        fp_sample_paths_all: list[str] = []
         for grp in groups:
-            det, cov, fp, rt, fp_tok, match_tok, fp_mx, fp_cnt, fp_sample = _eval_group(grp)
+            det, cov, fp, rt, fp_tok, match_tok, fp_mx, fp_cnt, fp_sample, fp_paths = _eval_group(grp)
             detections.append(det)
             coverages.append(cov)
             false_positives.append(fp)
@@ -1466,6 +1523,8 @@ def evaluate_single(
             fp_counts.append(fp_cnt)
             if fp_sample:
                 fp_tokens_samples_all.extend(fp_sample)
+            if fp_paths:
+                fp_sample_paths_all.extend(fp_paths)
 
         if isinstance(saliency, dict):
             flat = torch.cat(list(saliency.values()))
@@ -1513,8 +1572,8 @@ def evaluate_single(
         fp_max_total = max(fp_match_max_vals) if fp_match_max_vals else 0
         fp_matched_total = sum(fp_counts) if fp_counts else 0
         fp_ratio_benign = (
-            float(fp_matched_total) / float(total_benign)
-            if total_benign > 0
+            float(fp_matched_total) / float(cur_total_benign)
+            if cur_total_benign > 0
             else 0.0
         )
 
@@ -1530,12 +1589,14 @@ def evaluate_single(
             "freq_threshold": freq_thresh,
         }
         result["fp_count"] = fp_matched_total
-        result["total_benign"] = total_benign
+        result["total_benign"] = cur_total_benign
         result["fp_ratio_benign"] = fp_ratio_benign
         result["rule_texts"] = rule_texts
         result["false_positives"] = false_positives
         if fp_tokens_samples_all:
             result["fp_tokens_by_sample"] = fp_tokens_samples_all
+        if fp_sample_paths_all:
+            result["fp_samples"] = fp_sample_paths_all
         if matched_tokens_all_flat:
             result["matched_tokens"] = matched_tokens_all_flat
         if matched_tokens_fp:
@@ -1579,7 +1640,7 @@ def evaluate_single(
         LOGGER.debug(
             "fp_matched_total=%d total_benign=%d fp_ratio_benign=%.4f",
             fp_matched_total,
-            total_benign,
+            cur_total_benign,
             fp_ratio_benign,
         )
 
@@ -1596,7 +1657,7 @@ def evaluate_single(
         mode: str = combine_mode,
         exclude: Sequence[str] | None = None,
         auto_gmin: bool = auto_group_min,
-        total_benign: int = total_benign,
+        total_benign: int = cur_total_benign,
     ) -> Dict[str, Any]:
         res = _build_and_eval(
             f_thresh,
@@ -1608,7 +1669,7 @@ def evaluate_single(
             mode=mode,
             exclude=exclude,
             auto_gmin=auto_gmin,
-            total_benign=total_benign,
+            total_benign=cur_total_benign,
         )
         cnts = res.get("fp_token_counts")
         if cnts:
@@ -1847,6 +1908,7 @@ def evaluate_single(
             last_detected=last_detected_result,
             optimizer=optimizer,
             param_update=_apply_params,
+            set_clean_paths=_set_clean_paths,
         )
 
     out_result = best_result


### PR DESCRIPTION
## Summary
- track benign sample paths causing false positives
- restrict false positive retries to those samples only
- reuse loaded JSON tokens via TokenCache across retries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888f58dae58832ea89e783c4584158b