### PR TITLE
Improve token set checks

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -38,6 +38,19 @@ from filelock import FileLock
 LOGGER = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
+# Regex constants
+# ---------------------------------------------------------------------------
+
+_CALL_PREFIX_RE = re.compile(r"^(?:call|import|syscall|path|reg|url|byte\[[^]]*\])\s*:", re.I)
+_QUOTED_RE = re.compile(r'"([^\"]+)"')
+_BRACE_RE = re.compile(r"\{([^}]*)\}")
+_HEX_RE = re.compile(r"[A-Fa-f0-9?]{2}")
+_SLASH_RE = re.compile(r"/(.*)/")
+
+# Cache for dynamically constructed token regex patterns
+_TOKEN_REGEX_CACHE: dict[str, re.Pattern] = {}
+
+# ---------------------------------------------------------------------------
 # Token cache
 # ---------------------------------------------------------------------------
 
@@ -152,28 +165,23 @@ def _extract_tokens(feature: str) -> list[str]:
     tokens: list[str] = []
     for part in parts:
         part = part.strip()
-        part = re.sub(
-            r"^(?:call|import|syscall|path|reg|url|byte\[[^]]*\])\s*:",
-            "",
-            part,
-            flags=re.I,
-        )
+        part = _CALL_PREFIX_RE.sub("", part)
         if "!" in part:
             part = part.split("!")[-1]
 
-        m = re.search(r'"([^\"]+)"', part)
+        m = _QUOTED_RE.search(part)
         if m:
             tokens.append(m.group(1).lower())
             continue
 
-        m = re.search(r"\{([^}]*)\}", part)
+        m = _BRACE_RE.search(part)
         if m:
             hx = m.group(1)
-            for h in re.findall(r"[A-Fa-f0-9?]{2}", hx):
+            for h in _HEX_RE.findall(hx):
                 tokens.append(h.lower())
             continue
 
-        m = re.search(r"/(.*)/", part)
+        m = _SLASH_RE.search(part)
         if m:
             tokens.append(m.group(1).lower())
             continue
@@ -615,30 +623,33 @@ def verify_features(
         return False
 
     def _token_regex(tok: str) -> re.Pattern:
-        parts = split_name(tok)
+        tok_l = tok.lower()
+        cached = _TOKEN_REGEX_CACHE.get(tok_l)
+        if cached is not None:
+            return cached
+        parts = split_name(tok_l)
         if parts:
             pat = r"[_-]?".join(re.escape(p) for p in parts)
         else:
-            pat = re.escape(tok)
+            pat = re.escape(tok_l)
         pat = pat.replace(r"\_", "[-_]").replace(r"\-", "[-_]")
-        return re.compile(pat, re.IGNORECASE)
+        compiled = re.compile(pat, re.IGNORECASE)
+        _TOKEN_REGEX_CACHE[tok_l] = compiled
+        return compiled
 
     def _feat_present(feat: str) -> bool:
-        tks = _extract_tokens(feat)
+        nonlocal joined
+        tks_set = {t.lower() for t in _extract_tokens(feat)}
         if tokens is not None:
-            for tok in tks:
-                if tok.lower() in tokens:
-                    return True
-            return False
+            return bool(tokens.intersection(tks_set))
         if js is not None:
             if joined is None:
                 text_fields: list[str] = []
                 for key in ("c_code", "h_code", "asm_code", "llvm_ir"):
                     text_fields.extend(js.get(key, []))
-                joined_local = "\n".join(text_fields)
-            else:
-                joined_local = joined
-            for tok in tks:
+                joined = "\n".join(text_fields)
+            joined_local = joined
+            for tok in tks_set:
                 if _token_regex(tok).search(joined_local):
                     return True
         return False
@@ -963,7 +974,7 @@ def evaluate_single(
             features = [
                 f
                 for f in features
-                if not any(tok.lower() in excl for tok in _extract_tokens(f))
+                if {t.lower() for t in _extract_tokens(f)}.isdisjoint(excl)
             ]
             if LOGGER.isEnabledFor(logging.DEBUG) and before != len(features):
                 LOGGER.debug("Excluded %d features by token", before - len(features))
@@ -1177,7 +1188,7 @@ def evaluate_single(
 
                 def _check_json(p: Path | None) -> tuple[list[str], int, list[Path]] | None:
                     if token_cache.index and p is None:
-                        cand: Set[Path] | None = None
+                        cand_sets: list[Set[Path]] = []
                         matched: list[str] = []
                         for feat in feats:
                             for tok in _extract_tokens(feat):
@@ -1185,9 +1196,10 @@ def evaluate_single(
                                 if not paths:
                                     return None
                                 matched.append(tok.lower())
-                                cand = paths if cand is None else cand & paths
-                                if not cand:
-                                    return None
+                                cand_sets.append(paths)
+                        if not cand_sets:
+                            return None
+                        cand = set.intersection(*cand_sets)
                         if not cand:
                             return None
                         count = 0


### PR DESCRIPTION
## Summary
- cache regex patterns for `_extract_tokens`
- use regex cache for verifying feature tokens
- check membership with set operations
- simplify JSON token path search using set intersections

## Testing
- `pytest -k verify_features -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_6888f99e63b0832ea5fb0600ea9e9f43