### PR TITLE
Add multiprocess-aware optimizer persistence

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -225,10 +225,10 @@ python -m src.cli.explainer_rule_eval \
 제외된 토큰을 누적 저장하며, 다음 실행에서도 동일 파일을 지정하면
 자동으로 로드되어 동일 토큰을 계속 제외합니다.
 `--optimize` 플래그를 사용하면 재시도 과정에서 하이퍼파라미터를 온라인으로
-조정합니다. `--optimizer-pkl` 로 이전 상태를 불러오거나
-`--save-optimizer` 로 실행 후 상태를 저장할 수 있습니다.
+조정합니다. `--optimizer-pkl` 옵션의 기본값은 `optimizer_state.pkl`이며 실행이
+끝나면 이 위치에 상태가 자동 저장되고, 다음 실행 시 존재하면 기본으로 로드됩니다. 다른 경로에 저장하려면 `--save-optimizer` 를 사용합니다.
 
-배치 모드에서도 `--save-optimizer` 를 사용하면 종료 시점에 상태가 지정한 경로에 저장됩니다.
+배치 모드에서도 `--save-optimizer` 를 지정하면 종료 시점에 상태가 해당 경로에 추가 저장됩니다.
 
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로

--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -13,6 +13,7 @@ from collections import Counter
 from rulegen.yara_builder import YaraBuilder
 
 import torch
+import torch.multiprocessing as mp
 from tqdm.auto import tqdm
 from src.common.utils import get_logger, tqdm_wrap, human_bytes
 
@@ -69,7 +70,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--optimizer-pkl",
         type=Path,
-        help="Load optimizer state from this path",
+        default=Path("optimizer_state.pkl"),
+        help="Path to load and save optimizer state",
     )
     p.add_argument(
         "--save-optimizer",
@@ -363,6 +365,9 @@ def main(argv: list[str] | None = None) -> None:
     device = torch.device(args.device)
 
     optimizer: CategoricalOptimizer | PopulationOptimizer | None = None
+    opt_state = None
+    opt_lock = None
+    mp_manager = None
     if args.optimize:
         if args.pop_size > 1 or args.global_steps > 0:
             optimizer = PopulationOptimizer(
@@ -379,7 +384,10 @@ def main(argv: list[str] | None = None) -> None:
                 optimizer.load_state_dict(state)
             except Exception as exc:  # noqa: BLE001
                 LOGGER.warning("Failed to load optimizer state %s: %s", args.optimizer_pkl, exc)
-
+        mp_manager = mp.Manager()
+        opt_state = mp_manager.dict(optimizer.state_dict())
+        opt_lock = mp_manager.Lock()
+    
     classifier = None
     explainer = None
     need_model = args.saliency is None or (args.graph_dir and args.meta_csv)
@@ -534,7 +542,7 @@ def main(argv: list[str] | None = None) -> None:
         graph_bar = tqdm(total=len(tasks), desc="graphs", unit="graph", position=0)
         fp_bar = tqdm(total=args.fp_retries or 1, desc="fp retries", unit="try", position=1, leave=True)
 
-        import multiprocessing as mp
+        import multiprocessing as mp_mod
         from concurrent.futures import (
             ProcessPoolExecutor,
             wait,
@@ -546,7 +554,7 @@ def main(argv: list[str] | None = None) -> None:
         sal_dir.mkdir(parents=True, exist_ok=True)
 
         if not args.precomputed_saliency_dir:
-            ctx_sal = mp.get_context("spawn")
+            ctx_sal = mp_mod.get_context("spawn")
             with ProcessPoolExecutor(
                 max_workers=1,
                 mp_context=ctx_sal,
@@ -566,9 +574,9 @@ def main(argv: list[str] | None = None) -> None:
                         continue
 
         if args.num_workers > 1:
-            ctx = mp.get_context("forkserver")
-            manager = mp.Manager()
-            result_q: mp.Queue = manager.Queue()
+            ctx = mp_mod.get_context("forkserver")
+            manager = mp_mod.Manager()
+            result_q: mp_mod.Queue = manager.Queue()
             with ProcessPoolExecutor(
                 max_workers=args.num_workers,
                 mp_context=ctx,
@@ -627,6 +635,10 @@ def main(argv: list[str] | None = None) -> None:
                             batch.append(res)
                             if len(batch) >= args.batch_size:
                                 optimizer.step(batch)
+                                if opt_state is not None:
+                                    with opt_lock:
+                                        opt_state.clear()
+                                        opt_state.update(optimizer.state_dict())
                                 _apply_params_main(optimizer.discrete_params())
                                 batch.clear()
                         cnts = res.get("fp_token_counts_total")
@@ -696,6 +708,10 @@ def main(argv: list[str] | None = None) -> None:
                         batch.append(res_left)
                 if optimizer and batch:
                     optimizer.step(batch)
+                    if opt_state is not None:
+                        with opt_lock:
+                            opt_state.clear()
+                            opt_state.update(optimizer.state_dict())
                     _apply_params_main(optimizer.discrete_params())
         else:
             batch: list[dict[str, Any]] = []
@@ -726,6 +742,10 @@ def main(argv: list[str] | None = None) -> None:
                     batch.append(res)
                     if len(batch) >= args.batch_size:
                         optimizer.step(batch)
+                        if opt_state is not None:
+                            with opt_lock:
+                                opt_state.clear()
+                                opt_state.update(optimizer.state_dict())
                         _apply_params_main(optimizer.discrete_params())
                         batch.clear()
                 cnts = res.get("fp_token_counts_total")
@@ -788,6 +808,10 @@ def main(argv: list[str] | None = None) -> None:
 
             if optimizer and batch:
                 optimizer.step(batch)
+                if opt_state is not None:
+                    with opt_lock:
+                        opt_state.clear()
+                        opt_state.update(optimizer.state_dict())
                 _apply_params_main(optimizer.discrete_params())
         graph_bar.close()
         fp_bar.close()
@@ -875,15 +899,28 @@ def main(argv: list[str] | None = None) -> None:
         else:
             LOGGER.warning("No samples evaluated")
 
-        if optimizer and args.save_optimizer:
-            try:
-                torch.save(optimizer.state_dict(), args.save_optimizer)
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning(
-                    "Failed to save optimizer to %s: %s",
-                    args.save_optimizer,
-                    exc,
-                )
+        if optimizer:
+            if opt_state is not None:
+                with opt_lock:
+                    optimizer.load_state_dict(dict(opt_state))
+            if args.optimizer_pkl:
+                try:
+                    torch.save(optimizer.state_dict(), args.optimizer_pkl)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning(
+                        "Failed to save optimizer to %s: %s",
+                        args.optimizer_pkl,
+                        exc,
+                    )
+            if args.save_optimizer:
+                try:
+                    torch.save(optimizer.state_dict(), args.save_optimizer)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning(
+                        "Failed to save optimizer to %s: %s",
+                        args.save_optimizer,
+                        exc,
+                    )
 
     else:
         if args.graph is None or args.sample is None:
@@ -985,11 +1022,23 @@ def main(argv: list[str] | None = None) -> None:
                 rule_txt, encoding="utf-8"
             )
 
-        if optimizer and args.save_optimizer:
-            try:
-                torch.save(optimizer.state_dict(), args.save_optimizer)
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning("Failed to save optimizer to %s: %s", args.save_optimizer, exc)
+        if optimizer:
+            if opt_state is not None:
+                with opt_lock:
+                    optimizer.load_state_dict(dict(opt_state))
+            if args.optimizer_pkl:
+                try:
+                    torch.save(optimizer.state_dict(), args.optimizer_pkl)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to save optimizer to %s: %s", args.optimizer_pkl, exc)
+            if args.save_optimizer:
+                try:
+                    torch.save(optimizer.state_dict(), args.save_optimizer)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("Failed to save optimizer to %s: %s", args.save_optimizer, exc)
+
+    if mp_manager is not None:
+        mp_manager.shutdown()
 
 
 __all__ = ["main"]


### PR DESCRIPTION
## Summary
- persist optimizer across runs and share state via `torch.multiprocessing.Manager`
- load previous state automatically using `--optimizer-pkl` (default `optimizer_state.pkl`)
- document optimizer persistence in quick start guide

## Testing
- `pytest tests/test_categorical_optimizer.py tests/test_optimize_num_workers.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888f9b846ac832eaf11a713bdc4aad4