### PR TITLE
Implement global FP token exclusion

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -224,6 +224,7 @@ python -m src.cli.explainer_rule_eval \
 `--persist-fp-exclude` 옵션에 JSON 파일을 지정하면 재시도 과정에서
 제외된 토큰을 누적 저장하며, 다음 실행에서도 동일 파일을 지정하면
 자동으로 로드되어 동일 토큰을 계속 제외합니다.
+배치 모드에서는 이렇게 수집한 FP 토큰을 전역으로 합산하여 가장 빈도가 높은 토큰을 다음 그래프 평가 시 `exclude_tokens` 인자에 자동 추가합니다. `--max-exclude-tokens` 옵션으로 최대 수를 조정하고, 필요하면 `--freq-threshold` 값을 함께 낮춰 더 엄격하게 필터링할 수 있습니다.
 `--optimize` 플래그를 사용하면 재시도 과정에서 하이퍼파라미터를 온라인으로
 조정합니다. `--optimizer-pkl` 옵션의 기본값은 `optimizer_state.pkl`이며 실행이
 끝나면 이 위치에 상태가 자동 저장되고, 다음 실행 시 존재하면 기본으로 로드됩니다. 다른 경로에 저장하려면 `--save-optimizer` 를 사용합니다.

--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -452,9 +452,13 @@ def main(argv: list[str] | None = None) -> None:
                 json.dumps({k: [str(p) for p in v] for k, v in token_cache.index.items()})
             )
 
+        global_fp_tokens: list[str] = []
+        freq_threshold_val: float | int = args.freq_threshold
+
         def _apply_params_main(params: dict[str, object]) -> None:
             nonlocal condition_type, combine_mode, dynamic_k, auto_relax
             nonlocal adjust_group_percentage, group_min_ratio, combine_min_ratio
+            nonlocal global_fp_tokens, freq_threshold_val
             condition_type = params.get("condition_type", condition_type)
             combine_mode = params.get("combine_mode", combine_mode)
             dynamic_k = params.get("dynamic_k", dynamic_k)
@@ -464,8 +468,13 @@ def main(argv: list[str] | None = None) -> None:
             )
             group_min_ratio = params.get("group_min_ratio", group_min_ratio)
             combine_min_ratio = params.get("combine_min_ratio", combine_min_ratio)
+            if "exclude_tokens" in params:
+                global_fp_tokens = list(params["exclude_tokens"])
+            if "freq_threshold" in params:
+                freq_threshold_val = params["freq_threshold"]
 
         def _current_params() -> dict[str, object]:
+            excl = list({*(args.exclude_tokens or []), *global_fp_tokens})
             return {
                 "condition_type": condition_type,
                 "combine_mode": combine_mode,
@@ -474,6 +483,8 @@ def main(argv: list[str] | None = None) -> None:
                 "adjust_group_percentage": adjust_group_percentage,
                 "group_min_ratio": group_min_ratio,
                 "combine_min_ratio": combine_min_ratio,
+                "exclude_tokens": excl,
+                "freq_threshold": freq_threshold_val,
             }
         results: list[dict[str, Any]] = []
         fp_token_counter_all: Counter[str] = Counter()
@@ -644,6 +655,8 @@ def main(argv: list[str] | None = None) -> None:
                         cnts = res.get("fp_token_counts_total")
                         if cnts:
                             fp_token_counter_all.update({k.lower(): int(v) for k, v in cnts.items()})
+                            top_fp = [t for t, _ in sorted(fp_token_counter_all.items(), key=lambda x: (-x[1], x[0]))[: args.max_exclude_tokens]]
+                            _apply_params_main({"exclude_tokens": top_fp})
 
                         det_rate = sum(r.get("detected", False) for r in results) / len(results)
                         fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)
@@ -751,6 +764,8 @@ def main(argv: list[str] | None = None) -> None:
                 cnts = res.get("fp_token_counts_total")
                 if cnts:
                     fp_token_counter_all.update({k.lower(): int(v) for k, v in cnts.items()})
+                    top_fp = [t for t, _ in sorted(fp_token_counter_all.items(), key=lambda x: (-x[1], x[0]))[: args.max_exclude_tokens]]
+                    _apply_params_main({"exclude_tokens": top_fp})
 
                 det_rate = sum(r.get("detected", False) for r in results) / len(results)
                 fp_ratio = sum(1 for r in results if r.get("false_positive")) / len(results)


### PR DESCRIPTION
## Summary
- use global FP token counts to auto-exclude high-frequency tokens
- propagate updated `exclude_tokens` via `_apply_params_main`
- document global FP statistics in quick start guide

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_fp_retries -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_build_parser_exclude_tokens -q`


------
https://chatgpt.com/codex/tasks/task_e_688902d07cb4832eb28b81b61d507070