### PR TITLE
Add optimizer parameters for freq threshold and group count

### DIFF
--- a/docs/rulegen/quick_start.md
+++ b/docs/rulegen/quick_start.md
@@ -230,6 +230,8 @@ python -m src.cli.explainer_rule_eval \
 
 배치 모드에서도 `--save-optimizer` 를 지정하면 종료 시점에 상태가 해당 경로에 추가 저장됩니다.
 
+`freq_threshold` 와 `group_min_count` 값 역시 옵티마이저에서 학습하며 기본값은 각각 `10`과 `0(None)` 입니다. 값의 범위는 `-1~100`, `0~10` 사이로 제한되고 상태 파일에 함께 저장되어 다음 실행 시 자동 복원됩니다.
+
 `--group-min-count`나 `--group-percentage`로 조건을 조정할 수 있으며,
 `--adjust-group-percentage` 옵션을 주면 특징 수가 많을 때 비율이 자동으로
 낮춰집니다.

--- a/src/cli/categorical_optimizer.py
+++ b/src/cli/categorical_optimizer.py
@@ -10,6 +10,11 @@ class CategoricalOptimizer:
     CONDITION_TYPES = ["any", "all", "percentage", "count", "combo"]
     COMBINE_MODES = ["or", "and"]
 
+    FREQ_MIN = -1.0
+    FREQ_MAX = 100.0
+    GROUP_MIN_MIN = 0.0
+    GROUP_MIN_MAX = 10.0
+
     def __init__(self, lr: float = 0.1, beta: float = 0.5) -> None:
         """Initialize parameters with logits matching default CLI values."""
 
@@ -30,6 +35,24 @@ class CategoricalOptimizer:
         self.group_min_ratio_logit = torch.nn.Parameter(torch.logit(torch.tensor(1e-3)))
         self.combine_min_ratio_logit = torch.nn.Parameter(torch.logit(torch.tensor(0.7)))
 
+        self.freq_threshold_logit = torch.nn.Parameter(
+            torch.logit(
+                torch.tensor(
+                    (10.0 - self.FREQ_MIN) / (self.FREQ_MAX - self.FREQ_MIN)
+                )
+            )
+        )
+        self.group_min_count_logit = torch.nn.Parameter(
+            torch.logit(
+                torch.tensor(
+                    (0.0 - self.GROUP_MIN_MIN)
+                    / (self.GROUP_MIN_MAX - self.GROUP_MIN_MIN)
+                    if self.GROUP_MIN_MAX > self.GROUP_MIN_MIN
+                    else 0.0
+                )
+            )
+        )
+
         self._params = [
             self.condition_type_logits,
             self.combine_mode_logits,
@@ -38,6 +61,8 @@ class CategoricalOptimizer:
             self.adjust_group_percentage_logit,
             self.group_min_ratio_logit,
             self.combine_min_ratio_logit,
+            self.freq_threshold_logit,
+            self.group_min_count_logit,
         ]
         self.beta = beta
         self.optimizer = torch.optim.AdamW(self._params, lr=lr)
@@ -69,6 +94,8 @@ class CategoricalOptimizer:
             "adjust_group_percentage": self.adjust_group_percentage_logit,
             "group_min_ratio": self.group_min_ratio_logit,
             "combine_min_ratio": self.combine_min_ratio_logit,
+            "freq_threshold": self.freq_threshold_logit,
+            "group_min_count": self.group_min_count_logit,
         }
 
     # ------------------------------------------------------------------
@@ -80,6 +107,21 @@ class CategoricalOptimizer:
         adjust_gp = torch.sigmoid(self.adjust_group_percentage_logit).item() > 0.5
         g_ratio = torch.sigmoid(self.group_min_ratio_logit).item()
         c_ratio = torch.sigmoid(self.combine_min_ratio_logit).item()
+        freq = (
+            torch.sigmoid(self.freq_threshold_logit).item()
+            * (self.FREQ_MAX - self.FREQ_MIN)
+            + self.FREQ_MIN
+        )
+        g_count_f = (
+            torch.sigmoid(self.group_min_count_logit).item()
+            * (self.GROUP_MIN_MAX - self.GROUP_MIN_MIN)
+            + self.GROUP_MIN_MIN
+        )
+        g_count = int(round(g_count_f))
+        if g_count <= 0:
+            g_count_val: int | None = None
+        else:
+            g_count_val = g_count
         return {
             "condition_type": cond,
             "combine_mode": comb,
@@ -88,6 +130,8 @@ class CategoricalOptimizer:
             "adjust_group_percentage": adjust_gp,
             "group_min_ratio": g_ratio,
             "combine_min_ratio": c_ratio,
+            "freq_threshold": freq,
+            "group_min_count": g_count_val,
         }
 
     # ------------------------------------------------------------------
@@ -148,6 +192,19 @@ class CategoricalOptimizer:
             val = float(params["combine_min_ratio"])
             val = min(max(val, 0.0), 1.0)
             self.combine_min_ratio_logit.data.copy_(torch.logit(torch.tensor(val)))
+        if "freq_threshold" in params:
+            val = float(params["freq_threshold"])
+            val = min(max(val, self.FREQ_MIN), self.FREQ_MAX)
+            norm = (val - self.FREQ_MIN) / (self.FREQ_MAX - self.FREQ_MIN)
+            self.freq_threshold_logit.data.copy_(torch.logit(torch.tensor(norm)))
+        if "group_min_count" in params:
+            gval = params["group_min_count"]
+            if gval is None:
+                norm = 0.0
+            else:
+                gval = float(min(max(int(gval), self.GROUP_MIN_MIN), self.GROUP_MIN_MAX))
+                norm = (gval - self.GROUP_MIN_MIN) / (self.GROUP_MIN_MAX - self.GROUP_MIN_MIN)
+            self.group_min_count_logit.data.copy_(torch.logit(torch.tensor(norm)))
 
 
 class PopulationOptimizer:
@@ -259,5 +316,13 @@ class PopulationOptimizer:
             params[key] = not params.get(key, False)
         elif key in {"group_min_ratio", "combine_min_ratio"}:
             params[key] = min(1.0, max(0.0, params.get(key, 0.5) + random.uniform(-0.1, 0.1)))
+        elif key == "freq_threshold":
+            val = params.get(key, 10.0) + random.uniform(-1.0, 1.0)
+            params[key] = min(CategoricalOptimizer.FREQ_MAX, max(CategoricalOptimizer.FREQ_MIN, val))
+        elif key == "group_min_count":
+            val = int(params.get(key, 0) or 0)
+            val += random.choice([-1, 1])
+            val = min(int(CategoricalOptimizer.GROUP_MIN_MAX), max(int(CategoricalOptimizer.GROUP_MIN_MIN), val))
+            params[key] = None if val <= 0 else val
 
 

--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -234,6 +234,7 @@ class RetryState:
     combine_mode: str
     group_min_ratio: float
     group_min_count: int | None
+    freq_threshold: float | int
     best_result: Dict[str, Any]
     last_detected: Dict[str, Any] | None
 
@@ -295,7 +296,13 @@ def _evaluate_and_update(
 
     opt_res = optimizer_utils._optimizer_step(trial, optimizer, param_update)
     if opt_res is not None:
-        state.combine_min_ratio, state.combine_mode, state.group_min_ratio = opt_res
+        (
+            state.combine_min_ratio,
+            state.combine_mode,
+            state.group_min_ratio,
+            state.freq_threshold,
+            state.group_min_count,
+        ) = opt_res
 
     if fp_bar:
         fp_bar.update(1)
@@ -507,8 +514,15 @@ def adaptive_fp_retry(
     if set_clean_paths and result.get("fp_samples"):
         set_clean_paths([Path(p) for p in result["fp_samples"]])
 
-    if optimizer is not None and param_update is not None:
-        param_update(optimizer.discrete_params())
+    if optimizer is not None:
+        params_current = optimizer.discrete_params()
+        if param_update is not None:
+            param_update(params_current)
+        combine_mode = params_current.get("combine_mode", combine_mode)
+        combine_min_ratio = params_current.get("combine_min_ratio", combine_min_ratio)
+        group_min_ratio = params_current.get("group_min_ratio", group_min_ratio)
+        freq_threshold = params_current.get("freq_threshold", freq_threshold)
+        group_min_count = params_current.get("group_min_count", group_min_count)
 
     def _try(excl: set[str], gmc: int | None, ratio: float) -> Dict[str, Any]:
         return eval_fn(
@@ -530,6 +544,7 @@ def adaptive_fp_retry(
         combine_mode=combine_mode,
         group_min_ratio=group_min_ratio,
         group_min_count=group_min_count,
+        freq_threshold=freq_threshold,
         best_result=best_result,
         last_detected=last_detected,
     )
@@ -580,6 +595,7 @@ def adaptive_fp_retry(
         ):
             break
 
+    freq_threshold = state.freq_threshold
     attempts = _adjust_thresholds(
         _try,
         eval_fn,
@@ -946,7 +962,7 @@ def evaluate_single(
             cur_total_benign = len(token_cache.tokens)
 
     def _apply_params(params: dict[str, object]) -> None:
-        nonlocal condition_type, combine_mode, dynamic_k, auto_relax, adjust_group_percentage, group_min_ratio, combine_min_ratio
+        nonlocal condition_type, combine_mode, dynamic_k, auto_relax, adjust_group_percentage, group_min_ratio, combine_min_ratio, freq_threshold, group_min_count
         condition_type = params.get("condition_type", condition_type)
         combine_mode = params.get("combine_mode", combine_mode)
         dynamic_k = params.get("dynamic_k", dynamic_k)
@@ -956,6 +972,8 @@ def evaluate_single(
         )
         group_min_ratio = params.get("group_min_ratio", group_min_ratio)
         combine_min_ratio = params.get("combine_min_ratio", combine_min_ratio)
+        freq_threshold = params.get("freq_threshold", freq_threshold)
+        group_min_count = params.get("group_min_count", group_min_count)
 
     if optimizer is not None:
         if isinstance(optimizer, PopulationOptimizer):

--- a/src/cli/explainer_rule_eval/optimizer_utils.py
+++ b/src/cli/explainer_rule_eval/optimizer_utils.py
@@ -63,6 +63,8 @@ def _optimizer_loss(
                 opt.adjust_group_percentage_logit,
                 opt.group_min_ratio_logit,
                 opt.combine_min_ratio_logit,
+                opt.freq_threshold_logit,
+                opt.group_min_count_logit,
             ]
         )
     )
@@ -81,7 +83,7 @@ def _optimizer_step(
     trial: Mapping[str, Any],
     optimizer: CategoricalOptimizer | PopulationOptimizer | None,
     param_update=None,
-) -> tuple[float, str, float] | None:
+) -> tuple[float, str, float, float | int, int | None] | None:
     """Update optimizer with ``trial`` and return new parameters."""
 
     if optimizer is None:
@@ -102,4 +104,6 @@ def _optimizer_step(
         params["combine_min_ratio"],
         params["combine_mode"],
         params["group_min_ratio"],
+        params.get("freq_threshold", 0.0),
+        params.get("group_min_count"),
     )

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -3012,3 +3012,137 @@ def test_batch_optimizer_updates_kwargs(tmp_path, monkeypatch):
     assert params[0] != params[1]
 
 
+def test_optimizer_params_applied_evaluate_single(tmp_path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "sample.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    captured: dict[str, object] = {}
+
+    class DummyMiner:
+        def __init__(self, *, freq_threshold, **k):
+            captured["freq"] = freq_threshold
+
+        def mine(self, graph, saliency):
+            return ["call:foo"]
+
+    class DummyBuilder:
+        def __init__(self, *, group_min_count=None, **k):
+            captured["gmc"] = group_min_count
+
+        def build(self, feats, return_map=False):
+            return "rule", {}
+
+        def validate(self, t):
+            pass
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner(*a, **k))
+    monkeypatch.setattr("src.cli.explainer_rule_eval.evaluation.YaraBuilder", DummyBuilder)
+
+    opt = mod.CategoricalOptimizer()
+    opt.freq_threshold_logit.data.copy_(
+        torch.logit(torch.tensor((5 - opt.FREQ_MIN) / (opt.FREQ_MAX - opt.FREQ_MIN)))
+    )
+    opt.group_min_count_logit.data.copy_(
+        torch.logit(torch.tensor((3 - opt.GROUP_MIN_MIN) / (opt.GROUP_MIN_MAX - opt.GROUP_MIN_MIN)))
+    )
+
+    mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        optimizer=opt,
+    )
+
+    assert captured.get("freq") == pytest.approx(5.0, abs=1e-6)
+    assert captured.get("gmc") == 3
+
+
+def test_adaptive_retry_optimizer_params(monkeypatch):
+    from collections import Counter
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    called: list[tuple[float, int | None]] = []
+
+    def fake_eval(freq, gmc, *a, **k):
+        called.append((freq, gmc))
+        return {"detected": False, "false_positive": True}
+
+    opt = mod.CategoricalOptimizer()
+    opt.freq_threshold_logit.data.copy_(
+        torch.logit(torch.tensor((7 - opt.FREQ_MIN) / (opt.FREQ_MAX - opt.FREQ_MIN)))
+    )
+    opt.group_min_count_logit.data.copy_(
+        torch.logit(torch.tensor((2 - opt.GROUP_MIN_MIN) / (opt.GROUP_MIN_MAX - opt.GROUP_MIN_MIN)))
+    )
+
+    mod.adaptive_fp_retry(
+        fake_eval,
+        result={"false_positive": True},
+        exclude_set=set(),
+        fp_token_counter=Counter(),
+        group_min_count=None,
+        combine_min_ratio=0.7,
+        freq_threshold=10.0,
+        min_freq_threshold=0.0,
+        group_min_ratio=0.0,
+        num_rules=1,
+        chunk_size=None,
+        combine_mode="or",
+        auto_group_min=True,
+        freq_threshold_step=0.0,
+        comb_ratio_step=0.0,
+        chunk_size_step=1,
+        combine_max_ratio=1.0,
+        fp_retries=1,
+        fp_timeout=None,
+        max_exclude_tokens=5,
+        persist_fp_exclude=None,
+        fp_bar=None,
+        is_better=lambda n, c: True,
+        best_result={"detected": False, "false_positive": True},
+        last_detected=None,
+        optimizer=opt,
+    )
+
+    assert called
+    assert called[0][0] == pytest.approx(7.0, abs=1e-6)
+    assert called[0][1] == 2
+
+


### PR DESCRIPTION
## Summary
- allow learning `freq_threshold` and `group_min_count` in `CategoricalOptimizer`
- use optimizer continuous values in evaluation routines
- document new parameters
- test that optimizer values propagate to evaluation

## Testing
- `pytest 'tests/test_explainer_rule_eval_cli.py::test_optimizer_params_applied_evaluate_single' -vv` *(fails: 1 skipped)*
- `pytest 'tests/test_explainer_rule_eval_cli.py::test_adaptive_retry_optimizer_params' -vv` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688902d40e28832e9287a7a733f93ceb