### PR TITLE
Update freq threshold in adaptive retry

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -580,11 +580,13 @@ def adaptive_fp_retry(
         ):
             break
 
+    current_freq = freq_threshold
+
     attempts = _adjust_thresholds(
         _try,
         eval_fn,
         state,
-        freq_threshold=freq_threshold,
+        freq_threshold=current_freq,
         num_rules=num_rules,
         chunk_size=chunk_size,
         auto_group_min=auto_group_min,
@@ -599,6 +601,31 @@ def adaptive_fp_retry(
         param_update=param_update,
         set_clean_paths=set_clean_paths,
     )
+
+    if (
+        state.result.get("false_positive")
+        and freq_threshold_step
+        and current_freq > min_freq_threshold
+        and attempts <= fp_retries
+    ):
+        current_freq = max(min_freq_threshold, current_freq - freq_threshold_step)
+        freq_threshold = current_freq
+        trial = _try(set(), state.group_min_count, state.combine_min_ratio)
+        if set_clean_paths and trial.get("fp_samples"):
+            set_clean_paths([Path(p) for p in trial["fp_samples"]])
+        attempts += 1
+        _evaluate_and_update(
+            trial,
+            state,
+            exclude_tokens=set(),
+            persist_fp_exclude=persist_fp_exclude,
+            fp_bar=fp_bar,
+            is_better=is_better,
+            optimizer=optimizer,
+            param_update=param_update,
+        )
+
+    freq_threshold = current_freq
 
     return state.result, state.exclude_set, state.best_result
 


### PR DESCRIPTION
## Summary
- update `adaptive_fp_retry` to lower `freq_threshold` and evaluate again
- ensure updated freq threshold used in `_adjust_thresholds`

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_adaptive_fp_retry_freq_step_and_min_threshold -q`

------
https://chatgpt.com/codex/tasks/task_e_688905cc8c24832eb6dfd6351c52e1ae