### PR TITLE
Implement adaptive FP retry threshold update

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -616,6 +616,29 @@ def adaptive_fp_retry(
         set_clean_paths=set_clean_paths,
     )
 
+    freq_threshold = state.freq_threshold
+    if (
+        state.result.get("false_positive")
+        and freq_threshold_step
+        and freq_threshold > min_freq_threshold
+    ):
+        freq_threshold = max(min_freq_threshold, freq_threshold - freq_threshold_step)
+        state.freq_threshold = freq_threshold
+        trial = _try(set(), state.group_min_count, state.combine_min_ratio)
+        if set_clean_paths and trial.get("fp_samples"):
+            set_clean_paths([Path(p) for p in trial["fp_samples"]])
+        attempts += 1
+        _evaluate_and_update(
+            trial,
+            state,
+            exclude_tokens=set(),
+            persist_fp_exclude=persist_fp_exclude,
+            fp_bar=fp_bar,
+            is_better=is_better,
+            optimizer=optimizer,
+            param_update=param_update,
+        )
+
     return state.result, state.exclude_set, state.best_result
 
 


### PR DESCRIPTION
## Summary
- update `adaptive_fp_retry` to lower freq_threshold when previous attempts fail
- evaluate with the relaxed threshold

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_adaptive_fp_retry_freq_step_and_min_threshold -q` *(fails: ModuleNotFoundError: No module named 'torch.nn')*

------
https://chatgpt.com/codex/tasks/task_e_68890738decc832eb504836d3a54e227