### PR TITLE
Implement rollback on low detection

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -314,6 +314,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of threads for scanning clean files for FP checks",
     )
     p.add_argument(
+        "--target-det-rate",
+        type=float,
+        default=None,
+        help="Rollback parameters if average detection drops below this",
+    )
+    p.add_argument(
         "--json-match",
         action="store_true",
         help="Verify features in sample JSON instead of YARA match",
@@ -550,6 +556,9 @@ def main(argv: list[str] | None = None) -> None:
                 "cache_saliency": args.cache_saliency,
             }
             tasks.append((sha, gpath, spath, jpath, task_kwargs))
+
+        prev_params = _current_params()
+        prev_opt_state = optimizer.state_dict() if optimizer else None
         graph_bar = tqdm(total=len(tasks), desc="graphs", unit="graph", position=0)
         fp_bar = tqdm(total=args.fp_retries or 1, desc="fp retries", unit="try", position=1, leave=True)
 
@@ -641,6 +650,10 @@ def main(argv: list[str] | None = None) -> None:
                         sha_res, res = result_q.get()
                         sha = sha_res
                         res["sha256"] = sha
+                        snap_params = _current_params()
+                        snap_opt_state = (
+                            optimizer.state_dict() if optimizer else None
+                        )
                         results.append(res)
                         if optimizer:
                             batch.append(res)
@@ -665,6 +678,18 @@ def main(argv: list[str] | None = None) -> None:
                         graph_bar.set_postfix(
                             avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}", fpb=f"{fp_ratio_b:.3f}"
                         )
+
+                        if (
+                            args.target_det_rate is not None
+                            and det_rate < args.target_det_rate
+                        ):
+                            _apply_params_main(snap_params)
+                            if optimizer and snap_opt_state is not None:
+                                optimizer.load_state_dict(snap_opt_state)
+                        else:
+                            prev_params = _current_params()
+                            if optimizer:
+                                prev_opt_state = optimizer.state_dict()
 
                         if args.out_csv and args.flush_every:
                             flush_buffer.append(res)
@@ -733,6 +758,8 @@ def main(argv: list[str] | None = None) -> None:
                 sha, gpath, spath, jpath, kw = task
                 kw = kw.copy()
                 kw.update(_current_params())
+                snap_params = _current_params()
+                snap_opt_state = optimizer.state_dict() if optimizer else None
                 sal_path = sal_dir / f"{sha}.pt"
                 if not args.precomputed_saliency_dir:
                     graph = torch.load(gpath, map_location=device, weights_only=False)
@@ -774,6 +801,18 @@ def main(argv: list[str] | None = None) -> None:
                 graph_bar.set_postfix(
                     avg_det=f"{det_rate:.3f}", fp=f"{fp_ratio:.3f}", fpb=f"{fp_ratio_b:.3f}"
                 )
+
+                if (
+                    args.target_det_rate is not None
+                    and det_rate < args.target_det_rate
+                ):
+                    _apply_params_main(snap_params)
+                    if optimizer and snap_opt_state is not None:
+                        optimizer.load_state_dict(snap_opt_state)
+                else:
+                    prev_params = _current_params()
+                    if optimizer:
+                        prev_opt_state = optimizer.state_dict()
 
                 if args.out_csv and args.flush_every:
                     flush_buffer.append(res)

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -293,6 +293,24 @@ def test_build_parser_batch_size():
     assert args.batch_size == 4
 
 
+def test_build_parser_target_det_rate():
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+    parser = mod.build_parser()
+    args = parser.parse_args(
+        [
+            "--graph",
+            "g.pt",
+            "--sample",
+            "s.bin",
+            "--classifier",
+            "c.pt",
+            "--target-det-rate",
+            "0.8",
+        ]
+    )
+    assert args.target_det_rate == 0.8
+
+
 def test_build_parser_global_opts():
     mod = importlib.import_module("src.cli.explainer_rule_eval")
     parser = mod.build_parser()
@@ -3010,6 +3028,94 @@ def test_batch_optimizer_updates_kwargs(tmp_path, monkeypatch):
 
     assert len(params) == 2
     assert params[0] != params[1]
+
+
+def test_target_det_rate_rolls_back(tmp_path, monkeypatch):
+    import pandas as pd
+    import torch
+    import src.models.gnn.res_wrapper as res_wrapper
+
+    csv = tmp_path / "meta.csv"
+    pd.DataFrame({"sha256": ["a", "b", "c"], "label": [1, 1, 1], "filename": ["a.bin", "b.bin", "c.bin"]}).to_csv(
+        csv, index=False
+    )
+
+    gdir = tmp_path / "graphs"
+    gdir.mkdir()
+    for s in ["a", "b", "c"]:
+        (gdir / f"{s}.pt").write_text("stub")
+
+    sdir = tmp_path / "samples"
+    sdir.mkdir()
+    for s in ["a", "b", "c"]:
+        (sdir / f"{s}.bin").write_text("mal")
+
+    sal_dir = tmp_path / "sal"
+    sal_dir.mkdir()
+    for s in ["a", "b", "c"]:
+        torch.save({}, sal_dir / f"{s}.pt")
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyClf(torch.nn.Module):
+        def forward(self, x):
+            return torch.zeros(1)
+
+    monkeypatch.setattr(
+        res_wrapper.RESGCLClassifier,
+        "load_pretrained",
+        classmethod(lambda cls, *a, **k: DummyClf()),
+    )
+
+    modes = []
+
+    def fake_eval(*args, **kwargs):
+        modes.append(kwargs.get("combine_mode"))
+        idx = len(modes) - 1
+        return {"detected": idx != 1}
+
+    class DummyOpt:
+        def __init__(self, *a, **k):
+            self.state = 0
+
+        def state_dict(self):
+            return {"state": self.state}
+
+        def load_state_dict(self, d):
+            self.state = d["state"]
+
+        def step(self, batch):
+            self.state += 1
+
+        def discrete_params(self):
+            return {"combine_mode": "and" if self.state >= 1 else "or"}
+
+    monkeypatch.setattr(mod, "CategoricalOptimizer", DummyOpt)
+    monkeypatch.setattr(mod, "evaluate_single", fake_eval)
+
+    mod.main(
+        [
+            "--graph-dir",
+            str(gdir),
+            "--sample-dir",
+            str(sdir),
+            "--meta-csv",
+            str(csv),
+            "--classifier",
+            str(sdir / "a.bin"),
+            "--precomputed-saliency-dir",
+            str(sal_dir),
+            "--optimize",
+            "--batch-size",
+            "1",
+            "--target-det-rate",
+            "0.6",
+            "--optimizer-pkl",
+            str(tmp_path / "st.pkl"),
+        ]
+    )
+
+    assert modes == ["or", "and", "or"]
 
 
 def test_optimizer_params_applied_evaluate_single(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- rollback rule parameters when detection rate falls below user-specified threshold
- save and restore optimizer state for rollback
- expose `--target-det-rate` CLI option
- test CLI argument parsing
- test rollback behaviour when detection rate drops

## Testing
- `pytest -k target_det_rate_rolls_back -q` *(fails: ModuleNotFoundError: No module named 'gensim')*

------
https://chatgpt.com/codex/tasks/task_e_688916188c30832e8464e0e133d03653