### PR TITLE
Improve FP retry exclude logic

### DIFF
--- a/src/cli/explainer_rule_eval/__init__.py
+++ b/src/cli/explainer_rule_eval/__init__.py
@@ -10,6 +10,7 @@ from .evaluation import (
     _compute_saliency_with_explainer,
     _extract_tokens,
     compute_dynamic_group_min_count,
+    RetryState,
 )
 from .fp_token_utils import (
     TokenCache,
@@ -55,6 +56,7 @@ __all__ = [
     "_optimizer_step",
     "CategoricalOptimizer",
     "PopulationOptimizer",
+    "RetryState",
     "compute_dynamic_group_min_count",
     "build_parser",
     "main",

--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -307,20 +307,22 @@ def _evaluate_and_update(
     if fp_bar:
         fp_bar.update(1)
 
+    candidate_set = state.exclude_set.union(exclude_tokens)
+
     if is_better(trial, state.best_result):
         state.best_result = trial
+        state.exclude_set = candidate_set
         if state.best_result.get("detected"):
             state.last_detected = state.best_result
 
     if trial.get("detected") and not trial.get("false_positive"):
         state.result = trial
-        if exclude_tokens:
-            state.exclude_set.update(exclude_tokens)
-            if persist_fp_exclude is not None:
-                for tok in exclude_tokens:
-                    _FP_EXCLUDE_COUNTS[tok] += 1
-                    _FP_EXCLUDE_SET.add(tok)
-                _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
+        state.exclude_set = candidate_set
+        if exclude_tokens and persist_fp_exclude is not None:
+            for tok in exclude_tokens:
+                _FP_EXCLUDE_COUNTS[tok] += 1
+                _FP_EXCLUDE_SET.add(tok)
+            _save_fp_exclude(persist_fp_exclude, _FP_EXCLUDE_COUNTS)
         return True
     return False
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2910,6 +2910,7 @@ def test_select_exclude_tokens_hitting_set():
 
 def test_evaluate_and_update(tmp_path):
     mod = importlib.import_module("src.cli.explainer_rule_eval")
+    eval_mod = importlib.import_module("src.cli.explainer_rule_eval.evaluation")
 
     state = mod.RetryState(
         result={"false_positive": True},
@@ -2918,6 +2919,7 @@ def test_evaluate_and_update(tmp_path):
         combine_mode="or",
         group_min_ratio=0.0,
         group_min_count=None,
+        freq_threshold=10,
         best_result={"detected": False, "false_positive": True},
         last_detected=None,
     )
@@ -2925,7 +2927,7 @@ def test_evaluate_and_update(tmp_path):
     trial = {"detected": True, "false_positive": False}
     persist = tmp_path / "ex.json"
 
-    success = mod._evaluate_and_update(
+    success = eval_mod._evaluate_and_update(
         trial,
         state,
         exclude_tokens={"tok"},
@@ -3144,5 +3146,73 @@ def test_adaptive_retry_optimizer_params(monkeypatch):
     assert called
     assert called[0][0] == pytest.approx(7.0, abs=1e-6)
     assert called[0][1] == 2
+
+
+def test_token_exclusion_best_result(monkeypatch):
+    """State should keep best result and exclude set during token trials."""
+    from collections import Counter
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    def is_better(new, cur):
+        return float(new.get("fp_ratio_benign", 0.0)) < float(cur.get("fp_ratio_benign", 0.0))
+
+    def fake_eval(_freq, _gmc, _ratio, *, exclude, **_k):
+        excl = set(exclude or [])
+        if "foo" in excl and "bar" in excl:
+            fp_ratio = 0.35
+        elif "foo" in excl:
+            fp_ratio = 0.30
+        elif "bar" in excl:
+            fp_ratio = 0.55
+        else:
+            fp_ratio = 0.50
+        return {
+            "detected": True,
+            "false_positive": True,
+            "fp_ratio_benign": fp_ratio,
+            "coverage": 0.0,
+            "rule_length": 1,
+        }
+
+    result = {
+        "false_positive": True,
+        "fp_matched_tokens": ["foo", "bar"],
+        "fp_ratio_benign": 0.50,
+        "coverage": 0.0,
+        "rule_length": 1,
+        "detected": True,
+    }
+
+    res, excl, best = mod.adaptive_fp_retry(
+        fake_eval,
+        result=result,
+        exclude_set=set(),
+        fp_token_counter=Counter(),
+        group_min_count=None,
+        combine_min_ratio=0.7,
+        freq_threshold=10,
+        min_freq_threshold=0.0,
+        group_min_ratio=0.0,
+        num_rules=1,
+        chunk_size=None,
+        combine_mode="or",
+        auto_group_min=True,
+        freq_threshold_step=0.0,
+        comb_ratio_step=0.0,
+        chunk_size_step=1,
+        combine_max_ratio=1.0,
+        fp_retries=2,
+        fp_timeout=None,
+        max_exclude_tokens=5,
+        persist_fp_exclude=None,
+        fp_bar=None,
+        is_better=is_better,
+        best_result=result,
+        last_detected=None,
+    )
+
+    assert best["fp_ratio_benign"] == pytest.approx(0.30)
+    assert excl == {"foo"}
 
 


### PR DESCRIPTION
## Summary
- update `_evaluate_and_update` to track best result token set
- re-export `RetryState`
- test that token exclusion keeps the best result

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_and_update tests/test_explainer_rule_eval_cli.py::test_token_exclusion_best_result -q`

------
https://chatgpt.com/codex/tasks/task_e_6889162d8004832ebf9b8f96ab250c7a