### PR TITLE
Refine false positive comparison

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1905,8 +1905,8 @@ def evaluate_single(
 
         Priority order:
         1. Detection (prefer detected rules)
-        2. False positives (prefer fewer)
-        3. False-positive ratio in benign samples (prefer lower)
+        2. When both detect, prefer lower ``fp_ratio_benign``
+        3. False positives (prefer fewer)
         4. Coverage (prefer higher)
         5. Rule length (prefer shorter)
         """
@@ -1919,6 +1919,11 @@ def evaluate_single(
         new_fp = bool(new.get("false_positive"))
         cur_fp = bool(current.get("false_positive"))
         if new_fp != cur_fp:
+            if new_det and cur_det:
+                new_ratio = float(new.get("fp_ratio_benign", 0.0))
+                cur_ratio = float(current.get("fp_ratio_benign", 0.0))
+                if not math.isclose(new_ratio, cur_ratio):
+                    return new_ratio < cur_ratio
             return not new_fp
 
         if new_fp and cur_fp:


### PR DESCRIPTION
## Summary
- tweak rule comparison logic
- update docstring to document new decision order

## Testing
- `pytest -q tests` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_68891c355ee0832ea8b4ea2056f76da1