### PR TITLE
Improve optimizer loss schedule

### DIFF
--- a/src/cli/explainer_rule_eval/optimizer_utils.py
+++ b/src/cli/explainer_rule_eval/optimizer_utils.py
@@ -70,13 +70,22 @@ def _optimizer_loss(
     )
 
     mix = bool_probs.mean()
-    fp_weight = 1.0 + float(fp_ratio_benign)
-    fpb_penalty = torch.tensor(fp_ratio_benign, device=opt.condition_type_logits.device)
-    if beta is None:
-        beta = getattr(opt, "beta", 0.5)
+
     fp_val = fp * torch.sum(cond_prob * cond_indicator) * mix
     tp_val = tp * torch.sum(comb_prob * comb_indicator) * mix
-    loss = fp_weight * fp_val + float(beta) * (1.0 - tp_val) + fpb_penalty
+
+    fp_weight = (1.0 + float(fp_ratio_benign)) ** 2
+    # increase fp penalty when detection probability is high
+    fp_weight_tensor = torch.tensor(fp_weight, device=opt.condition_type_logits.device) * (1.0 + tp_val)
+    fpb_penalty = torch.tensor(fp_ratio_benign, device=opt.condition_type_logits.device)
+    fp_loss = fp_weight_tensor * fp_val + fpb_penalty
+
+    if beta is None:
+        beta = getattr(opt, "beta", 0.5)
+    beta_adj = float(beta) + max(0.0, 1.0 - float(tp_val.detach()))
+    tp_loss = torch.minimum(torch.tensor(beta_adj, device=opt.condition_type_logits.device) * (1.0 - tp_val), torch.tensor(1.0, device=opt.condition_type_logits.device))
+
+    loss = fp_loss + tp_loss
     return loss
 
 


### PR DESCRIPTION
## Summary
- revamp `_optimizer_loss` to separately compute FP and TP penalties
- increase FP weight when FP rate and detection are high
- adjust beta dynamically and cap TP loss at 1

## Testing
- `python -m py_compile src/cli/explainer_rule_eval/optimizer_utils.py`
- `pytest -k optimizer_loss -vv` *(fails: ModuleNotFoundError: numpy, torch, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68891c575d9c832eadc884f9d0fdc78d