### PR TITLE
Add TokenCache bitvector intersection method

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1259,18 +1259,13 @@ def evaluate_single(
 
                 def _check_json(p: Path | None) -> tuple[list[str], int, list[Path]] | None:
                     if token_cache.index and p is None:
-                        cand_sets: list[Set[Path]] = []
                         matched: list[str] = []
                         for feat in feats:
                             for tok in _extract_tokens(feat):
-                                paths = token_cache.index.get(tok.lower())
-                                if not paths:
+                                if tok.lower() not in token_cache.index:
                                     return None
                                 matched.append(tok.lower())
-                                cand_sets.append(paths)
-                        if not cand_sets:
-                            return None
-                        cand = set.intersection(*cand_sets)
+                        cand = token_cache.intersect_tokens(matched)
                         if not cand:
                             return None
                         count = 0

--- a/src/cli/explainer_rule_eval/fp_token_utils.py
+++ b/src/cli/explainer_rule_eval/fp_token_utils.py
@@ -84,6 +84,31 @@ class TokenCache:
         for t in tokens:
             self.index.setdefault(t, set()).add(path)
 
+    def intersect_tokens(self, tokens: Iterable[str]) -> set[Path]:
+        """Return sample paths containing any of ``tokens`` using bit vectors."""
+        tokens_norm = [str(t).lower() for t in tokens]
+        if any(t not in self.token_index for t in tokens_norm):
+            return set()
+
+        # build token vector without mutating internal mappings
+        tmp_idx = dict(self.token_index)
+        tmp_rev = list(self.index_tokens)
+        vec = tokens_to_bitvec(tokens_norm, tmp_idx, tmp_rev)
+        size = len(self.index_tokens)
+        if vec.size < size:
+            vec = np.pad(vec, (0, size - vec.size))
+        elif vec.size > size:
+            vec = vec[:size]
+
+        result: set[Path] = set()
+        for p, tok_vec in self.tokens.items():
+            if tok_vec.size < size:
+                tok_vec = np.pad(tok_vec, (0, size - tok_vec.size))
+                self.tokens[p] = tok_vec
+            if np.bitwise_and(tok_vec, vec).any():
+                result.add(p)
+        return result
+
 
 # Persistent false positive exclude tokens
 _FP_EXCLUDE_COUNTS: Counter[str] = Counter()


### PR DESCRIPTION
## Summary
- extend `TokenCache` with `intersect_tokens` for bitvector intersection
- use new method in evaluation when filtering candidate samples

## Testing
- `pytest tests/test_fp_exclude_persist.py tests/test_logger_memory.py -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_68891e22ee18832ea2a37dd3a922d3b1