### PR TITLE
Use token index intersection for JSON verification

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1258,33 +1258,27 @@ def evaluate_single(
             if json_match:
 
                 def _check_json(p: Path | None) -> tuple[list[str], int, list[Path]] | None:
-                    if token_cache.index and p is None:
+                    if token_cache.index:
                         matched: list[str] = []
                         for feat in feats:
                             for tok in _extract_tokens(feat):
-                                if tok.lower() not in token_cache.index:
+                                tok_l = tok.lower()
+                                if tok_l not in token_cache.index:
                                     return None
-                                matched.append(tok.lower())
+                                matched.append(tok_l)
                         cand = token_cache.intersect_tokens(matched)
+                        if p is not None:
+                            if p not in cand:
+                                return None
+                            cand = {p}
                         if not cand:
                             return None
                         count = 0
                         matched_paths: list[Path] = []
                         for cp in cand:
-                            toks_set = token_cache.tokens.get(cp)
-                            if toks_set is None:
-                                j = cp.with_suffix(".json")
-                                if not j.is_file():
-                                    continue
-                                try:
-                                    obj = json.loads(j.read_text(encoding="utf-8"))
-                                    toks = extract_json_tokens(obj)
-                                    token_cache.add(cp, toks)
-                                    toks_set = token_cache.tokens.get(cp)
-                                except Exception:  # noqa: BLE001
-                                    continue
+                            vec = token_cache.tokens[cp]
                             ok = verify_features(
-                                toks_set,
+                                vec,
                                 feats,
                                 condition_type=condition_type,
                                 group_percentage=group_pct,
@@ -1296,13 +1290,16 @@ def evaluate_single(
                                 count += 1
                                 matched_paths.append(cp)
                         return (matched, count, matched_paths) if count > 0 else None
+
                     if p is None:
                         return None
-                    toks_set = token_cache.tokens.get(p)
-                    if toks_set is None:
+
+                    vec = token_cache.tokens.get(p)
+                    if vec is None:
                         return None
+
                     ok, mt = verify_features(
-                        toks_set,
+                        vec,
                         feats,
                         condition_type=condition_type,
                         group_percentage=group_pct,
@@ -1311,6 +1308,7 @@ def evaluate_single(
                         saliency_stats=saliency_stats,
                         return_matched=True,
                     )
+
                     return (mt, 1, [p]) if ok else None
 
                 fp_tokens_set: set[str] = set()


### PR DESCRIPTION
## Summary
- update `_check_json` to always query the token cache index using `intersect_tokens`
- verify features for matched paths without reloading token data

## Testing
- `pytest -q` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68891f8dc1b4832e98b4cde3f79e4f18