### PR TITLE
Fix missing import for saliency function

### DIFF
--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -29,6 +29,7 @@ from .evaluation import (
     _cache_version_info,
     _load_clean_cache,
     extract_json_tokens,
+    _compute_saliency_with_explainer,
 )
 from .fp_token_utils import estimate_token_cache_size, _save_clean_cache
 from .optimizer_utils import CategoricalOptimizer, PopulationOptimizer


### PR DESCRIPTION
## Summary
- import `_compute_saliency_with_explainer` in `explainer_rule_eval/cli.py`

## Testing
- `pytest -k explainer_rule_eval` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_explainer_rule_eval_cli.py tests/test_explainer_rule_eval_saliency.py -q`
- `python -m src.cli.explainer_rule_eval --help`

------
https://chatgpt.com/codex/tasks/task_e_6889625d8ab4832eaadc440905d645e7