### PR TITLE
Implement dynamic token loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ python -m src.cli.explainer_rule_eval \
     --classifier models/gnn/res_gcl.pt \
     --out-csv results.csv --flush-every 5
 ```
+다중 워커(`--num-workers`) 사용 시 `--save-clean-cache` 옵션이 없으면
+클린 샘플 토큰은 인덱스를 통해 필요할 때 자동으로 로드되어 FP 검출에 사용됩니다.
 # XAI selector 학습
 # 분류기가 HeteroData 그래프를 입력으로 받아도 동일하게 사용할 수 있습니다.
 

--- a/src/cli/explainer_rule_eval/cli.py
+++ b/src/cli/explainer_rule_eval/cli.py
@@ -271,7 +271,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--save-clean-cache",
         type=Path,
-        help="Save/load clean token cache to this path",
+        help=(
+            "Save/load clean token cache to this path. "
+            "Without this, tokens are loaded on demand when using multiple workers"
+        ),
     )
     p.add_argument("--out", type=Path, help="Save JSON result path")
     p.add_argument("--out-csv", type=Path, help="Save CSV results for batch mode")

--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1276,7 +1276,18 @@ def evaluate_single(
                         count = 0
                         matched_paths: list[Path] = []
                         for cp in cand:
-                            vec = token_cache.tokens[cp]
+                            vec = token_cache.tokens.get(cp)
+                            if vec is None:
+                                jpath = cp.with_suffix(".json")
+                                try:
+                                    obj = json.loads(jpath.read_text(encoding="utf-8"))
+                                    toks = extract_json_tokens(obj)
+                                    token_cache.add(cp, toks)
+                                    vec = token_cache.tokens.get(cp)
+                                except Exception:  # noqa: BLE001
+                                    continue
+                            if vec is None:
+                                continue
                             ok = verify_features(
                                 vec,
                                 feats,
@@ -1295,6 +1306,15 @@ def evaluate_single(
                         return None
 
                     vec = token_cache.tokens.get(p)
+                    if vec is None:
+                        try:
+                            obj = json.loads(p.with_suffix(".json").read_text(encoding="utf-8"))
+                            toks = extract_json_tokens(obj)
+                            token_cache.add(p, toks)
+                            vec = token_cache.tokens.get(p)
+                        except Exception:  # noqa: BLE001
+                            return None
+
                     if vec is None:
                         return None
 

--- a/src/cli/explainer_rule_eval/fp_token_utils.py
+++ b/src/cli/explainer_rule_eval/fp_token_utils.py
@@ -87,6 +87,11 @@ class TokenCache:
     def intersect_tokens(self, tokens: Iterable[str]) -> set[Path]:
         """Return sample paths containing any of ``tokens`` using bit vectors."""
         tokens_norm = [str(t).lower() for t in tokens]
+
+        if not self.tokens and self.index:
+            sets = [self.index.get(t, set()) for t in tokens_norm]
+            return set.intersection(*sets) if sets else set()
+
         if any(t not in self.token_index for t in tokens_norm):
             return set()
 

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2910,6 +2910,72 @@ def test_adaptive_fp_retry_token_index_profile(tmp_path, monkeypatch):
     assert with_index < no_index
 
 
+def test_evaluate_single_index_only_fp(tmp_path, monkeypatch):
+    """TokenCache with only index should still trigger FP via dynamic loading."""
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "mal.bin"
+    sample.write_bytes(b"mal")
+    sample_json = tmp_path / "mal.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    clean = tmp_path / "c.bin"
+    clean.write_bytes(b"ben")
+    clean_json = tmp_path / "c.json"
+    clean_json.write_text(json.dumps({"c_code": ["foo"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["call:foo"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    cache = mod.TokenCache()
+    cache.index["foo"].add(clean)
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="any",
+        percentage=70,
+        min_count=None,
+        group_percentage=None,
+        group_min_count=None,
+        clean_paths=[clean],
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        token_cache=cache,
+    )
+
+    assert res["false_positive"] is True
+
+
 def test_select_exclude_tokens_hitting_set():
     from collections import Counter
     mod = importlib.import_module("src.cli.explainer_rule_eval")


### PR DESCRIPTION
## Summary
- handle token intersection with index-only caches
- dynamically load tokens from JSON when missing during evaluation
- note on-demand token loading in README and CLI help
- add regression test for index-only false positive detection

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_index_only_fp -q`

------
https://chatgpt.com/codex/tasks/task_e_688967320da4832e891f82eef6a3f16c