### PR TITLE
Add advanced token intersection options

### DIFF
--- a/src/cli/explainer_rule_eval/fp_token_utils.py
+++ b/src/cli/explainer_rule_eval/fp_token_utils.py
@@ -84,13 +84,49 @@ class TokenCache:
         for t in tokens:
             self.index.setdefault(t, set()).add(path)
 
-    def intersect_tokens(self, tokens: Iterable[str]) -> set[Path]:
-        """Return sample paths containing any of ``tokens`` using bit vectors."""
+    def intersect_tokens(
+        self,
+        tokens: Iterable[str],
+        *,
+        mode: str = "all",
+        min_count: int = 1,
+    ) -> set[Path]:
+        """Return sample paths matching ``tokens`` according to ``mode``.
+
+        Parameters
+        ----------
+        tokens:
+            Iterable of token strings.
+        mode:
+            Matching mode, one of ``"any"``, ``"all"`` or ``"count"``. ``"all"``
+            requires all tokens to be present, ``"any"`` matches if any token is
+            present and ``"count"`` matches if at least ``min_count`` tokens are
+            present.
+        min_count:
+            Minimum number of tokens that must be present when ``mode`` is
+            ``"count"``.  Defaults to ``1``.
+        """
         tokens_norm = [str(t).lower() for t in tokens]
+
+        if mode not in {"any", "all", "count"}:
+            raise ValueError(f"invalid mode: {mode}")
+
+        if mode == "count" and min_count <= 0:
+            return set()
 
         if not self.tokens and self.index:
             sets = [self.index.get(t, set()) for t in tokens_norm]
-            return set.intersection(*sets) if sets else set()
+            if not sets:
+                return set()
+            if mode == "all":
+                return set.intersection(*sets)
+            if mode == "any":
+                return set.union(*sets)
+            counts: dict[Path, int] = {}
+            for st in sets:
+                for p in st:
+                    counts[p] = counts.get(p, 0) + 1
+            return {p for p, c in counts.items() if c >= min_count}
 
         if any(t not in self.token_index for t in tokens_norm):
             return set()
@@ -110,8 +146,16 @@ class TokenCache:
             if tok_vec.size < size:
                 tok_vec = np.pad(tok_vec, (0, size - tok_vec.size))
                 self.tokens[p] = tok_vec
-            if np.bitwise_and(tok_vec, vec).any():
-                result.add(p)
+            overlap = np.bitwise_and(tok_vec, vec)
+            if mode == "any":
+                if overlap.any():
+                    result.add(p)
+            elif mode == "all":
+                if overlap.sum() == vec.sum():
+                    result.add(p)
+            else:  # count
+                if int(overlap.sum()) >= min_count:
+                    result.add(p)
         return result
 
 


### PR DESCRIPTION
## Summary
- extend `TokenCache.intersect_tokens` to support `mode` and `min_count`
- default to `mode="all"` for backward compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_688970d5b310832eb8fe603e8e0c205a