### PR TITLE
Fix token cache lookup logic

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1264,9 +1264,32 @@ def evaluate_single(
                             for tok in _extract_tokens(feat):
                                 tok_l = tok.lower()
                                 if tok_l not in token_cache.index:
-                                    return None
+                                    continue
                                 matched.append(tok_l)
-                        cand = token_cache.intersect_tokens(matched)
+
+                        mode = "all"
+                        min_required = 1
+                        if condition_type == "any":
+                            mode = "any"
+                        elif condition_type == "all":
+                            mode = "all"
+                        elif condition_type == "percentage":
+                            mode = "count"
+                            min_required = max(1, math.ceil(len(matched) * percentage / 100.0))
+                        elif condition_type == "count":
+                            mode = "count"
+                            min_required = min_count or 1
+                        elif condition_type == "combo":
+                            if group_cnt is not None:
+                                mode = "count"
+                                min_required = group_cnt
+                            elif group_pct is not None:
+                                mode = "count"
+                                min_required = max(1, math.ceil(len(matched) * group_pct / 100.0))
+                            else:
+                                mode = "any"
+
+                        cand = token_cache.intersect_tokens(matched, mode=mode, min_count=min_required)
                         if p is not None:
                             if p not in cand:
                                 return None


### PR DESCRIPTION
## Summary
- skip unmapped tokens during JSON check
- call `TokenCache.intersect_tokens` with mode and min_count based on rule condition

## Testing
- `pytest tests/test_fp_exclude_persist.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gensim')*

------
https://chatgpt.com/codex/tasks/task_e_688971e426d8832eb0f831beec1d879a