### PR TITLE
Adjust JSON token mode for count/percentage

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1271,14 +1271,14 @@ def evaluate_single(
                         min_required = 1
                         if condition_type == "any":
                             mode = "any"
-                        elif condition_type == "all":
-                            mode = "all"
+                        elif condition_type == "count":
+                            mode = "count"
+                            min_required = group_cnt or 1
                         elif condition_type == "percentage":
                             mode = "count"
                             min_required = max(1, math.ceil(len(matched) * percentage / 100.0))
-                        elif condition_type == "count":
-                            mode = "count"
-                            min_required = min_count or 1
+                        elif condition_type == "all":
+                            mode = "all"
                         elif condition_type == "combo":
                             if group_cnt is not None:
                                 mode = "count"


### PR DESCRIPTION
## Summary
- refine `_check_json` to align token intersection mode with given condition
- keep existing verification logic untouched

## Testing
- `pytest tests/test_running_stats.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688975ff1dbc832eacf24f4c4f79162d