### PR TITLE
Improve token cache filtering

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1259,46 +1259,74 @@ def evaluate_single(
 
                 def _check_json(p: Path | None) -> tuple[list[str], int, list[Path]] | None:
                     if token_cache.index:
-                        matched: list[str] = []
+                        prefix_map = {"call:": "c", "import:": "i"}
+                        groups: dict[str, list[str]] = {}
                         for feat in feats:
+                            tag = "o"
+                            for pre, tg in prefix_map.items():
+                                if feat.startswith(pre):
+                                    tag = tg
+                                    break
                             for tok in _extract_tokens(feat):
                                 tok_l = tok.lower()
                                 if tok_l not in token_cache.index:
                                     continue
-                                matched.append(tok_l)
+                                groups.setdefault(tag, []).append(tok_l)
 
-                        mode = "all"
-                        min_required = 1
-                        if condition_type == "any":
-                            mode = "any"
-                        elif condition_type == "count":
-                            mode = "count"
-                            min_required = group_cnt or 1
-                        elif condition_type == "percentage":
-                            mode = "count"
-                            min_required = max(1, math.ceil(len(matched) * percentage / 100.0))
-                        elif condition_type == "all":
-                            mode = "all"
-                        elif condition_type == "combo":
-                            if group_cnt is not None:
-                                mode = "count"
-                                min_required = group_cnt
-                            elif group_pct is not None:
-                                mode = "count"
-                                min_required = max(1, math.ceil(len(matched) * group_pct / 100.0))
-                            else:
-                                mode = "any"
-
-                        cand = token_cache.intersect_tokens(matched, mode=mode, min_count=min_required)
-                        if p is not None:
-                            if p not in cand:
-                                return None
-                            cand = {p}
-                        if not cand:
+                        if not groups:
                             return None
+
+                        candidate_sets: list[set[Path]] = []
+                        for toks in groups.values():
+                            mode = "all"
+                            min_required = 1
+                            if condition_type == "any":
+                                mode = "any"
+                            elif condition_type == "count":
+                                mode = "count"
+                                min_required = group_cnt or 1
+                            elif condition_type == "percentage":
+                                mode = "count"
+                                pct = percentage
+                                if len(groups) == 1 and adjust_group_percentage:
+                                    scaled = int(round(pct / math.sqrt(len(toks))))
+                                    pct = max(1, min(pct, scaled))
+                                min_required = max(1, math.ceil(len(toks) * pct / 100.0))
+                            elif condition_type == "all":
+                                mode = "all"
+                            elif condition_type == "combo":
+                                if group_cnt is not None:
+                                    mode = "count"
+                                    min_required = min(group_cnt, len(toks))
+                                elif group_pct is not None:
+                                    mode = "count"
+                                    pct = group_pct
+                                    if len(groups) == 1 and adjust_group_percentage:
+                                        scaled = int(round(pct / math.sqrt(len(toks))))
+                                        pct = max(1, min(pct, scaled))
+                                    min_required = max(1, math.ceil(len(toks) * pct / 100.0))
+                                else:
+                                    mode = "any"
+
+                            cand = token_cache.intersect_tokens(toks, mode=mode, min_count=min_required)
+                            if not cand:
+                                return None
+                            candidate_sets.append(cand)
+
+                        cand_final = set.intersection(*candidate_sets) if candidate_sets else set()
+
+                        if p is not None:
+                            if p not in cand_final:
+                                return None
+                            cand_final = {p}
+
+                        if not cand_final:
+                            return None
+
+                        all_matched = [t for toks in groups.values() for t in toks]
                         count = 0
                         matched_paths: list[Path] = []
-                        for cp in cand:
+                        for cp in cand_final:
                             vec = token_cache.tokens.get(cp)
                             if vec is None:
                                 jpath = cp.with_suffix(".json")
@@ -1323,7 +1351,7 @@ def evaluate_single(
                             if ok:
                                 count += 1
                                 matched_paths.append(cp)
-                        return (matched, count, matched_paths) if count > 0 else None
+                        return (all_matched, count, matched_paths) if count > 0 else None
 
                     if p is None:
                         return None


### PR DESCRIPTION
## Summary
- refine `_check_json` logic in rule evaluator
- group features by type and intersect candidate sets from `TokenCache`
- apply `adjust_group_percentage` when only one group under percentage mode

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_verify_features_combo_percentage -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_json_match_fp_with_clean_sample -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_evaluate_single_json_match_fp_with_clean_dir -q`
- `pytest tests/test_explainer_rule_eval_cli.py::test_verify_features_combo_adjust_pct -q`


------
https://chatgpt.com/codex/tasks/task_e_68897c9490a0832e94f6fd79c5de01ca