### PR TITLE
Add percentage mode for token intersection

### DIFF
--- a/src/cli/explainer_rule_eval/fp_token_utils.py
+++ b/src/cli/explainer_rule_eval/fp_token_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import pickle
+import math
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -98,24 +99,34 @@ class TokenCache:
         tokens:
             Iterable of token strings.
         mode:
-            Matching mode, one of ``"any"``, ``"all"`` or ``"count"``. ``"all"``
-            requires all tokens to be present, ``"any"`` matches if any token is
-            present and ``"count"`` matches if at least ``min_count`` tokens are
+            Matching mode, one of ``"any"``, ``"all"``, ``"count`` or
+            ``"percentage"``. ``"all"`` requires all tokens to be present,
+            ``"any"`` matches if any token is present, ``"count"`` matches if at
+            least ``min_count`` tokens are present and ``"percentage"`` matches
+            if at least ``ceil(len(tokens) * min_count / 100)`` tokens are
             present.
         min_count:
             Minimum number of tokens that must be present when ``mode`` is
-            ``"count"``.  Defaults to ``1``.
+            ``"count"`` or percentage threshold when ``mode`` is
+            ``"percentage"``. Defaults to ``1``.
         """
         tokens_norm = [str(t).lower() for t in tokens]
 
-        if mode not in {"any", "all", "count"}:
+        if mode not in {"any", "all", "count", "percentage"}:
             raise ValueError(f"invalid mode: {mode}")
 
-        if mode == "count" and min_count <= 0:
+        if mode in {"count", "percentage"} and min_count <= 0:
             return set()
 
         if not self.tokens and self.index:
-            sets = [self.index.get(t, set()) for t in tokens_norm]
+            sets: list[set[Path]] = []
+            for t in tokens_norm:
+                st = self.index.get(t)
+                if st is None:
+                    if mode == "all":
+                        return set()
+                    continue
+                sets.append(st)
             if not sets:
                 return set()
             if mode == "all":
@@ -126,15 +137,23 @@ class TokenCache:
             for st in sets:
                 for p in st:
                     counts[p] = counts.get(p, 0) + 1
+            if mode == "percentage":
+                threshold = math.ceil(len(tokens_norm) * min_count / 100)
+                return {p for p, c in counts.items() if c >= threshold}
             return {p for p, c in counts.items() if c >= min_count}
 
-        if any(t not in self.token_index for t in tokens_norm):
+        tokens_filtered = tokens_norm
+        if mode != "all":
+            tokens_filtered = [t for t in tokens_norm if t in self.token_index]
+        if mode == "all" and any(t not in self.token_index for t in tokens_norm):
+            return set()
+        if not tokens_filtered:
             return set()
 
         # build token vector without mutating internal mappings
         tmp_idx = dict(self.token_index)
         tmp_rev = list(self.index_tokens)
-        vec = tokens_to_bitvec(tokens_norm, tmp_idx, tmp_rev)
+        vec = tokens_to_bitvec(tokens_filtered, tmp_idx, tmp_rev)
         size = len(self.index_tokens)
         if vec.size < size:
             vec = np.pad(vec, (0, size - vec.size))
@@ -152,6 +171,10 @@ class TokenCache:
                     result.add(p)
             elif mode == "all":
                 if overlap.sum() == vec.sum():
+                    result.add(p)
+            elif mode == "percentage":
+                threshold = math.ceil(len(tokens_norm) * min_count / 100)
+                if int(overlap.sum()) >= threshold:
                     result.add(p)
             else:  # count
                 if int(overlap.sum()) >= min_count:

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1574,6 +1574,28 @@ def test_estimate_token_cache_size(tmp_path):
     assert size < 1_000_000  # <1MB
 
 
+def test_token_cache_intersect_tokens_percentage(tmp_path):
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    cache = mod.TokenCache()
+    p1 = tmp_path / "a.bin"
+    p2 = tmp_path / "b.bin"
+    cache.add(p1, {"foo", "bar"})
+    cache.add(p2, {"foo"})
+
+    res = cache.intersect_tokens(["foo", "bar"], mode="percentage", min_count=50)
+    assert res == {p1, p2}
+
+    res_missing = cache.intersect_tokens(["foo", "qux"], mode="percentage", min_count=50)
+    assert res_missing == {p1, p2}
+
+    res_any = cache.intersect_tokens(["qux", "foo"], mode="any")
+    assert res_any == {p1, p2}
+
+    res_all = cache.intersect_tokens(["foo", "qux"], mode="all")
+    assert res_all == set()
+
+
 def test_fp_retry_exclude_tokens(tmp_path, monkeypatch):
     pytest.importorskip("torch")
     pytest.importorskip("torch_geometric")


### PR DESCRIPTION
## Summary
- support `percentage` mode in `TokenCache.intersect_tokens`
- ignore unknown tokens for `any`, `count`, and `percentage` modes
- test token cache intersection logic

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_token_cache_intersect_tokens_percentage -q`

------
https://chatgpt.com/codex/tasks/task_e_68897c62581c832ebc6b24290ad6673f