### PR TITLE
Implement group-based token intersection

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1259,37 +1259,68 @@ def evaluate_single(
 
                 def _check_json(p: Path | None) -> tuple[list[str], int, list[Path]] | None:
                     if token_cache.index:
-                        matched: list[str] = []
+                        prefix_map = {"call:": "c", "import:": "i"}
+                        grouped: dict[str, list[str]] = {}
                         for feat in feats:
+                            tag = "o"
+                            for pfx, tg in prefix_map.items():
+                                if feat.startswith(pfx):
+                                    tag = tg
+                                    break
                             for tok in _extract_tokens(feat):
                                 tok_l = tok.lower()
                                 if tok_l not in token_cache.index:
                                     continue
-                                matched.append(tok_l)
+                                grouped.setdefault(tag, []).append(tok_l)
 
-                        mode = "all"
-                        min_required = 1
-                        if condition_type == "any":
-                            mode = "any"
-                        elif condition_type == "count":
-                            mode = "count"
-                            min_required = group_cnt or 1
-                        elif condition_type == "percentage":
-                            mode = "count"
-                            min_required = max(1, math.ceil(len(matched) * percentage / 100.0))
-                        elif condition_type == "all":
-                            mode = "all"
-                        elif condition_type == "combo":
-                            if group_cnt is not None:
-                                mode = "count"
-                                min_required = group_cnt
-                            elif group_pct is not None:
-                                mode = "count"
-                                min_required = max(1, math.ceil(len(matched) * group_pct / 100.0))
-                            else:
+                        matched = [t for ts in grouped.values() for t in ts]
+                        if not matched:
+                            return None
+
+                        group_count = sum(1 for ts in grouped.values() if ts)
+                        feat_count = len(matched)
+
+                        cand: set[Path] | None = None
+
+                        if condition_type == "combo" and group_pct is not None and group_count <= 1:
+                            req = min(2, feat_count)
+                            cand = token_cache.intersect_tokens(matched, mode="count", min_count=req)
+                        else:
+                            for tag, toks in grouped.items():
+                                if not toks:
+                                    continue
                                 mode = "any"
+                                min_required = 1
+                                if condition_type == "any":
+                                    mode = "any"
+                                elif condition_type == "count":
+                                    mode = "count"
+                                    min_required = group_cnt or 1
+                                elif condition_type == "percentage":
+                                    mode = "count"
+                                    min_required = max(1, math.ceil(len(toks) * percentage / 100.0))
+                                elif condition_type == "all":
+                                    mode = "all"
+                                elif condition_type == "combo":
+                                    if group_cnt is not None:
+                                        mode = "count"
+                                        min_required = min(group_cnt, len(toks))
+                                    elif group_pct is not None:
+                                        pct = group_pct
+                                        if adjust_group_percentage:
+                                            scaled = int(round(pct / math.sqrt(len(toks))))
+                                            pct = max(1, min(pct, scaled))
+                                        min_required = max(1, math.ceil(len(toks) * pct / 100.0))
+                                    else:
+                                        mode = "any"
 
-                        cand = token_cache.intersect_tokens(matched, mode=mode, min_count=min_required)
+                                cur = token_cache.intersect_tokens(toks, mode=mode, min_count=min_required)
+                                cand = cur if cand is None else cand.intersection(cur)
+                                if not cand:
+                                    break
+
+                        if cand is None:
+                            return None
                         if p is not None:
                             if p not in cand:
                                 return None

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -2976,6 +2976,91 @@ def test_evaluate_single_index_only_fp(tmp_path, monkeypatch):
     assert res["false_positive"] is True
 
 
+def test_check_json_multi_group_intersection(tmp_path, monkeypatch):
+    """Token index intersection should consider feature groups."""
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "mal.bin"
+    sample.write_bytes(b"mal")
+    sample_json = tmp_path / "mal.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo", "bar"]}))
+
+    c1 = tmp_path / "c1.bin"
+    c1.write_bytes(b"ben1")
+    (tmp_path / "c1.json").write_text(json.dumps({"c_code": ["foo"]}))
+    c2 = tmp_path / "c2.bin"
+    c2.write_bytes(b"ben2")
+    (tmp_path / "c2.json").write_text(json.dumps({"c_code": ["bar"]}))
+    c3 = tmp_path / "c3.bin"
+    c3.write_bytes(b"ben3")
+    (tmp_path / "c3.json").write_text(json.dumps({"c_code": ["foo", "bar"]}))
+    clean_paths = [c1, c2, c3]
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency, *a, **k):
+            return ["call:foo", "import:bar"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    index = mod.TokenCache()
+    index.index["foo"].update({c1, c3})
+    index.index["bar"].update({c2, c3})
+
+    read_count = 0
+    orig_read = Path.read_text
+
+    def fake_read(self, *a, **k):
+        nonlocal read_count
+        if self.suffix == ".json" and self.name.startswith("c"):
+            read_count += 1
+        return orig_read(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", fake_read)
+
+    mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=1,
+        condition_type="combo",
+        percentage=70,
+        min_count=None,
+        group_percentage=50,
+        group_min_count=None,
+        clean_paths=clean_paths,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        token_cache=index,
+        fp_retries=1,
+    )
+
+    assert read_count == 1
+
+
 def test_select_exclude_tokens_hitting_set():
     from collections import Counter
     mod = importlib.import_module("src.cli.explainer_rule_eval")


### PR DESCRIPTION
## Summary
- handle token intersections per feature group when using JSON tokens
- add a regression test for multi-group token intersection logic

## Testing
- `pytest tests/test_explainer_rule_eval_cli.py::test_check_json_multi_group_intersection -q`

------
https://chatgpt.com/codex/tasks/task_e_68897d06d3e4832ea6c8e2c2e5f0adde