### PR TITLE
Improve feature grouping in JSON cache search

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1276,44 +1276,67 @@ def evaluate_single(
                         if not groups:
                             return None
 
-                        candidate_sets: list[set[Path]] = []
-                        for toks in groups.values():
-                            mode = "all"
-                            min_required = 1
-                            if condition_type == "any":
-                                mode = "any"
-                            elif condition_type == "count":
-                                mode = "count"
-                                min_required = group_cnt or 1
-                            elif condition_type == "percentage":
-                                mode = "count"
-                                pct = percentage
-                                if len(groups) == 1 and adjust_group_percentage:
-                                    scaled = int(round(pct / math.sqrt(len(toks))))
-                                    pct = max(1, min(pct, scaled))
-                                min_required = max(1, math.ceil(len(toks) * pct / 100.0))
-                            elif condition_type == "all":
+                        group_count = len(groups)
+                        feat_count = sum(len(v) for v in groups.values())
+
+                        cand_final: set[Path] | None = None
+                        if (
+                            condition_type == "combo"
+                            and group_pct is not None
+                            and group_count <= 1
+                        ):
+                            tokens_all = [t for ts in groups.values() for t in ts]
+                            min_required = min(2, feat_count)
+                            cand_final = token_cache.intersect_tokens(
+                                tokens_all, mode="count", min_count=min_required
+                            )
+                        else:
+                            candidate_sets: list[set[Path]] = []
+                            for toks in groups.values():
                                 mode = "all"
-                            elif condition_type == "combo":
-                                if group_cnt is not None:
+                                min_required = 1
+                                if condition_type == "any":
+                                    mode = "any"
+                                elif condition_type == "count":
                                     mode = "count"
-                                    min_required = min(group_cnt, len(toks))
-                                elif group_pct is not None:
+                                    min_required = group_cnt or 1
+                                elif condition_type == "percentage":
                                     mode = "count"
-                                    pct = group_pct
+                                    pct = percentage
                                     if len(groups) == 1 and adjust_group_percentage:
                                         scaled = int(round(pct / math.sqrt(len(toks))))
                                         pct = max(1, min(pct, scaled))
                                     min_required = max(1, math.ceil(len(toks) * pct / 100.0))
-                                else:
-                                    mode = "any"
+                                elif condition_type == "all":
+                                    mode = "all"
+                                elif condition_type == "combo":
+                                    if group_cnt is not None:
+                                        mode = "count"
+                                        min_required = min(group_cnt, len(toks))
+                                    elif group_pct is not None:
+                                        mode = "count"
+                                        pct = group_pct
+                                        if len(groups) == 1 and adjust_group_percentage:
+                                            scaled = int(round(pct / math.sqrt(len(toks))))
+                                            pct = max(1, min(pct, scaled))
+                                        min_required = max(1, math.ceil(len(toks) * pct / 100.0))
+                                    else:
+                                        mode = "any"
 
-                            cand = token_cache.intersect_tokens(toks, mode=mode, min_count=min_required)
-                            if not cand:
-                                return None
-                            candidate_sets.append(cand)
+                                cand = token_cache.intersect_tokens(
+                                    toks, mode=mode, min_count=min_required
+                                )
+                                if not cand:
+                                    cand_final = set()
+                                    break
+                                candidate_sets.append(cand)
 
-                        cand_final = set.intersection(*candidate_sets) if candidate_sets else set()
+                            if cand_final is None:
+                                cand_final = (
+                                    set.intersection(*candidate_sets)
+                                    if candidate_sets
+                                    else set()
+                                )
 
                         if p is not None:
                             if p not in cand_final:

--- a/tests/test_explainer_rule_eval_cli.py
+++ b/tests/test_explainer_rule_eval_cli.py
@@ -1596,6 +1596,83 @@ def test_token_cache_intersect_tokens_percentage(tmp_path):
     assert res_all == set()
 
 
+def test_check_json_multi_group_token_cache(tmp_path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("torch_geometric")
+
+    import torch
+    from torch_geometric.data import HeteroData
+
+    g = HeteroData()
+    g["bb"].x = torch.zeros(1, 1)
+    g["bb"].num_nodes = 1
+    g[("bb", "cfg", "bb")].edge_index = torch.tensor([[0], [0]])
+    gpath = tmp_path / "graph.pt"
+    torch.save(g, gpath)
+
+    sal = {"bb": torch.tensor([0.9])}
+    salpath = tmp_path / "sal.pt"
+    torch.save(sal, salpath)
+
+    sample = tmp_path / "samp.bin"
+    sample.write_bytes(b"dummy")
+    sample_json = tmp_path / "samp.json"
+    sample_json.write_text(json.dumps({"c_code": ["foo", "bar"]}))
+
+    clean1 = tmp_path / "c1.bin"
+    clean1.write_bytes(b"d1")
+    (tmp_path / "c1.json").write_text(json.dumps({"c_code": ["foo"]}))
+
+    clean2 = tmp_path / "c2.bin"
+    clean2.write_bytes(b"d2")
+    (tmp_path / "c2.json").write_text(json.dumps({"c_code": ["bar"]}))
+
+    clean3 = tmp_path / "c3.bin"
+    clean3.write_bytes(b"d3")
+    (tmp_path / "c3.json").write_text(json.dumps({"c_code": ["foo", "bar"]}))
+
+    mod = importlib.import_module("src.cli.explainer_rule_eval")
+
+    token_cache = mod.TokenCache()
+    for p in (clean1, clean2, clean3):
+        js = json.loads(p.with_suffix(".json").read_text())
+        token_cache.add(p, mod.extract_json_tokens(js))
+
+    class DummyMiner:
+        def __init__(self, *a, **k):
+            pass
+
+        def mine(self, graph, saliency):
+            return ["call:foo", "import:bar"]
+
+    monkeypatch.setattr(mod, "FeatureMiner", lambda *a, **k: DummyMiner())
+
+    res = mod.evaluate_single(
+        gpath,
+        sample,
+        classifier_ckpt=sample,
+        explainer_ckpt=None,
+        saliency_path=salpath,
+        device=torch.device("cpu"),
+        top_k=2,
+        condition_type="combo",
+        percentage=70,
+        min_count=None,
+        group_percentage=50,
+        group_min_count=None,
+        clean_dir=None,
+        clean_sample=None,
+        clean_paths=None,
+        sample_json=sample_json,
+        json_match=True,
+        combine_mode="or",
+        token_cache=token_cache,
+    )
+
+    assert res["fp_count"] == 1
+    assert res.get("fp_samples") == [str(clean3)]
+
+
 def test_fp_retry_exclude_tokens(tmp_path, monkeypatch):
     pytest.importorskip("torch")
     pytest.importorskip("torch_geometric")


### PR DESCRIPTION
## Summary
- refine `_check_json` to calculate token intersections per group
- relax single-group percentage conditions
- add multi-group token cache test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68898062f824832e83d168adf69242aa