### PR TITLE
Refactor _check_json token filtering

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -1259,84 +1259,113 @@ def evaluate_single(
 
                 def _check_json(p: Path | None) -> tuple[list[str], int, list[Path]] | None:
                     if token_cache.index:
-                        prefix_map = {"call:": "c", "import:": "i"}
-                        groups: dict[str, list[str]] = {}
-                        for feat in feats:
-                            tag = "o"
-                            for pre, tg in prefix_map.items():
-                                if feat.startswith(pre):
-                                    tag = tg
-                                    break
-                            for tok in _extract_tokens(feat):
-                                tok_l = tok.lower()
-                                if tok_l not in token_cache.index:
-                                    continue
-                                groups.setdefault(tag, []).append(tok_l)
+                        if condition_type != "combo":
+                            tokens_raw = [t for f in feats for t in _extract_tokens(f)]
+                            tokens_all = [t.lower() for t in tokens_raw if t.lower() in token_cache.index]
+                            if not tokens_all:
+                                return None
 
-                        if not groups:
-                            return None
-
-                        group_count = len(groups)
-                        feat_count = sum(len(v) for v in groups.values())
-
-                        cand_final: set[Path] | None = None
-                        if (
-                            condition_type == "combo"
-                            and group_pct is not None
-                            and group_count <= 1
-                        ):
-                            tokens_all = [t for ts in groups.values() for t in ts]
-                            min_required = min(2, feat_count)
-                            cand_final = token_cache.intersect_tokens(
-                                tokens_all, mode="count", min_count=min_required
-                            )
-                        else:
-                            candidate_sets: list[set[Path]] = []
-                            for toks in groups.values():
+                            mode = "all"
+                            min_required = 1
+                            if condition_type == "any":
+                                mode = "any"
+                            elif condition_type == "count":
+                                mode = "count"
+                                min_required = min_count or 1
+                            elif condition_type == "percentage":
+                                mode = "count"
+                                min_required = max(1, math.ceil(len(tokens_all) * percentage / 100.0))
+                            elif condition_type == "all":
                                 mode = "all"
-                                min_required = 1
-                                if condition_type == "any":
-                                    mode = "any"
-                                elif condition_type == "count":
-                                    mode = "count"
-                                    min_required = group_cnt or 1
-                                elif condition_type == "percentage":
-                                    mode = "count"
-                                    pct = percentage
-                                    if len(groups) == 1 and adjust_group_percentage:
-                                        scaled = int(round(pct / math.sqrt(len(toks))))
-                                        pct = max(1, min(pct, scaled))
-                                    min_required = max(1, math.ceil(len(toks) * pct / 100.0))
-                                elif condition_type == "all":
+
+                            if mode == "all" and len(tokens_all) < len(tokens_raw):
+                                return None
+                            if mode == "count" and min_required > len(tokens_all):
+                                return None
+
+                            cand_final = token_cache.intersect_tokens(tokens_all, mode=mode, min_count=min_required)
+                            all_matched = tokens_all
+                        else:
+                            prefix_map = {"call:": "c", "import:": "i"}
+                            groups: dict[str, list[str]] = {}
+                            for feat in feats:
+                                tag = "o"
+                                for pre, tg in prefix_map.items():
+                                    if feat.startswith(pre):
+                                        tag = tg
+                                        break
+                                for tok in _extract_tokens(feat):
+                                    tok_l = tok.lower()
+                                    if tok_l not in token_cache.index:
+                                        continue
+                                    groups.setdefault(tag, []).append(tok_l)
+
+                            if not groups:
+                                return None
+
+                            group_count = len(groups)
+                            feat_count = sum(len(v) for v in groups.values())
+
+                            cand_final: set[Path] | None = None
+                            if (
+                                condition_type == "combo"
+                                and group_pct is not None
+                                and group_count <= 1
+                            ):
+                                tokens_all = [t for ts in groups.values() for t in ts]
+                                min_required = min(2, feat_count)
+                                cand_final = token_cache.intersect_tokens(
+                                    tokens_all, mode="count", min_count=min_required
+                                )
+                            else:
+                                candidate_sets: list[set[Path]] = []
+                                for toks in groups.values():
                                     mode = "all"
-                                elif condition_type == "combo":
-                                    if group_cnt is not None:
+                                    min_required = 1
+                                    if condition_type == "any":
+                                        mode = "any"
+                                    elif condition_type == "count":
                                         mode = "count"
-                                        min_required = min(group_cnt, len(toks))
-                                    elif group_pct is not None:
+                                        min_required = group_cnt or 1
+                                    elif condition_type == "percentage":
                                         mode = "count"
-                                        pct = group_pct
+                                        pct = percentage
                                         if len(groups) == 1 and adjust_group_percentage:
                                             scaled = int(round(pct / math.sqrt(len(toks))))
                                             pct = max(1, min(pct, scaled))
                                         min_required = max(1, math.ceil(len(toks) * pct / 100.0))
-                                    else:
-                                        mode = "any"
+                                    elif condition_type == "all":
+                                        mode = "all"
+                                    elif condition_type == "combo":
+                                        if group_cnt is not None:
+                                            mode = "count"
+                                            min_required = min(group_cnt, len(toks))
+                                        elif group_pct is not None:
+                                            mode = "count"
+                                            pct = group_pct
+                                            if len(groups) == 1 and adjust_group_percentage:
+                                                scaled = int(round(pct / math.sqrt(len(toks))))
+                                                pct = max(1, min(pct, scaled))
+                                            min_required = max(1, math.ceil(len(toks) * pct / 100.0))
+                                        else:
+                                            mode = "any"
 
-                                cand = token_cache.intersect_tokens(
-                                    toks, mode=mode, min_count=min_required
-                                )
-                                if not cand:
-                                    cand_final = set()
-                                    break
-                                candidate_sets.append(cand)
+                                    cand = token_cache.intersect_tokens(
+                                        toks, mode=mode, min_count=min_required
+                                    )
+                                    if not cand:
+                                        cand_final = set()
+                                        break
+                                    candidate_sets.append(cand)
 
-                            if cand_final is None:
-                                cand_final = (
-                                    set.intersection(*candidate_sets)
-                                    if candidate_sets
-                                    else set()
-                                )
+                                if cand_final is None:
+                                    cand_final = (
+                                        set.intersection(*candidate_sets)
+                                        if candidate_sets
+                                        else set()
+                                    )
+
+                            all_matched = [t for toks in groups.values() for t in toks]
 
                         if p is not None:
                             if p not in cand_final:
@@ -1346,7 +1375,6 @@ def evaluate_single(
                         if not cand_final:
                             return None
 
-                        all_matched = [t for toks in groups.values() for t in toks]
                         count = 0
                         matched_paths: list[Path] = []
                         for cp in cand_final:


### PR DESCRIPTION
## Summary
- restructure `_check_json` token lookup logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*

------
https://chatgpt.com/codex/tasks/task_e_6889e66edaf0832eb9002ba02af22684