### PR TITLE
Update prefix maps and adjust group pct scaling

### DIFF
--- a/src/cli/explainer_rule_eval/evaluation.py
+++ b/src/cli/explainer_rule_eval/evaluation.py
@@ -747,7 +747,14 @@ def verify_features(
         return (result, matched) if return_matched else result
 
     # combo mode
-    prefix_map = {"call:": "c", "import:": "i"}
+    prefix_map = {
+        "call:": "c",
+        "import:": "i",
+        "syscall:": "s",
+        "path:": "p",
+        "url:": "u",
+        "reg:": "r",
+    }
     groups: dict[str, list[str]] = {}
     matched_groups: dict[str, int] = {}
     for feat in features:
@@ -1244,7 +1251,14 @@ def evaluate_single(
 
             def _max_group_count(toks: Sequence[str]) -> int:
                 """Return highest match count among feature groups."""
-                prefix_map = {"call:": "c", "import:": "i"}
+                prefix_map = {
+                    "call:": "c",
+                    "import:": "i",
+                    "syscall:": "s",
+                    "path:": "p",
+                    "url:": "u",
+                    "reg:": "r",
+                }
                 counts: dict[str, int] = {}
                 for t in toks:
                     tag = "o"
@@ -1286,7 +1300,14 @@ def evaluate_single(
                             cand_final = token_cache.intersect_tokens(tokens_all, mode=mode, min_count=min_required)
                             all_matched = tokens_all
                         else:
-                            prefix_map = {"call:": "c", "import:": "i"}
+                            prefix_map = {
+                                "call:": "c",
+                                "import:": "i",
+                                "syscall:": "s",
+                                "path:": "p",
+                                "url:": "u",
+                                "reg:": "r",
+                            }
                             groups: dict[str, list[str]] = {}
                             for feat in feats:
                                 tag = "o"
@@ -1330,7 +1351,7 @@ def evaluate_single(
                                     elif condition_type == "percentage":
                                         mode = "count"
                                         pct = percentage
-                                        if len(groups) == 1 and adjust_group_percentage:
+                                        if adjust_group_percentage:
                                             scaled = int(round(pct / math.sqrt(len(toks))))
                                             pct = max(1, min(pct, scaled))
                                         min_required = max(1, math.ceil(len(toks) * pct / 100.0))
@@ -1343,7 +1364,7 @@ def evaluate_single(
                                         elif group_pct is not None:
                                             mode = "count"
                                             pct = group_pct
-                                            if len(groups) == 1 and adjust_group_percentage:
+                                            if adjust_group_percentage:
                                                 scaled = int(round(pct / math.sqrt(len(toks))))
                                                 pct = max(1, min(pct, scaled))
                                             min_required = max(1, math.ceil(len(toks) * pct / 100.0))

--- a/src/rulegen/yara_builder.py
+++ b/src/rulegen/yara_builder.py
@@ -254,7 +254,15 @@ class YaraBuilder:
         groups: dict[str, list[str]] = {}
         id_map: dict[str, str] = {}
         if self.condition_type == "combo":
-            prefix_map = {"call:": "c", "import:": "i", "marker:": "m"}
+            prefix_map = {
+                "call:": "c",
+                "import:": "i",
+                "syscall:": "s",
+                "path:": "p",
+                "url:": "u",
+                "reg:": "r",
+                "marker:": "m",
+            }
             for feat in unique_feats:
                 tag = "o"
                 for p, t in prefix_map.items():


### PR DESCRIPTION
## Summary
- expand prefix mappings for feature grouping
- scale group percentage for each group when checking JSON

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6889e9033f18832ea2b90705b545f0eb